### PR TITLE
Echo/netstate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ ui/wp-plugin.zip
 ui/package-lock.json
 ui/package
 
-# netstated globe web client
+# netstated globe web client and build
 netstate/d/webclients/globe/node_modules
+netstate/d/webclients/globe/build

--- a/netstate/d/netstated.go
+++ b/netstate/d/netstated.go
@@ -450,6 +450,10 @@ func main() {
 		http.HandleFunc("/neato", handleNeato)
 	}
 
+	if unsafe == 1 {
+		http.Handle("/globe/", http.StripPrefix("/globe/", http.FileServer(http.Dir("./webclients/globe/build"))))
+	}
+
 	http.HandleFunc("/data", handleData)
 	http.HandleFunc("/exec", handleExec)
 	common.Debugf("netstated listening on %v", srv.Addr)

--- a/netstate/d/webclients/globe/src/App.js
+++ b/netstate/d/webclients/globe/src/App.js
@@ -4,7 +4,7 @@ import Globe from 'react-globe.gl';
 import { useState, useEffect } from 'react';
 
 function App() {
-  const netstatedUrl = "https://netstated-d7bbec1ed55b.herokuapp.com/data";
+  const netstatedUrl = process.env.REACT_APP_NETSTATE_URL || "https://netstated-d7bbec1ed55b.herokuapp.com/data";
   const [peerData, setPeerData] = useState([]);
 
   useEffect(() => {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -55,7 +55,7 @@ commands=(
     "cd cmd && ./build.sh widget && cd dist/bin && TAG=alice NETSTATED=http://localhost:8080/exec FREDDIE=http://localhost:9000 EGRESS=http://localhost:8000 ./widget"
 
     # start netstate
-    "UNSAFE=1 go run ./netstate/d"
+    "cd netstate/d && UNSAFE=1 go run ."
 
     # build and start up a number of censored peers
     "cd cmd && ./build.sh desktop && TAG=bob NETSTATED=http://localhost:8080/exec FREDDIE=http://localhost:9000 EGRESS=http://localhost:8000 ./derek.sh $peers"


### PR DESCRIPTION
@jay-418 this fixes the web view of netstate for your quickstart.sh script. see screenshot below or visit http://localhost:8080/

also I added in the globe visualization. if you build the viz using `PUBLIC_URL=/globe REACT_APP_NETSTATE_URL=http://localhost:8080/data npm run build` you can then view it at http://localhost:8080/globe/

<img width="903" alt="Screenshot 2025-03-07 at 3 26 05 PM" src="https://github.com/user-attachments/assets/d914c153-a3f6-4479-a5cf-ffdf561368f9" />

<img width="600" alt="Screenshot 2025-03-07 at 3 27 27 PM" src="https://github.com/user-attachments/assets/0e6d59ac-f410-4a8f-877a-e59ed093c048" />
