### PR TITLE
Add Dockerfiles for egress and freddie

### DIFF
--- a/Dockerfile.egress
+++ b/Dockerfile.egress
@@ -1,0 +1,13 @@
+FROM golang:1.20-alpine
+
+WORKDIR /usr/src/app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/local/bin/egress ./egress/cmd/...
+
+EXPOSE 8000/tcp
+
+CMD ["egress"]

--- a/Dockerfile.freddie
+++ b/Dockerfile.freddie
@@ -1,0 +1,13 @@
+FROM golang:1.20-alpine
+
+WORKDIR /usr/src/app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/local/bin/freddie ./freddie/...
+
+EXPOSE 9000/tcp
+
+CMD ["freddie"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  freddie:
+    image: freddie
+    build:
+      dockerfile: ./Dockerfile.freddie
+    ports:
+      - 9000:9000/tcp
+  egress:
+    image: egress
+    build:
+      dockerfile: ./Dockerfile.egress
+    ports:
+      - 8000:8000/tcp


### PR DESCRIPTION
This adds two simple Dockerfiles for `freddie` and `egress`, and a `docker-compose.yml` file that brings up both.

[![asciicast](https://asciinema.org/a/F96YZXrOrehic39ORfIAOnDW6.svg)](https://asciinema.org/a/F96YZXrOrehic39ORfIAOnDW6)