### PR TITLE
Add WebTransport support to WASM

### DIFF
--- a/clientcore/egress_consumer_ws.go
+++ b/clientcore/egress_consumer_ws.go
@@ -1,0 +1,118 @@
+// egress_consumer.go implements egress consumer behavior over WebSockets, including connection
+// establishment, connection error detection, and reset. See:
+// https://docs.google.com/spreadsheets/d/1qM1gwPRtTKTFfZZ0e51R7AdS6qkPlKMuJX3D3vmpG_U/edit#gid=654426763
+
+package clientcore
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/getlantern/broflake/common"
+)
+
+func NewEgressConsumerWebSocket(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM {
+	return NewWorkerFSM(wg, []FSMstate{
+		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+			// State 0
+			// (no input data)
+			common.Debugf("Egress consumer state 0, opening WebSocket connection...")
+
+			// We're resetting this slot, so send a nil path assertion IPC message
+			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+
+			// TODO: interesting quirk here: if the table router which manages this WorkerFSM implements
+			// non-multiplexed just-in-time strategy wherein it creates a new websocket connection for
+			// each new censored peer, we've got a chicken and egg deadlock: the consumer table won't
+			// start advertising connectivity until it detects a non-nil path assertion, and we won't
+			// have a non-nil path assertion until a censored peer connects to us. 3 poss solutions: make
+			// this egress consumer WorkerFSM always emit a (*, 1) path assertion, even when it doesn't
+			// have upstream connectivity... OR invent another special case for the host field which
+			// indicates "on request", as an escape hatch which indicates to a consumer table that it
+			// can use that slot to dial a lantern-controlled exit node, so we'd be emitting something
+			// like ($, 1)... OR just disallow just-in-time strategies, and make egress consumers
+			// pre-establish N websocket connections
+
+			options.ConnectTimeout = 15 * time.Second
+			ctx, cancel := context.WithTimeout(ctx, options.ConnectTimeout)
+			defer cancel()
+
+			// TODO: WSS
+
+			c, _, err := websocket.Dial(ctx, options.Addr+options.Endpoint, nil)
+			if err != nil {
+				common.Debugf("Couldn't connect to egress server at %v: %v", options.Addr, err)
+				<-time.After(options.ErrorBackoff)
+				return 0, []interface{}{}
+			}
+
+			return 1, []interface{}{c}
+		}),
+		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+			// State 1
+			// input[0]: *websocket.Conn
+			c := input[0].(*websocket.Conn)
+			common.Debugf("Egress consumer state 1, WebSocket connection established!")
+
+			// Send a path assertion IPC message representing the connectivity now provided by this slot
+			// TODO: post-MVP we shouldn't be hardcoding (*, 1) here...
+			allowAll := []common.Endpoint{{Host: "*", Distance: 1}}
+			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}
+
+			// WebSocket read loop:
+			readStatus := make(chan error)
+			go func(ctx context.Context) {
+				for {
+					_, b, err := c.Read(ctx)
+					if err != nil {
+						readStatus <- err
+						return
+					}
+
+					// Wrap the chunk and send it on to the router
+					select {
+					case com.tx <- IPCMsg{IpcType: ChunkIPC, Data: b}:
+						// Do nothing, msg sent
+					default:
+						// Drop the chunk if we can't keep up with the data rate
+					}
+				}
+			}(ctx)
+
+			// Main loop:
+			// 1. handle chunks from the bus, write them to the WebSocket, detect and handle write errors
+			// 2. listen for errors from the read goroutine and handle them
+
+			// On read or write error, we counterintuitively close the websocket with StatusNormalClosure.
+			// This is to ensure that the egress server detects closed connections while respecting a
+			// quirk in our WS library's net.Conn wrapper: https://pkg.go.dev/nhooyr.io/websocket#NetConn
+			for {
+				select {
+				case msg := <-com.rx:
+					// Write the chunk to the websocket, detect and handle error
+					// TODO: is it safe to assume the message is a chunk type? Do we trust the router?
+					err := c.Write(ctx, websocket.MessageBinary, msg.Data.([]byte))
+					if err != nil {
+						c.Close(websocket.StatusNormalClosure, err.Error())
+						common.Debugf("Egress consumer WebSocket write error: %v", err)
+						return 0, []interface{}{}
+					}
+				case err := <-readStatus:
+					c.Close(websocket.StatusNormalClosure, err.Error())
+					common.Debugf("Egress consumer WebSocket read error: %v", err)
+					return 0, []interface{}{}
+
+					// Ordinarily it would be incorrect to put a worker into an infinite loop without including
+					// a case to listen for context cancellation, but here we handle context cancellation in a
+					// non-explicit way. Since the worker context bounds the call to websocket.Read, worker
+					// context cancellation results in a Read error, which we trap to stop the child read
+					// goroutine, close the websocket, and return from this state, at which point the worker
+					// stop logic in protocol.go takes over and kills this goroutine.
+				}
+			}
+		}),
+	})
+}

--- a/clientcore/egress_consumer_wt.go
+++ b/clientcore/egress_consumer_wt.go
@@ -1,6 +1,4 @@
-// egress_consumer.go implements egress consumer behavior over WebSockets, including connection
-// establishment, connection error detection, and reset. See:
-// https://docs.google.com/spreadsheets/d/1qM1gwPRtTKTFfZZ0e51R7AdS6qkPlKMuJX3D3vmpG_U/edit#gid=654426763
+//go:build !wasm
 
 package clientcore
 
@@ -12,8 +10,6 @@ import (
 	"net"
 	"sync"
 	"time"
-
-	"github.com/coder/websocket"
 
 	"github.com/getlantern/broflake/common"
 	"github.com/getlantern/quicwrapper/webt"
@@ -97,7 +93,7 @@ func NewEgressConsumerWebTransport(options *EgressOptions, wg *sync.WaitGroup) *
 			readStatus := make(chan error)
 			go func(ctx context.Context) {
 				for {
-					buf := make([]byte, 1280)
+					buf := make([]byte, 2048)
 					bytesRead, _, err := pconn.ReadFrom(buf)
 					if err != nil {
 						readStatus <- err
@@ -128,7 +124,7 @@ func NewEgressConsumerWebTransport(options *EgressOptions, wg *sync.WaitGroup) *
 						common.Debugf("Egress consumer WebTransport received non-byte chunk: %v", msg.Data)
 						return 0, []interface{}{}
 					}
-					_, err := pconn.WriteTo(data, &net.TCPAddr{}) // addr not used
+					_, err := pconn.WriteTo(data, nil)
 					if err != nil {
 						common.Debugf("Egress consumer WebTransport write error: %v", err)
 						return 0, []interface{}{}
@@ -146,109 +142,6 @@ func NewEgressConsumerWebTransport(options *EgressOptions, wg *sync.WaitGroup) *
 					// non-explicit way. Since the worker context bounds the call to net.Conn.Read, worker
 					// context cancellation results in a Read error, which we trap to stop the child read
 					// goroutine, close the connection, and return from this state, at which point the worker
-					// stop logic in protocol.go takes over and kills this goroutine.
-				}
-			}
-		}),
-	})
-}
-
-func NewEgressConsumerWebSocket(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM {
-	return NewWorkerFSM(wg, []FSMstate{
-		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
-			// State 0
-			// (no input data)
-			common.Debugf("Egress consumer state 0, opening WebSocket connection...")
-
-			// We're resetting this slot, so send a nil path assertion IPC message
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
-
-			// TODO: interesting quirk here: if the table router which manages this WorkerFSM implements
-			// non-multiplexed just-in-time strategy wherein it creates a new websocket connection for
-			// each new censored peer, we've got a chicken and egg deadlock: the consumer table won't
-			// start advertising connectivity until it detects a non-nil path assertion, and we won't
-			// have a non-nil path assertion until a censored peer connects to us. 3 poss solutions: make
-			// this egress consumer WorkerFSM always emit a (*, 1) path assertion, even when it doesn't
-			// have upstream connectivity... OR invent another special case for the host field which
-			// indicates "on request", as an escape hatch which indicates to a consumer table that it
-			// can use that slot to dial a lantern-controlled exit node, so we'd be emitting something
-			// like ($, 1)... OR just disallow just-in-time strategies, and make egress consumers
-			// pre-establish N websocket connections
-
-			options.ConnectTimeout = 15 * time.Second
-			ctx, cancel := context.WithTimeout(ctx, options.ConnectTimeout)
-			defer cancel()
-
-			// TODO: WSS
-
-			c, _, err := websocket.Dial(ctx, options.Addr+options.Endpoint, nil)
-			if err != nil {
-				common.Debugf("Couldn't connect to egress server at %v: %v", options.Addr, err)
-				<-time.After(options.ErrorBackoff)
-				return 0, []interface{}{}
-			}
-
-			return 1, []interface{}{c}
-		}),
-		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
-			// State 1
-			// input[0]: *websocket.Conn
-			c := input[0].(*websocket.Conn)
-			common.Debugf("Egress consumer state 1, WebSocket connection established!")
-
-			// Send a path assertion IPC message representing the connectivity now provided by this slot
-			// TODO: post-MVP we shouldn't be hardcoding (*, 1) here...
-			allowAll := []common.Endpoint{{Host: "*", Distance: 1}}
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}
-
-			// WebSocket read loop:
-			readStatus := make(chan error)
-			go func(ctx context.Context) {
-				for {
-					_, b, err := c.Read(ctx)
-					if err != nil {
-						readStatus <- err
-						return
-					}
-
-					// Wrap the chunk and send it on to the router
-					select {
-					case com.tx <- IPCMsg{IpcType: ChunkIPC, Data: b}:
-						// Do nothing, msg sent
-					default:
-						// Drop the chunk if we can't keep up with the data rate
-					}
-				}
-			}(ctx)
-
-			// Main loop:
-			// 1. handle chunks from the bus, write them to the WebSocket, detect and handle write errors
-			// 2. listen for errors from the read goroutine and handle them
-
-			// On read or write error, we counterintuitively close the websocket with StatusNormalClosure.
-			// This is to ensure that the egress server detects closed connections while respecting a
-			// quirk in our WS library's net.Conn wrapper: https://pkg.go.dev/nhooyr.io/websocket#NetConn
-			for {
-				select {
-				case msg := <-com.rx:
-					// Write the chunk to the websocket, detect and handle error
-					// TODO: is it safe to assume the message is a chunk type? Do we trust the router?
-					err := c.Write(ctx, websocket.MessageBinary, msg.Data.([]byte))
-					if err != nil {
-						c.Close(websocket.StatusNormalClosure, err.Error())
-						common.Debugf("Egress consumer WebSocket write error: %v", err)
-						return 0, []interface{}{}
-					}
-				case err := <-readStatus:
-					c.Close(websocket.StatusNormalClosure, err.Error())
-					common.Debugf("Egress consumer WebSocket read error: %v", err)
-					return 0, []interface{}{}
-
-					// Ordinarily it would be incorrect to put a worker into an infinite loop without including
-					// a case to listen for context cancellation, but here we handle context cancellation in a
-					// non-explicit way. Since the worker context bounds the call to websocket.Read, worker
-					// context cancellation results in a Read error, which we trap to stop the child read
-					// goroutine, close the websocket, and return from this state, at which point the worker
 					// stop logic in protocol.go takes over and kills this goroutine.
 				}
 			}

--- a/clientcore/egress_consumer_wt_wasm.go
+++ b/clientcore/egress_consumer_wt_wasm.go
@@ -1,0 +1,288 @@
+//go:build wasm
+
+package clientcore
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+	"syscall/js"
+	"time"
+
+	"github.com/getlantern/broflake/common"
+	"github.com/getlantern/quicwrapper/webt"
+)
+
+const (
+	jsWTCallBackObjectName = "WebTransportCallbacks" // the JS object name in global namespace "window" that holds the WebTransport callbacks
+	jsConnectMethodName    = "connect"               // the JS method name in global namespace "window.WebTransportCallbacks" for connect
+	jsSendMethodName       = "send"                  // the JS method name in global namespace "window.WebTransportCallbacks" for send
+	jsReceiveeMethodName   = "receive"               // the JS method name in global namespace "window.WebTransportCallbacks" for receive
+	jsDisconnectMethodName = "disconnect"            // the JS method name in global namespace "window.WebTransportCallbacks" for disconnect
+)
+
+// wtInstanceManager tracks which WebTransport instances are currently in use
+type wtInstanceManager struct {
+	mutex     sync.Mutex
+	instances map[int]struct{}
+}
+
+// newWTInstanceManager creates a new instance of WTInstanceManager
+func newWTInstanceManager() *wtInstanceManager {
+	return &wtInstanceManager{
+		instances: make(map[int]struct{}),
+	}
+}
+
+// Acquire returns the next available WebTransport instance ID
+func (manager *wtInstanceManager) Acquire() int {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	// always start from the lowest ID because in JS there are exactly the same number of web transport instances created as the number of egress consumers
+	for i := 0; ; i++ {
+		if _, exists := manager.instances[i]; !exists {
+			manager.instances[i] = struct{}{}
+			return i
+		}
+	}
+}
+
+// Release deletes the specified instance ID from the manager
+func (manager *wtInstanceManager) Release(id int) {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+	delete(manager.instances, id)
+}
+
+var wtManager = newWTInstanceManager()
+
+type JSWebTransportConn struct {
+	id      int
+	send    js.Value
+	chunker *webt.DatagramChunker
+}
+
+func newJSWebTransportConn(id int) *JSWebTransportConn {
+	conn := &JSWebTransportConn{
+		id:      id,
+		send:    js.Global().Get(jsWTCallBackObjectName).Get(jsSendMethodName).Get(strconv.Itoa(id)),
+		chunker: webt.NewDatagramChunker(),
+	}
+
+	// setup the receive callback for JS
+	js.Global().Get(jsWTCallBackObjectName).Get(jsReceiveeMethodName).
+		Set(strconv.Itoa(id), js.FuncOf(func(this js.Value, args []js.Value) any {
+			if len(args) == 0 {
+				return nil
+			}
+			buf := make([]byte, args[0].Get("length").Int())
+			//common.Debugf("[Go WT:%v]: receive datagram of %v", id, len(buf))
+			js.CopyBytesToGo(buf, args[0])
+			conn.chunker.Receive(buf)
+			return nil
+		}))
+
+	// setup the disconnect callback for JS
+	js.Global().Get(jsWTCallBackObjectName).Get(jsDisconnectMethodName).
+		Set(strconv.Itoa(id), js.FuncOf(func(this js.Value, args []js.Value) any {
+			conn.Close()
+			return nil
+		}))
+
+	return conn
+}
+
+func (c *JSWebTransportConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	data, err := c.chunker.Read()
+	if err != nil {
+		return 0, nil, err
+	}
+	n = copy(p, data)
+	addr = nil
+	return
+}
+
+func (c *JSWebTransportConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	chunks := c.chunker.Chunk(p)
+	for _, chunk := range chunks {
+		arr := js.Global().Get("Uint8Array").New(len(chunk))
+		js.CopyBytesToJS(arr, chunk)
+		promise := c.send.Invoke(arr)
+
+		done := make(chan error)
+		promise.Call("then", js.FuncOf(func(this js.Value, args []js.Value) any {
+			done <- nil
+			return nil
+		})).Call("catch", js.FuncOf(func(this js.Value, args []js.Value) any {
+			jsErr := args[0]
+			// try to get the .message field if it's an Error object
+			msg := jsErr.Get("message")
+			if msg.Truthy() {
+				common.Debugf("WebTransport %d send error: %s", c.id, msg.String())
+				done <- errors.New(msg.String())
+			} else {
+				// fallback to JSON.stringify
+				jsonStr := js.Global().Get("JSON").Call("stringify", jsErr)
+				common.Debugf("WebTransport %d send error: %s", c.id, jsonStr.String())
+				done <- errors.New(jsonStr.String())
+			}
+			return nil
+		}))
+		err = <-done
+		if err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+func (c *JSWebTransportConn) Close() error {
+	common.Debugf("Closing WebTransport connection %d", c.id)
+	c.chunker.Close()
+	return nil
+}
+
+func (d *JSWebTransportConn) LocalAddr() net.Addr                { return nil }
+func (d *JSWebTransportConn) SetDeadline(t time.Time) error      { return nil }
+func (d *JSWebTransportConn) SetReadDeadline(t time.Time) error  { return nil }
+func (d *JSWebTransportConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func NewEgressConsumerWebTransport(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM {
+	return NewWorkerFSM(wg, []FSMstate{
+		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+			// State 0
+			// (no input data)
+			wtId := wtManager.Acquire()
+			common.Debugf("Egress consumer state 0, opening WebTransport connection %v in JS...", wtId)
+
+			// We're resetting this slot, so send a nil path assertion IPC message
+			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+
+			// TODO: interesting quirk here: if the table router which manages this WorkerFSM implements
+			// non-multiplexed just-in-time strategy wherein it creates a new WebTransport connection for
+			// each new censored peer, we've got a chicken and egg deadlock: the consumer table won't
+			// start advertising connectivity until it detects a non-nil path assertion, and we won't
+			// have a non-nil path assertion until a censored peer connects to us. 3 poss solutions: make
+			// this egress consumer WorkerFSM always emit a (*, 1) path assertion, even when it doesn't
+			// have upstream connectivity... OR invent another special case for the host field which
+			// indicates "on request", as an escape hatch which indicates to a consumer table that it
+			// can use that slot to dial a lantern-controlled exit node, so we'd be emitting something
+			// like ($, 1)... OR just disallow just-in-time strategies, and make egress consumers
+			// pre-establish N WebTransport connections
+
+			ctx, cancel := context.WithTimeout(ctx, options.ConnectTimeout)
+			defer cancel()
+
+			url := options.Addr + options.Endpoint
+
+			// create a briding connection
+			pconn := newJSWebTransportConn(wtId)
+
+			// call into the JS to initialize the WebTransport
+			connectFunc := js.Global().Get(jsWTCallBackObjectName).Get(jsConnectMethodName).Get(strconv.Itoa(wtId))
+			if connectFunc.Type() != js.TypeFunction {
+				common.Debugf("Cannot find connect callback for WebTransport %d, %v", wtId, connectFunc)
+				wtManager.Release(wtId)
+				<-time.After(options.ErrorBackoff)
+				return 0, []interface{}{}
+			}
+
+			promise := connectFunc.Invoke(js.ValueOf(url))
+			resultCh := make(chan bool)
+			then := js.FuncOf(func(this js.Value, args []js.Value) any {
+				if len(args) > 0 && args[0].Type() == js.TypeBoolean {
+					resultCh <- args[0].Bool()
+				} else {
+					resultCh <- false // fallback if something went wrong
+				}
+				return nil
+			})
+			promise.Call("then", then)
+
+			// wait for completion in JS
+			if <-resultCh {
+				common.Debugf("WebTransport %d is connected successfully", wtId)
+				<-time.After(1 * time.Second) // TODO: find out why this wait is needed or the FSM enters an infinite loop that calls this state
+				return 1, []interface{}{pconn, wtId}
+			} else {
+				common.Debugf("WebTransport %d failed to connect", wtId)
+				wtManager.Release(wtId)
+				<-time.After(options.ErrorBackoff)
+				return 0, []interface{}{}
+			}
+		}),
+		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+			// State 1
+			pconn := input[0].(net.PacketConn)
+			wtId := input[1].(int)
+			common.Debugf("Egress consumer state 1, WebTransport connection %d established from JS!", wtId)
+			defer func() {
+				wtManager.Release(wtId)
+			}()
+
+			// Send a path assertion IPC message representing the connectivity now provided by this slot
+			// TODO: post-MVP we shouldn't be hardcoding (*, 1) here...
+			allowAll := []common.Endpoint{{Host: "*", Distance: 1}}
+			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}
+
+			// WebTransport read loop:
+			readStatus := make(chan error)
+			go func(ctx context.Context) {
+				for {
+					buf := make([]byte, 2048)
+					bytesRead, _, err := pconn.ReadFrom(buf)
+					if err != nil {
+						readStatus <- err
+						return
+					}
+					//common.Debugf("Egress consumer WebTransport received %v bytes", bytesRead)
+
+					// Wrap the chunk and send it on to the router
+					select {
+					case com.tx <- IPCMsg{IpcType: ChunkIPC, Data: buf[:bytesRead]}:
+						// Do nothing, msg sent
+					default:
+						// Drop the chunk if we can't keep up with the data rate
+					}
+				}
+			}(ctx)
+
+			// Main loop:
+			// 1. handle chunks from the bus, write them to the WebTransport, detect and handle write errors
+			// 2. listen for errors from the read goroutine and handle them
+			// On read or write error, we close the WebTransport to ensure that the egress server detects
+			// closed connections.
+			for {
+				select {
+				case msg := <-com.rx:
+					data, ok := msg.Data.([]byte)
+					if !ok {
+						common.Debugf("Egress consumer WebTransport %d received non-byte chunk: %v", wtId, msg.Data)
+						return 0, []interface{}{}
+					}
+					_, err := pconn.WriteTo(data, nil)
+					if err != nil {
+						common.Debugf("Egress consumer WebTransport %d write error: %v", wtId, err)
+						return 0, []interface{}{}
+					}
+					//common.Debugf("Egress consumer WebTransport %d sent %v/%v bytes", wtId, bytesWritten, len(data))
+
+					// At this point the chunks are written, so loop around and wait for the next chunk
+				case err := <-readStatus:
+					common.Debugf("Egress consumer WebTransport %d read error: %v", wtId, err)
+					return 0, []interface{}{}
+
+					// Ordinarily it would be incorrect to put a worker into an infinite loop without including
+					// a case to listen for context cancellation, but here we handle context cancellation in a
+					// non-explicit way. Since the worker context bounds the call to net.Conn.Read, worker
+					// context cancellation results in a Read error, which we trap to stop the child read
+					// goroutine, close the connection, and return from this state, at which point the worker
+					// stop logic in protocol.go takes over and kills this goroutine.
+				}
+			}
+		}),
+	})
+}

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -300,7 +300,7 @@ func (wtpconn webtransportPacketConn) SetWriteDeadline(t time.Time) error {
 	return wtpconn.PacketConn.SetWriteDeadline(t)
 }
 
-func (l proxyListener) handleWebTransport(pconn net.PacketConn, remoteAddr net.Addr) {
+func (l *proxyListener) handleWebTransport(pconn net.PacketConn, remoteAddr net.Addr) {
 	addr := common.DebugAddr(fmt.Sprintf("WebTransport connection %v", uuid.NewString()))
 	wtpconn := webtransportPacketConn{pconn}
 	defer wtpconn.Close()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/elazarl/goproxy v1.7.2
 	github.com/enobufs/go-nats v0.0.1
 	github.com/getlantern/geo v0.0.0-20240108161311-50692a1b69a9
-	github.com/getlantern/quicwrapper v0.0.0-20250411041809-c9ee84ad419e
+	github.com/getlantern/quicwrapper v0.0.0-20250417060014-acb01527c4c2
 	github.com/getlantern/telemetry v0.0.0-20230523155019-be7c1d8cd8cb
 	github.com/google/uuid v1.3.1
 	github.com/pion/webrtc/v3 v3.3.4

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/getlantern/ops v0.0.0-20200403153110-8476b16edcd6/go.mod h1:D5ao98qkA
 github.com/getlantern/ops v0.0.0-20220713155959-1315d978fff7/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20230424193308-26325dfed3cf h1:q8nsH0Lx9fP8HY6T9rA1zogvOzO9JtbUI5BXkh7wxxI=
 github.com/getlantern/ops v0.0.0-20230424193308-26325dfed3cf/go.mod h1:R7HfJVLsnSeqaDWkiUlU+ANBjac4oYmXGrrps8vW7CM=
-github.com/getlantern/quicwrapper v0.0.0-20250411041809-c9ee84ad419e h1:PVisk2PK5YSo2IUuiQm7thTRGEtegqarLqQSOIyl9EQ=
-github.com/getlantern/quicwrapper v0.0.0-20250411041809-c9ee84ad419e/go.mod h1:8JUff02h2OIo2TSuJDJmTVphoh3MzeE7V5gbjPa+r0w=
+github.com/getlantern/quicwrapper v0.0.0-20250417060014-acb01527c4c2 h1:4TMpZ++GTJtfBGx38IE8JRezp461s0CcWwPOGMyIfTU=
+github.com/getlantern/quicwrapper v0.0.0-20250417060014-acb01527c4c2/go.mod h1:8JUff02h2OIo2TSuJDJmTVphoh3MzeE7V5gbjPa+r0w=
 github.com/getlantern/telemetry v0.0.0-20230523155019-be7c1d8cd8cb h1:6XZ3Q4oD6A1Tjq6QLgzzQrdQ8FvulzW16HhNQOSECAM=
 github.com/getlantern/telemetry v0.0.0-20230523155019-be7c1d8cd8cb/go.mod h1:nGOdDc0aD/LRTaY2SGKQ7nsYcWFXrhgkrhIhJuYN614=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,7 @@
     "rewire": "^6.0.0",
     "styled-components": "^5.3.6",
     "ts-loader": "^9.4.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.8.3",
     "web-vitals": "^2.1.4",
     "webpack": "^5.75.0",
     "webpack-watched-glob-entries-plugin": "^2.2.6"

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="connect-src 'self' *">
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/ui/src/constants/index.ts
+++ b/ui/src/constants/index.ts
@@ -124,7 +124,7 @@ export const WASM_CLIENT_CONFIG = {
 	tag: '',
 	egressAddr: process.env.REACT_APP_EGRESS_ADDR!,
 	egressEndpoint: process.env.REACT_APP_EGRESS_ENDPOINT!,
-	webTransport: false // TODO: webtransport isn't supported in WASM yet, so disable for now. Should call supportsWebTransport() when WT in WASM is ready.
+	webTransport: supportsWebTransport()
 }
 
 // @todo rm stubbing out store urls until extension is ready

--- a/ui/src/utils/goWasmExec.ts
+++ b/ui/src/utils/goWasmExec.ts
@@ -5,276 +5,234 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+"use strict";
+
 (() => {
 	const enosys = () => {
-		const err = new Error('not implemented')
-		err.code = 'ENOSYS'
-		return err
-	}
+		const err = new Error("not implemented");
+		err.code = "ENOSYS";
+		return err;
+	};
 
 	if (!globalThis.fs) {
-		let outputBuf = ''
+		let outputBuf = "";
 		globalThis.fs = {
-			constants: {O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1}, // unused
+			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1, O_DIRECTORY: -1 }, // unused
 			writeSync(fd, buf) {
-				outputBuf += decoder.decode(buf)
-				const nl = outputBuf.lastIndexOf('\n')
+				outputBuf += decoder.decode(buf);
+				const nl = outputBuf.lastIndexOf("\n");
 				if (nl != -1) {
-					console.log(outputBuf.substring(0, nl))
-					outputBuf = outputBuf.substring(nl + 1)
+					console.log(outputBuf.substring(0, nl));
+					outputBuf = outputBuf.substring(nl + 1);
 				}
-				return buf.length
+				return buf.length;
 			},
 			write(fd, buf, offset, length, position, callback) {
 				if (offset !== 0 || length !== buf.length || position !== null) {
-					callback(enosys())
-					return
+					callback(enosys());
+					return;
 				}
-				const n = this.writeSync(fd, buf)
-				callback(null, n)
+				const n = this.writeSync(fd, buf);
+				callback(null, n);
 			},
-			chmod(path, mode, callback) {
-				callback(enosys())
-			},
-			chown(path, uid, gid, callback) {
-				callback(enosys())
-			},
-			close(fd, callback) {
-				callback(enosys())
-			},
-			fchmod(fd, mode, callback) {
-				callback(enosys())
-			},
-			fchown(fd, uid, gid, callback) {
-				callback(enosys())
-			},
-			fstat(fd, callback) {
-				callback(enosys())
-			},
-			fsync(fd, callback) {
-				callback(null)
-			},
-			ftruncate(fd, length, callback) {
-				callback(enosys())
-			},
-			lchown(path, uid, gid, callback) {
-				callback(enosys())
-			},
-			link(path, link, callback) {
-				callback(enosys())
-			},
-			lstat(path, callback) {
-				callback(enosys())
-			},
-			mkdir(path, perm, callback) {
-				callback(enosys())
-			},
-			open(path, flags, mode, callback) {
-				callback(enosys())
-			},
-			read(fd, buffer, offset, length, position, callback) {
-				callback(enosys())
-			},
-			readdir(path, callback) {
-				callback(enosys())
-			},
-			readlink(path, callback) {
-				callback(enosys())
-			},
-			rename(from, to, callback) {
-				callback(enosys())
-			},
-			rmdir(path, callback) {
-				callback(enosys())
-			},
-			stat(path, callback) {
-				callback(enosys())
-			},
-			symlink(path, link, callback) {
-				callback(enosys())
-			},
-			truncate(path, length, callback) {
-				callback(enosys())
-			},
-			unlink(path, callback) {
-				callback(enosys())
-			},
-			utimes(path, atime, mtime, callback) {
-				callback(enosys())
-			}
-		}
+			chmod(path, mode, callback) { callback(enosys()); },
+			chown(path, uid, gid, callback) { callback(enosys()); },
+			close(fd, callback) { callback(enosys()); },
+			fchmod(fd, mode, callback) { callback(enosys()); },
+			fchown(fd, uid, gid, callback) { callback(enosys()); },
+			fstat(fd, callback) { callback(enosys()); },
+			fsync(fd, callback) { callback(null); },
+			ftruncate(fd, length, callback) { callback(enosys()); },
+			lchown(path, uid, gid, callback) { callback(enosys()); },
+			link(path, link, callback) { callback(enosys()); },
+			lstat(path, callback) { callback(enosys()); },
+			mkdir(path, perm, callback) { callback(enosys()); },
+			open(path, flags, mode, callback) { callback(enosys()); },
+			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+			readdir(path, callback) { callback(enosys()); },
+			readlink(path, callback) { callback(enosys()); },
+			rename(from, to, callback) { callback(enosys()); },
+			rmdir(path, callback) { callback(enosys()); },
+			stat(path, callback) { callback(enosys()); },
+			symlink(path, link, callback) { callback(enosys()); },
+			truncate(path, length, callback) { callback(enosys()); },
+			unlink(path, callback) { callback(enosys()); },
+			utimes(path, atime, mtime, callback) { callback(enosys()); },
+		};
 	}
 
 	if (!globalThis.process) {
 		globalThis.process = {
-			getuid() {
-				return -1
-			},
-			getgid() {
-				return -1
-			},
-			geteuid() {
-				return -1
-			},
-			getegid() {
-				return -1
-			},
-			getgroups() {
-				throw enosys()
-			},
+			getuid() { return -1; },
+			getgid() { return -1; },
+			geteuid() { return -1; },
+			getegid() { return -1; },
+			getgroups() { throw enosys(); },
 			pid: -1,
 			ppid: -1,
-			umask() {
-				throw enosys()
-			},
-			cwd() {
-				throw enosys()
-			},
-			chdir() {
-				throw enosys()
+			umask() { throw enosys(); },
+			cwd() { throw enosys(); },
+			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
 			}
 		}
 	}
 
 	if (!globalThis.crypto) {
-		throw new Error('globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)')
+		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
 	}
 
 	if (!globalThis.performance) {
-		throw new Error('globalThis.performance is not available, polyfill required (performance.now only)')
+		throw new Error("globalThis.performance is not available, polyfill required (performance.now only)");
 	}
 
 	if (!globalThis.TextEncoder) {
-		throw new Error('globalThis.TextEncoder is not available, polyfill required')
+		throw new Error("globalThis.TextEncoder is not available, polyfill required");
 	}
 
 	if (!globalThis.TextDecoder) {
-		throw new Error('globalThis.TextDecoder is not available, polyfill required')
+		throw new Error("globalThis.TextDecoder is not available, polyfill required");
 	}
 
-	const encoder = new TextEncoder('utf-8')
-	const decoder = new TextDecoder('utf-8')
+	const encoder = new TextEncoder("utf-8");
+	const decoder = new TextDecoder("utf-8");
 
 	globalThis.Go = class {
 		constructor() {
-			this.argv = ['js']
-			this.env = {}
+			this.argv = ["js"];
+			this.env = {};
 			this.exit = (code) => {
 				if (code !== 0) {
-					console.warn('exit code:', code)
+					console.warn("exit code:", code);
 				}
-			}
+			};
 			this._exitPromise = new Promise((resolve) => {
-				this._resolveExitPromise = resolve
-			})
-			this._pendingEvent = null
-			this._scheduledTimeouts = new Map()
-			this._nextCallbackTimeoutID = 1
+				this._resolveExitPromise = resolve;
+			});
+			this._pendingEvent = null;
+			this._scheduledTimeouts = new Map();
+			this._nextCallbackTimeoutID = 1;
 
 			const setInt64 = (addr, v) => {
-				this.mem.setUint32(addr + 0, v, true)
-				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true)
+				this.mem.setUint32(addr + 0, v, true);
+				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
 			}
 
 			const setInt32 = (addr, v) => {
-				this.mem.setUint32(addr + 0, v, true)
+				this.mem.setUint32(addr + 0, v, true);
 			}
 
 			const getInt64 = (addr) => {
-				const low = this.mem.getUint32(addr + 0, true)
-				const high = this.mem.getInt32(addr + 4, true)
-				return low + high * 4294967296
+				const low = this.mem.getUint32(addr + 0, true);
+				const high = this.mem.getInt32(addr + 4, true);
+				return low + high * 4294967296;
 			}
 
 			const loadValue = (addr) => {
-				const f = this.mem.getFloat64(addr, true)
+				const f = this.mem.getFloat64(addr, true);
 				if (f === 0) {
-					return undefined
+					return undefined;
 				}
 				if (!isNaN(f)) {
-					return f
+					return f;
 				}
 
-				const id = this.mem.getUint32(addr, true)
-				return this._values[id]
+				const id = this.mem.getUint32(addr, true);
+				return this._values[id];
 			}
 
 			const storeValue = (addr, v) => {
-				const nanHead = 0x7FF80000
+				const nanHead = 0x7FF80000;
 
-				if (typeof v === 'number' && v !== 0) {
+				if (typeof v === "number" && v !== 0) {
 					if (isNaN(v)) {
-						this.mem.setUint32(addr + 4, nanHead, true)
-						this.mem.setUint32(addr, 0, true)
-						return
+						this.mem.setUint32(addr + 4, nanHead, true);
+						this.mem.setUint32(addr, 0, true);
+						return;
 					}
-					this.mem.setFloat64(addr, v, true)
-					return
+					this.mem.setFloat64(addr, v, true);
+					return;
 				}
 
 				if (v === undefined) {
-					this.mem.setFloat64(addr, 0, true)
-					return
+					this.mem.setFloat64(addr, 0, true);
+					return;
 				}
 
-				let id = this._ids.get(v)
+				let id = this._ids.get(v);
 				if (id === undefined) {
-					id = this._idPool.pop()
+					id = this._idPool.pop();
 					if (id === undefined) {
-						id = this._values.length
+						id = this._values.length;
 					}
-					this._values[id] = v
-					this._goRefCounts[id] = 0
-					this._ids.set(v, id)
+					this._values[id] = v;
+					this._goRefCounts[id] = 0;
+					this._ids.set(v, id);
 				}
-				this._goRefCounts[id]++
-				let typeFlag = 0
+				this._goRefCounts[id]++;
+				let typeFlag = 0;
 				switch (typeof v) {
-					case 'object':
+					case "object":
 						if (v !== null) {
-							typeFlag = 1
+							typeFlag = 1;
 						}
-						break
-					case 'string':
-						typeFlag = 2
-						break
-					case 'symbol':
-						typeFlag = 3
-						break
-					case 'function':
-						typeFlag = 4
-						break
+						break;
+					case "string":
+						typeFlag = 2;
+						break;
+					case "symbol":
+						typeFlag = 3;
+						break;
+					case "function":
+						typeFlag = 4;
+						break;
 				}
-				this.mem.setUint32(addr + 4, nanHead | typeFlag, true)
-				this.mem.setUint32(addr, id, true)
+				this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+				this.mem.setUint32(addr, id, true);
 			}
 
 			const loadSlice = (addr) => {
-				const array = getInt64(addr + 0)
-				const len = getInt64(addr + 8)
-				return new Uint8Array(this._inst.exports.mem.buffer, array, len)
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
 			}
 
 			const loadSliceOfValues = (addr) => {
-				const array = getInt64(addr + 0)
-				const len = getInt64(addr + 8)
-				const a = new Array(len)
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				const a = new Array(len);
 				for (let i = 0; i < len; i++) {
-					a[i] = loadValue(array + i * 8)
+					a[i] = loadValue(array + i * 8);
 				}
-				return a
+				return a;
 			}
 
 			const loadString = (addr) => {
-				const saddr = getInt64(addr + 0)
-				const len = getInt64(addr + 8)
-				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len))
+				const saddr = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
 			}
 
-			const timeOrigin = Date.now() - performance.now()
+			const testCallExport = (a, b) => {
+				this._inst.exports.testExport0();
+				return this._inst.exports.testExport(a, b);
+			}
+
+			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
 				_gotest: {
-					add: (a, b) => a + b
+					add: (a, b) => a + b,
+					callExport: testCallExport,
 				},
 				gojs: {
 					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
@@ -283,254 +241,254 @@
 					// This changes the SP, thus we have to update the SP used by the imported function.
 
 					// func wasmExit(code int32)
-					'runtime.wasmExit': (sp) => {
-						sp >>>= 0
-						const code = this.mem.getInt32(sp + 8, true)
-						this.exited = true
-						delete this._inst
-						delete this._values
-						delete this._goRefCounts
-						delete this._ids
-						delete this._idPool
-						this.exit(code)
+					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
+						const code = this.mem.getInt32(sp + 8, true);
+						this.exited = true;
+						delete this._inst;
+						delete this._values;
+						delete this._goRefCounts;
+						delete this._ids;
+						delete this._idPool;
+						this.exit(code);
 					},
 
 					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
-					'runtime.wasmWrite': (sp) => {
-						sp >>>= 0
-						const fd = getInt64(sp + 8)
-						const p = getInt64(sp + 16)
-						const n = this.mem.getInt32(sp + 24, true)
-						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n))
+					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
+						const fd = getInt64(sp + 8);
+						const p = getInt64(sp + 16);
+						const n = this.mem.getInt32(sp + 24, true);
+						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
 					},
 
 					// func resetMemoryDataView()
-					'runtime.resetMemoryDataView': (sp) => {
-						sp >>>= 0
-						this.mem = new DataView(this._inst.exports.mem.buffer)
+					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
+						this.mem = new DataView(this._inst.exports.mem.buffer);
 					},
 
 					// func nanotime1() int64
-					'runtime.nanotime1': (sp) => {
-						sp >>>= 0
-						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000)
+					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
 					},
 
 					// func walltime() (sec int64, nsec int32)
-					'runtime.walltime': (sp) => {
-						sp >>>= 0
-						const msec = (new Date).getTime()
-						setInt64(sp + 8, msec / 1000)
-						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true)
+					"runtime.walltime": (sp) => {
+						sp >>>= 0;
+						const msec = (new Date).getTime();
+						setInt64(sp + 8, msec / 1000);
+						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
 					},
 
 					// func scheduleTimeoutEvent(delay int64) int32
-					'runtime.scheduleTimeoutEvent': (sp) => {
-						sp >>>= 0
-						const id = this._nextCallbackTimeoutID
-						this._nextCallbackTimeoutID++
+					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this._nextCallbackTimeoutID;
+						this._nextCallbackTimeoutID++;
 						this._scheduledTimeouts.set(id, setTimeout(
 							() => {
-								this._resume()
+								this._resume();
 								while (this._scheduledTimeouts.has(id)) {
 									// for some reason Go failed to register the timeout event, log and try again
 									// (temporary workaround for https://github.com/golang/go/issues/28975)
-									console.warn('scheduleTimeoutEvent: missed timeout event')
-									this._resume()
+									console.warn("scheduleTimeoutEvent: missed timeout event");
+									this._resume();
 								}
 							},
-							getInt64(sp + 8)
-						))
-						this.mem.setInt32(sp + 16, id, true)
+							getInt64(sp + 8),
+						));
+						this.mem.setInt32(sp + 16, id, true);
 					},
 
 					// func clearTimeoutEvent(id int32)
-					'runtime.clearTimeoutEvent': (sp) => {
-						sp >>>= 0
-						const id = this.mem.getInt32(sp + 8, true)
-						clearTimeout(this._scheduledTimeouts.get(id))
-						this._scheduledTimeouts.delete(id)
+					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getInt32(sp + 8, true);
+						clearTimeout(this._scheduledTimeouts.get(id));
+						this._scheduledTimeouts.delete(id);
 					},
 
 					// func getRandomData(r []byte)
-					'runtime.getRandomData': (sp) => {
-						sp >>>= 0
-						crypto.getRandomValues(loadSlice(sp + 8))
+					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
+						crypto.getRandomValues(loadSlice(sp + 8));
 					},
 
 					// func finalizeRef(v ref)
-					'syscall/js.finalizeRef': (sp) => {
-						sp >>>= 0
-						const id = this.mem.getUint32(sp + 8, true)
-						this._goRefCounts[id]--
+					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getUint32(sp + 8, true);
+						this._goRefCounts[id]--;
 						if (this._goRefCounts[id] === 0) {
-							const v = this._values[id]
-							this._values[id] = null
-							this._ids.delete(v)
-							this._idPool.push(id)
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
 						}
 					},
 
 					// func stringVal(value string) ref
-					'syscall/js.stringVal': (sp) => {
-						sp >>>= 0
-						storeValue(sp + 24, loadString(sp + 8))
+					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, loadString(sp + 8));
 					},
 
 					// func valueGet(v ref, p string) ref
-					'syscall/js.valueGet': (sp) => {
-						sp >>>= 0
-						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16))
-						sp = this._inst.exports.getsp() >>> 0 // see comment above
-						storeValue(sp + 32, result)
+					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
+						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
+						storeValue(sp + 32, result);
 					},
 
 					// func valueSet(v ref, p string, x ref)
-					'syscall/js.valueSet': (sp) => {
-						sp >>>= 0
-						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32))
+					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
 					},
 
 					// func valueDelete(v ref, p string)
-					'syscall/js.valueDelete': (sp) => {
-						sp >>>= 0
-						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16))
+					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
+						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
 					},
 
 					// func valueIndex(v ref, i int) ref
-					'syscall/js.valueIndex': (sp) => {
-						sp >>>= 0
-						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)))
+					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
 					},
 
 					// valueSetIndex(v ref, i int, x ref)
-					'syscall/js.valueSetIndex': (sp) => {
-						sp >>>= 0
-						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24))
+					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
 					},
 
 					// func valueCall(v ref, m string, args []ref) (ref, bool)
-					'syscall/js.valueCall': (sp) => {
-						sp >>>= 0
+					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
 						try {
-							const v = loadValue(sp + 8)
-							const m = Reflect.get(v, loadString(sp + 16))
-							const args = loadSliceOfValues(sp + 32)
-							const result = Reflect.apply(m, v, args)
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 56, result)
-							this.mem.setUint8(sp + 64, 1)
+							const v = loadValue(sp + 8);
+							const m = Reflect.get(v, loadString(sp + 16));
+							const args = loadSliceOfValues(sp + 32);
+							const result = Reflect.apply(m, v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, result);
+							this.mem.setUint8(sp + 64, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 56, err)
-							this.mem.setUint8(sp + 64, 0)
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, err);
+							this.mem.setUint8(sp + 64, 0);
 						}
 					},
 
 					// func valueInvoke(v ref, args []ref) (ref, bool)
-					'syscall/js.valueInvoke': (sp) => {
-						sp >>>= 0
+					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
 						try {
-							const v = loadValue(sp + 8)
-							const args = loadSliceOfValues(sp + 16)
-							const result = Reflect.apply(v, undefined, args)
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 40, result)
-							this.mem.setUint8(sp + 48, 1)
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.apply(v, undefined, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 40, err)
-							this.mem.setUint8(sp + 48, 0)
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
 						}
 					},
 
 					// func valueNew(v ref, args []ref) (ref, bool)
-					'syscall/js.valueNew': (sp) => {
-						sp >>>= 0
+					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
 						try {
-							const v = loadValue(sp + 8)
-							const args = loadSliceOfValues(sp + 16)
-							const result = Reflect.construct(v, args)
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 40, result)
-							this.mem.setUint8(sp + 48, 1)
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.construct(v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
-							sp = this._inst.exports.getsp() >>> 0 // see comment above
-							storeValue(sp + 40, err)
-							this.mem.setUint8(sp + 48, 0)
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
 						}
 					},
 
 					// func valueLength(v ref) int
-					'syscall/js.valueLength': (sp) => {
-						sp >>>= 0
-						setInt64(sp + 16, parseInt(loadValue(sp + 8).length))
+					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
 					},
 
 					// valuePrepareString(v ref) (ref, int)
-					'syscall/js.valuePrepareString': (sp) => {
-						sp >>>= 0
-						const str = encoder.encode(String(loadValue(sp + 8)))
-						storeValue(sp + 16, str)
-						setInt64(sp + 24, str.length)
+					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
+						const str = encoder.encode(String(loadValue(sp + 8)));
+						storeValue(sp + 16, str);
+						setInt64(sp + 24, str.length);
 					},
 
 					// valueLoadString(v ref, b []byte)
-					'syscall/js.valueLoadString': (sp) => {
-						sp >>>= 0
-						const str = loadValue(sp + 8)
-						loadSlice(sp + 16).set(str)
+					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
+						const str = loadValue(sp + 8);
+						loadSlice(sp + 16).set(str);
 					},
 
 					// func valueInstanceOf(v ref, t ref) bool
-					'syscall/js.valueInstanceOf': (sp) => {
-						sp >>>= 0
-						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0)
+					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
+						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
 					},
 
 					// func copyBytesToGo(dst []byte, src ref) (int, bool)
-					'syscall/js.copyBytesToGo': (sp) => {
-						sp >>>= 0
-						const dst = loadSlice(sp + 8)
-						const src = loadValue(sp + 32)
+					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
+						const dst = loadSlice(sp + 8);
+						const src = loadValue(sp + 32);
 						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
-							this.mem.setUint8(sp + 48, 0)
-							return
+							this.mem.setUint8(sp + 48, 0);
+							return;
 						}
-						const toCopy = src.subarray(0, dst.length)
-						dst.set(toCopy)
-						setInt64(sp + 40, toCopy.length)
-						this.mem.setUint8(sp + 48, 1)
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
 					},
 
 					// func copyBytesToJS(dst ref, src []byte) (int, bool)
-					'syscall/js.copyBytesToJS': (sp) => {
-						sp >>>= 0
-						const dst = loadValue(sp + 8)
-						const src = loadSlice(sp + 16)
+					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
+						const dst = loadValue(sp + 8);
+						const src = loadSlice(sp + 16);
 						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
-							this.mem.setUint8(sp + 48, 0)
-							return
+							this.mem.setUint8(sp + 48, 0);
+							return;
 						}
-						const toCopy = src.subarray(0, dst.length)
-						dst.set(toCopy)
-						setInt64(sp + 40, toCopy.length)
-						this.mem.setUint8(sp + 48, 1)
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
 					},
 
-					'debug': (value) => {
-						console.log(value)
-					}
+					"debug": (value) => {
+						console.log(value);
+					},
 				}
-			}
+			};
 		}
 
 		async run(instance) {
 			if (!(instance instanceof WebAssembly.Instance)) {
-				throw new Error('Go.run: WebAssembly.Instance expected')
+				throw new Error("Go.run: WebAssembly.Instance expected");
 			}
-			this._inst = instance
-			this.mem = new DataView(this._inst.exports.mem.buffer)
+			this._inst = instance;
+			this.mem = new DataView(this._inst.exports.mem.buffer);
 			this._values = [ // JS values that Go currently has references to, indexed by reference id
 				NaN,
 				0,
@@ -538,90 +496,91 @@
 				true,
 				false,
 				globalThis,
-				this
-			]
-			this._goRefCounts = new Array(this._values.length).fill(Infinity) // number of references that Go has to a JS value, indexed by reference id
+				this,
+			];
+			this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
 			this._ids = new Map([ // mapping from JS values to reference ids
 				[0, 1],
 				[null, 2],
 				[true, 3],
 				[false, 4],
 				[globalThis, 5],
-				[this, 6]
-			])
-			this._idPool = []   // unused ids that have been garbage collected
-			this.exited = false // whether the Go program has exited
+				[this, 6],
+			]);
+			this._idPool = [];   // unused ids that have been garbage collected
+			this.exited = false; // whether the Go program has exited
 
 			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
-			let offset = 4096
+			let offset = 4096;
 
 			const strPtr = (str) => {
-				const ptr = offset
-				const bytes = encoder.encode(str + '\0')
-				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes)
-				offset += bytes.length
+				const ptr = offset;
+				const bytes = encoder.encode(str + "\0");
+				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+				offset += bytes.length;
 				if (offset % 8 !== 0) {
-					offset += 8 - (offset % 8)
+					offset += 8 - (offset % 8);
 				}
-				return ptr
-			}
+				return ptr;
+			};
 
-			const argc = this.argv.length
+			const argc = this.argv.length;
 
-			const argvPtrs = []
+			const argvPtrs = [];
 			this.argv.forEach((arg) => {
-				argvPtrs.push(strPtr(arg))
-			})
-			argvPtrs.push(0)
+				argvPtrs.push(strPtr(arg));
+			});
+			argvPtrs.push(0);
 
-			const keys = Object.keys(this.env).sort()
+			const keys = Object.keys(this.env).sort();
 			keys.forEach((key) => {
-				argvPtrs.push(strPtr(`${key}=${this.env[key]}`))
-			})
-			argvPtrs.push(0)
+				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+			});
+			argvPtrs.push(0);
 
-			const argv = offset
+			const argv = offset;
 			argvPtrs.forEach((ptr) => {
-				this.mem.setUint32(offset, ptr, true)
-				this.mem.setUint32(offset + 4, 0, true)
-				offset += 8
-			})
+				this.mem.setUint32(offset, ptr, true);
+				this.mem.setUint32(offset + 4, 0, true);
+				offset += 8;
+			});
 
 			// The linker guarantees global data starts from at least wasmMinDataAddr.
 			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
-			const wasmMinDataAddr = 4096 + 8192
+			const wasmMinDataAddr = 4096 + 8192;
 			if (offset >= wasmMinDataAddr) {
-				throw new Error('total length of command line and environment variables exceeds limit')
+				throw new Error("total length of command line and environment variables exceeds limit");
 			}
 
-			this._inst.exports.run(argc, argv)
+			this._inst.exports.run(argc, argv);
 			if (this.exited) {
-				this._resolveExitPromise()
+				this._resolveExitPromise();
 			}
-			await this._exitPromise
+			await this._exitPromise;
 		}
 
 		_resume() {
 			if (this.exited) {
-				throw new Error('Go program has already exited')
+				throw new Error("Go program has already exited");
 			}
-			this._inst.exports.resume()
+			this._inst.exports.resume();
 			if (this.exited) {
-				this._resolveExitPromise()
+				this._resolveExitPromise();
 			}
 		}
 
 		_makeFuncWrapper(id) {
-			const go = this
+			const go = this;
 			return function () {
-				const event = {id: id, this: this, args: arguments}
-				go._pendingEvent = event
-				go._resume()
-				return event.result
-			}
+				const event = { id: id, this: this, args: arguments };
+				go._pendingEvent = event;
+				go._resume();
+				return event.result;
+			};
 		}
 	}
-})()
+})();
+
 
 const go = new globalThis.Go()
 export default go

--- a/ui/src/utils/wasmInterface.ts
+++ b/ui/src/utils/wasmInterface.ts
@@ -85,12 +85,129 @@ declare global {
 		tag: string,
 		egressAddr: string,
 		egressEndpoint: string,
-	): WasmClient
+	): WasmClient;
 }
 
 interface Config {
 	mock: boolean
 	target: Targets
+}
+
+
+// a WebTransport bridge used by Go to send and receive datagrams since Go compiled to WASM can't access webtransport
+export class WebTransportBridge {
+	wt!: WebTransport
+
+	datagramReader!: ReadableStreamDefaultReader<Uint8Array>
+	datagramWriter!: WritableStreamDefaultWriter<Uint8Array>
+	connected: boolean = false
+	connecting: Promise<boolean> | null = null;
+
+	id: number = -1
+	receiveFunction!: (datagram: Uint8Array) => void
+	readLoopPromise: Promise<void> | null = null
+
+	constructor(id: number) {
+		this.id = id;
+
+		// bind 2 functions to global window for Go to call
+		const callbacks = (window as any).WebTransportCallbacks;
+		callbacks.connect[this.id] = this.connect.bind(this);
+		callbacks.send[this.id] = this.send.bind(this);
+	}
+
+	async connect(url: string): Promise<boolean> {
+		if (this.connected) return true;
+		if (this.connecting) return this.connecting;
+
+		this.connecting = (async () => {
+			try {
+				console.debug("[JS WT:%d]: connecting to %s", this.id, url);
+				this.wt = new WebTransport(url);
+				await this.wt.ready;
+
+				this.datagramReader = this.wt.datagrams.readable.getReader();
+				this.datagramWriter = this.wt.datagrams.writable.getWriter();
+
+				const callbacks = (window as any).WebTransportCallbacks;
+				this.receiveFunction = callbacks.receive[this.id];
+				if (!this.receiveFunction) {
+					throw new Error(`Missing Go receive function for instance ${this.id}`);
+				}
+
+				this.connected = true;
+				this.readLoopPromise = this.readLoop();
+				return true;
+			} catch (e) {
+				console.error(`[JS WT:${this.id}]: connection error`, e);
+				return false;
+			} finally {
+				this.connecting = null;
+			}
+		})();
+		return this.connecting;
+	}
+
+	// readLoop reads incoming datagrams and forward the data to Go by calling this.receiveFunction
+	async readLoop() {
+		while (true) {
+			try {
+				const { value, done } = await this.datagramReader.read();
+				if (done || !value) continue;
+				this.receiveFunction(value); // Pass the received datagram to the function in Go
+			} catch (error) {
+				console.warn("[JS WT:%d]: error reading datagram:%s", this.id, error);
+				this.connected = false;
+				this.wt.close();
+				// disconnect in Go, so FSM can resume
+				this.goDisconnect();
+				break;
+			}
+		}
+	}
+
+	// this function will be called by Go through "sendWebTransportDatagramJS" + id"
+	async send(data: Uint8Array): Promise<void> {
+		try {
+			await this.datagramWriter.write(data);
+		} catch (e) {
+			console.debug(`[JS WT:${this.id}]: send failed`, e);
+			throw e;
+		}
+	}
+
+	// this will be called in WasmInterface.stop()
+	async disconnect() {
+		if (!this.connected) {
+			return;
+		}
+		// specifically close the datagram writer to force stop the write() because sometimes when the
+		// write() is in progress it hangs there forever even if the wt.close() is called
+		try {
+			await this.datagramWriter.close();
+		// we don't care about this error because either way the webtransport will be closed by the next line
+		} catch (_) {}
+
+		// close the webtransport, which will force all read() to finish
+		this.wt.close();
+
+		// wait for readLoop to finish
+		if (this.readLoopPromise) {
+			try {
+				await this.readLoopPromise;
+			} catch (_) {}
+		}
+		this.goDisconnect();
+		this.connected = false;
+	}
+
+	// call Go's disconnect so the FSM state can finish and stop
+	goDisconnect() {
+		const callbacks = (window as any).WebTransportCallbacks;
+		if (callbacks.disconnect[this.id]) {
+			callbacks.disconnect[this.id]();
+		}
+	}
 }
 
 export class WasmInterface {
@@ -107,6 +224,8 @@ export class WasmInterface {
 	initializing: boolean
 	target: Targets
 
+	wtInstances!: Array<WebTransportBridge>
+
 	constructor() {
 		this.ready = false
 		this.initializing = false
@@ -117,12 +236,25 @@ export class WasmInterface {
 		this.target = Targets.WEB
 	}
 
-
 	initialize = async ({mock, target}: Config): Promise<WebAssemblyInstance | undefined> => {
 		// this dumb state is needed to prevent multiple calls to initialize from react hot reload dev server 🥵
 		if (this.initializing || this.instance) { // already initialized or initializing
 			console.warn('Wasm client has already been initialized or is initializing, aborting init.')
 		  return
+		}
+
+		// check if we need webtransport and initialize it
+		if (WASM_CLIENT_CONFIG.webTransport) {
+			// initialize WebTransport callbacks for JS<->Go communications
+			// which contains 4 methods (as key name), each is a object that maps webtransport instance id to the actual function
+			(window as any).WebTransportCallbacks = {
+				connect: {},	// set in WebTransportBridge constructor, defined in JS
+				send: {},		// set in WebTransportBridge constructor, defined in JS
+				receive: {}, 	// set in Go's newJSWebTransportConn(), defined in Go
+				disconnect: {},	// set in Go's newJSWebTransportConn(), defined in Go
+			};
+			console.log('JS: initializing %d webtransport instances', WASM_CLIENT_CONFIG.cTableSz);
+			this.wtInstances = Array.from({length: WASM_CLIENT_CONFIG.cTableSz}, (_, i) => new WebTransportBridge(i))
 		}
 
 		this.initializing = true
@@ -185,7 +317,7 @@ export class WasmInterface {
 		}
 	}
 
-	stop = () => {
+	stop = async () => {
 		if (!this.wasmClient) return console.warn('Wasm client has not been initialized, aborting stop.')
 		// if the widget is running in an extension popup window, send message to the offscreen window
 		if (this.target === Targets.EXTENSION_POPUP) {
@@ -200,6 +332,13 @@ export class WasmInterface {
 			readyEmitter.update(this.ready)
 			this.wasmClient.stop()
 			sharingEmitter.update(false)
+
+			// disconnect the webtransport instances
+			if (WASM_CLIENT_CONFIG.webTransport) {
+				console.debug('JS: disconnecting %d webtransport instances...', WASM_CLIENT_CONFIG.cTableSz);
+				await Promise.all(this.wtInstances.map(wt => wt.disconnect()));
+				console.debug("All %d webtransport instances disconnected", WASM_CLIENT_CONFIG.cTableSz);
+			}
 		}
 	}
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9840,10 +9840,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR is part of [1393](https://github.com/getlantern/engineering/issues/1393)  that should be merged after merging [this PR](https://github.com/getlantern/quicwrapper/pull/44).

This PR does:
- UI related changes: pull goWasmExec.ts, upgrade typescript package and set content security policy. See details in the commit messages that starts with title "ui:"
- add support to WebTransport built as WASM by bridging the JS<->Go. See [this commit](https://github.com/getlantern/unbounded/commit/b895a93642409b3386dd2a2b130172537ec3a4a8) for detail.

To test:
- please add your localhost certificate to your browser so it can access https://localhost:8000 (local egress server)
- local egress server: please set env variable when running: `TLS_CERT=/path/to/localhost.crt TLS_KEY=/path/to/localhost.key PORT=8000 WEBTRANSPORT=1` 
- build the WASM using `./build_web.sh` under `cmd/` and start the UI the usual way