### PR TITLE
Allow redirecting of logs

### DIFF
--- a/clientcore/broflake.go
+++ b/clientcore/broflake.go
@@ -3,9 +3,10 @@ package clientcore
 
 import (
 	"fmt"
-	"log"
 	"runtime"
 	"sync"
+
+	"github.com/getlantern/broflake/common"
 )
 
 type BroflakeEngine struct {
@@ -35,13 +36,13 @@ func (b *BroflakeEngine) stop() {
 }
 
 func (b *BroflakeEngine) debug() {
-	log.Printf("NumGoroutine: %v\n", runtime.NumGoroutine())
+	common.Debugf("NumGoroutine: %v", runtime.NumGoroutine())
 }
 
 func NewBroflake(bfOpt *BroflakeOptions, rtcOpt *WebRTCOptions, egOpt *EgressOptions) (bfconn *BroflakeConn, ui *UIImpl, err error) {
 	if bfOpt.ClientType != "desktop" && bfOpt.ClientType != "widget" {
 		err = fmt.Errorf("Invalid clientType '%v\n'", bfOpt.ClientType)
-		log.Printf(err.Error())
+		common.Debugf(err.Error())
 		return bfconn, ui, err
 	}
 

--- a/clientcore/protocol.go
+++ b/clientcore/protocol.go
@@ -3,8 +3,9 @@ package clientcore
 
 import (
 	"context"
-	"log"
 	"sync"
+
+	"github.com/getlantern/broflake/common"
 )
 
 const (
@@ -46,13 +47,13 @@ func (fsm *WorkerFSM) Start() {
 				fsm.wg.Done()
 			}
 		}()
-		log.Println("Starting WorkerFSM...")
+		common.Debug("Starting WorkerFSM...")
 		fsm.ctx, fsm.cancel = context.WithCancel(context.Background())
 
 		for {
 			select {
 			case <-fsm.ctx.Done():
-				log.Println("Stopping WorkerFSM...")
+				common.Debug("Stopping WorkerFSM...")
 				return
 			default:
 				fsm.currentState, fsm.nextInput = fsm.state[fsm.currentState](fsm.ctx, fsm.com, fsm.nextInput)

--- a/clientcore/ui.go
+++ b/clientcore/ui.go
@@ -2,14 +2,13 @@
 package clientcore
 
 import (
-	"log"
 	"net"
 	"strconv"
 	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/broflake/common"
-	"github.com/getlantern/broflake/netstate/client"
+	netstatecl "github.com/getlantern/broflake/netstate/client"
 )
 
 const (
@@ -86,7 +85,7 @@ func UpstreamUIHandler(ui UIImpl, netstated, tag string) func(msg IPCMsg) {
 				)
 
 				if err != nil {
-					log.Printf("netstatecl.Exec error: %v\n", err)
+					common.Debugf("netstatecl.Exec error: %v", err)
 				}
 			}
 		}

--- a/clientcore/user.go
+++ b/clientcore/user.go
@@ -8,12 +8,12 @@ package clientcore
 
 import (
 	"context"
-	"log"
 	"net"
 	"sync"
 
-	"github.com/getlantern/broflake/common"
 	"github.com/google/uuid"
+
+	"github.com/getlantern/broflake/common"
 )
 
 type BroflakeConn struct {
@@ -54,7 +54,7 @@ func NewProducerUserStream(wg *sync.WaitGroup) (*BroflakeConn, *WorkerFSM) {
 		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
 			// State 0
 			// (no input data)
-			log.Printf("User stream producer state 0...\n")
+			common.Debugf("User stream producer state 0...")
 			// TODO: check for a non-nil path assertion to alert the UI that we're ready to proxy?
 			select {}
 		}),

--- a/cmd/client_default_impl.go
+++ b/cmd/client_default_impl.go
@@ -30,16 +30,16 @@ func main() {
 		proxyPort = "1080"
 	}
 
-	log.Printf("Welcome to Broflake %v\n", common.Version)
-	log.Printf("clientType: %v\n", clientType)
-	log.Printf("freddie: %v\n", freddie)
-	log.Printf("egress: %v\n", egress)
-	log.Printf("netstated: %v\n", netstated)
-	log.Printf("tag: %v\n", tag)
-	log.Printf("pprof: %v\n", pprof)
-	log.Printf("ca: %v\n", ca)
-	log.Printf("serverName: %v\n", serverName)
-	log.Printf("proxyPort: %v\n", proxyPort)
+	common.Debugf("Welcome to Broflake %v", common.Version)
+	common.Debugf("clientType: %v", clientType)
+	common.Debugf("freddie: %v", freddie)
+	common.Debugf("egress: %v", egress)
+	common.Debugf("netstated: %v", netstated)
+	common.Debugf("tag: %v", tag)
+	common.Debugf("pprof: %v", pprof)
+	common.Debugf("ca: %v", ca)
+	common.Debugf("serverName: %v", serverName)
+	common.Debugf("proxyPort: %v", proxyPort)
 
 	bfOpt := clientcore.NewDefaultBroflakeOptions()
 	bfOpt.ClientType = clientType
@@ -72,7 +72,7 @@ func main() {
 
 	if pprof != "" {
 		go func() {
-			log.Println(http.ListenAndServe("localhost:"+pprof, nil))
+			common.Debug(http.ListenAndServe("localhost:"+pprof, nil))
 		}()
 	}
 

--- a/cmd/client_wasm_impl.go
+++ b/cmd/client_wasm_impl.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	log.Printf("wasm client started...")
+	common.Debugf("wasm client started...")
 
 	// A constructor is exposed to JS. Some (but not all) defaults are forcibly overridden by passing
 	// args. You *must* pass valid values for all of these args:
@@ -52,11 +52,11 @@ func main() {
 
 			_, ui, err := clientcore.NewBroflake(&bfOpt, rtcOpt, egOpt)
 			if err != nil {
-				log.Printf("newBroflake error: %v\n", err)
+				common.Debugf("newBroflake error: %v", err)
 				return nil
 			}
 
-			log.Printf("Built new Broflake API: %v\n", ui.ID)
+			common.Debugf("Built new Broflake API: %v", ui.ID)
 			return js.Global().Get(ui.ID)
 		}),
 	)

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/elazarl/goproxy"
+
 	"github.com/getlantern/broflake/clientcore"
+	"github.com/getlantern/broflake/common"
 )
 
 const (
@@ -38,7 +40,7 @@ func runLocalProxy(port string, bfconn *clientcore.BroflakeConn, ca, sn string) 
 		certPool.AppendCertsFromPEM(pem)
 	} else {
 		insecureSkipVerify = true
-		log.Printf("!!! WARNING !!! No root CA cert specified, using insecure TLS!")
+		common.Debugf("!!! WARNING !!! No root CA cert specified, using insecure TLS!")
 	}
 
 	ql, err := clientcore.NewQUICLayer(
@@ -46,7 +48,7 @@ func runLocalProxy(port string, bfconn *clientcore.BroflakeConn, ca, sn string) 
 		&clientcore.QUICLayerOptions{ServerName: sn, InsecureSkipVerify: insecureSkipVerify, CA: certPool},
 	)
 	if err != nil {
-		log.Printf("Cannot start local HTTP proxy: failed to create QUIC layer: %v", err)
+		common.Debugf("Cannot start local HTTP proxy: failed to create QUIC layer: %v", err)
 		return
 	}
 
@@ -55,8 +57,8 @@ func runLocalProxy(port string, bfconn *clientcore.BroflakeConn, ca, sn string) 
 
 	proxy.OnRequest().DoFunc(
 		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-			log.Println("HTTP proxy just saw a request:")
-			log.Println(r)
+			common.Debug("HTTP proxy just saw a request:")
+			common.Debug(r)
 			return r, nil
 		},
 	)
@@ -64,10 +66,10 @@ func runLocalProxy(port string, bfconn *clientcore.BroflakeConn, ca, sn string) 
 	addr := fmt.Sprintf("%v:%v", ip, port)
 
 	go func() {
-		log.Printf("Starting HTTP CONNECT proxy on %v...\n", addr)
+		common.Debugf("Starting HTTP CONNECT proxy on %v...", addr)
 		err := http.ListenAndServe(addr, proxy)
 		if err != nil {
-			log.Printf("HTTP CONNECT proxy error: %v\n", err)
+			common.Debugf("HTTP CONNECT proxy error: %v", err)
 		}
 	}()
 }

--- a/egress/cmd/egress.go
+++ b/egress/cmd/egress.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"os"
 
 	"github.com/elazarl/goproxy"
+
+	"github.com/getlantern/broflake/common"
 	"github.com/getlantern/broflake/egress"
 )
 
@@ -56,16 +57,16 @@ func main() {
 	// Instantiate our local HTTP CONNECT proxy
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = true
-	log.Printf("Starting HTTP CONNECT proxy...\n")
+	common.Debugf("Starting HTTP CONNECT proxy...")
 
 	proxy.OnRequest().DoFunc(
 		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-			log.Println("HTTP proxy just saw a request:")
+			common.Debug("HTTP proxy just saw a request:")
 			// TODO: overriding the context is a hack to prevent "context canceled" errors when proxying
 			// HTTP (not HTTPS) requests. It's not yet clear why this is necessary -- it may be a quirk
 			// of elazarl/goproxy. See: https://github.com/getlantern/broflake/issues/47
 			r = r.WithContext(context.Background())
-			log.Println(r)
+			common.Debug(r)
 			return r, nil
 		},
 	)

--- a/netstate/d/netstated.go
+++ b/netstate/d/netstated.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/getlantern/broflake/netstate/client"
+	"github.com/getlantern/broflake/common"
+	netstatecl "github.com/getlantern/broflake/netstate/client"
 )
 
 type vertex string
@@ -122,7 +122,7 @@ func handleExec(w http.ResponseWriter, r *http.Request) {
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Error: %v\n", err)
+		common.Debugf("Error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("400\n"))
 		return
@@ -131,7 +131,7 @@ func handleExec(w http.ResponseWriter, r *http.Request) {
 	inst := netstatecl.Instruction{}
 	err = json.Unmarshal(b, &inst)
 	if err != nil {
-		log.Printf("Error: %v\n", err)
+		common.Debugf("Error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("400\n"))
 		return
@@ -155,7 +155,7 @@ func handleExec(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.Println(world.data)
+	common.Debug(world.data)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -186,9 +186,9 @@ func main() {
 	http.Handle("/", http.FileServer(http.Dir("./webclients/gv/public")))
 	http.HandleFunc("/exec", handleExec)
 	http.HandleFunc("/neato", handleNeato)
-	log.Printf("netstated listening on %v\n\n", srv.Addr)
+	common.Debugf("netstated listening on %v", srv.Addr)
 	err := srv.ListenAndServe()
 	if err != nil {
-		log.Println(err)
+		common.Debug(err)
 	}
 }


### PR DESCRIPTION
This allows us to plug into external logging systems like the one used in flashlight. In flashlight, this results in logs like the following:

```
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:30 Consumer state 0, constructing RTCPeerConnection...
May 02 15:15:48.852 - 0m2s DEBUG broflake: context.go:209 Starting WorkerFSM...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:30 Consumer state 0, constructing RTCPeerConnection...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:41 Created STUN batch (5/5 servers)
May 02 15:15:48.852 - 0m2s DEBUG broflake: context.go:209 Starting WorkerFSM...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:30 Consumer state 0, constructing RTCPeerConnection...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:41 Created STUN batch (5/5 servers)
May 02 15:15:48.852 - 0m2s DEBUG broflake: context.go:209 Starting WorkerFSM...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:30 Consumer state 0, constructing RTCPeerConnection...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:30 Consumer state 0, constructing RTCPeerConnection...
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:41 Created STUN batch (5/5 servers)
May 02 15:15:48.852 - 0m2s DEBUG broflake: consumer.go:41 Created STUN batch (5/5 servers)
```

This depends on https://github.com/getlantern/golog/pull/21