### PR TITLE
bump quic-go to 0.41

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/getlantern/telemetry v0.0.0-20230523155019-be7c1d8cd8cb
 	github.com/google/uuid v1.3.0
 	github.com/pion/webrtc/v3 v3.2.6
-	github.com/quic-go/quic-go v0.40.0
+	github.com/quic-go/quic-go v0.41.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/metric v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/quic-go/quic-go v0.34.0 h1:OvOJ9LFjTySgwOTYUZmNoq0FzVicP8YujpV0kB7m2l
 github.com/quic-go/quic-go v0.34.0/go.mod h1:+4CVgVppm0FNjpG3UcX8Joi/frKOH7/ciD5yGcwOO1g=
 github.com/quic-go/quic-go v0.40.0 h1:GYd1iznlKm7dpHD7pOVpUvItgMPo/jrMgDWZhMCecqw=
 github.com/quic-go/quic-go v0.40.0/go.mod h1:PeN7kuVJ4xZbxSv/4OX6S1USOX8MJvydwpTx31vx60c=
+github.com/quic-go/quic-go v0.41.0 h1:aD8MmHfgqTURWNJy48IYFg2OnxwHT3JL7ahGs73lb4k=
+github.com/quic-go/quic-go v0.41.0/go.mod h1:qCkNjqczPEvgsOnxZ0eCD14lv+B2LHlFAB++CNOh9hA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
This PR bumps Broflake to use the newest quic-go.  Since the new quic-go requires Go 1.21, **this PR should not be merged until https://github.com/getlantern/flashlight/pull/1351 has been applied to flashlight to bump it from Go 1.20 to Go 1.21:**



It seems that no code changes were required to perform the upgrade here.  The new quic-go "just works," as least as far as Broflake is concerned.

Some informal things I did to check Broflake's system functions after bumping to 0.41:

I stood up a test network consisting of a local Freddie, a local standalone egress server, a single widget, and a single desktop client.  I allowed the widget and desktop client to discover each other and complete signaling, and I observed the "QUIC connection established, ready to proxy!" message emitted by the desktop client.

I disconnected and reconnected the widget a few times, and I observed the desktop client re-discover it, recover from its broken QUIC connection, and successfully dial a new one.

I disconnected the desktop client a few times and repeated the above.

I hosted a development build of the web widget using a freshly compiled wasm engine.  I allowed the web widget to discover my local native binary desktop client and establish a connection.  I disconnected and reconnected both clients a few times, observing correct recovery and re-connection.

I used Firefox to proxy through the web widget.  I visited a bunch of sites, Youtube, Spotify, etc.

All seems good.

We've only had one historical issue with quic-go updates, and that issue presented as a race condition which sometimes left the desktop client unable to dial and maintain a QUIC connection.  That was caused by a breaking API change.  Nothing like that seems to have happened with this new update.