### PR TITLE
log error and return if websocket conn cant be accepted

### DIFF
--- a/egress/cmd/egress.go
+++ b/egress/cmd/egress.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -35,13 +34,13 @@ func main() {
 	// XXX: in the process of delivering the cert and key to egress.NewListener, we suboptimally
 	// cast back and forth between []string and []byte... it's just a byproduct of the API
 	if certFile != "" && keyFile != "" {
-		cert, err := ioutil.ReadFile(certFile)
+		cert, err := os.ReadFile(certFile)
 		if err != nil {
 			panic(err)
 		}
 		tlsCert = string(cert)
 
-		key, err := ioutil.ReadFile(keyFile)
+		key, err := os.ReadFile(keyFile)
 		if err != nil {
 			panic(err)
 		}

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -164,6 +164,10 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 			CompressionMode:    websocket.CompressionDisabled,
 		},
 	)
+	if err != nil {
+		common.Debugf("Error accepting WebSocket connection: %v", err)
+		return
+	}
 
 	tcpAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
 	if err != nil {


### PR DESCRIPTION
because `websocket.Accept()` returns `nil` on error, any request to the egress server that couldn't be accepted, would mean that later we would try to read from a `nil` `websocket.Conn`. This caused the server to crash via segfault if a bad request was sent to it. Also moved some calls from `ioutil` -> `os` because that package was deprecated