### PR TITLE
[freddie] Don't use the default ServeMux

### DIFF
--- a/freddie/freddie.go
+++ b/freddie/freddie.go
@@ -82,12 +82,15 @@ type Freddie struct {
 }
 
 func New(ctx context.Context, listenAddr string) (Freddie, error) {
+	mux := http.NewServeMux()
+
 	f := Freddie{
 		ctx: ctx,
 		srv: &http.Server{
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 30 * time.Second,
 			Addr:         listenAddr,
+			Handler:      mux,
 		},
 	}
 
@@ -103,11 +106,11 @@ func New(ctx context.Context, listenAddr string) (Freddie, error) {
 		return Freddie{}, err
 	}
 
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf("freddie (%v)\n", common.Version)))
 	})
-	http.HandleFunc("/v1/signal", f.handleSignal)
+	mux.HandleFunc("/v1/signal", f.handleSignal)
 
 	return f, nil
 }


### PR DESCRIPTION
I need to enable pprof on Freddie, but don't want to expose the pprof http endpoints to the entire world. Unfortunately, `net/http/pprof` unconditionally registers its handlers with `http.DefaultServeMux` in its package `init()` function. So, we should use our own `ServeMux` for Freddie to work around this. (We should not be implicitly using `DefaultServeMux` anyway, regardless of pprof usage.)