### PR TITLE
Make standalone egress server listen both WebSocket and WebTransport

### DIFF
--- a/egress/cmd/egress.go
+++ b/egress/cmd/egress.go
@@ -9,33 +9,29 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sync"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/elazarl/goproxy"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/getlantern/broflake/common"
 	"github.com/getlantern/broflake/egress"
 )
 
 func main() {
-	// cancels on SIGINT or SIGTERM
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8000"
+	portStr := os.Getenv("PORT")
+	if portStr == "" {
+		portStr = "8000"
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		log.Fatalf("Invalid port %v: %v", portStr, err)
 	}
 
 	certFile := os.Getenv("TLS_CERT")
 	keyFile := os.Getenv("TLS_KEY")
-
-	webTransport, webTransportEnabled := os.Getenv("WEBTRANSPORT"), false
-	if webTransport == "1" {
-		webTransportEnabled = true
-	}
 
 	var tlsCert string
 	var tlsKey string
@@ -56,18 +52,28 @@ func main() {
 		tlsKey = string(key)
 	}
 
+	// cancels on SIGINT or SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// for running the websocket and webtransport listeners
+	g, ctx := errgroup.WithContext(ctx)
+
+	// listen websocket on PORT
 	addr := fmt.Sprintf(":%v", port)
-	var ll net.Listener
-	var err error
-	if webTransportEnabled {
-		ll, err = egress.NewWebTransportListener(ctx, addr, tlsCert, tlsKey)
-	} else {
-		ll, err = egress.NewWebSocketListener(ctx, addr, tlsCert, tlsKey)
-	}
+	lws, err := egress.NewWebSocketListener(ctx, addr, tlsCert, tlsKey)
 	if err != nil {
-		log.Fatalf("Failed to start websocket/webtransport listener: %v", err)
+		log.Fatalf("Failed to start websocket listener: %v", err)
 	}
-	defer ll.Close()
+	defer lws.Close()
+
+	// listen webtransport on the next port
+	addr = fmt.Sprintf(":%v", port+1)
+	lwt, err := egress.NewWebTransportListener(ctx, addr, tlsCert, tlsKey)
+	if err != nil {
+		log.Fatalf("Failed to start webtransport listener: %v", err)
+	}
+	defer lwt.Close()
 
 	// Instantiate our local HTTP CONNECT proxy
 	proxy := goproxy.NewProxyHttpServer()
@@ -93,29 +99,42 @@ func main() {
 		},
 	)
 
-	server := &http.Server{Handler: proxy}
-	serverErr := make(chan error, 1)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		serverErr <- server.Serve(ll)
-	}()
+	// start a server to serve websocket
+	serverWS := &http.Server{Handler: proxy}
+	g.Go(func() error {
+		if err := serverWS.Serve(lws); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("WebSocket server error: %w", err)
+		}
+		return nil
+	})
 
-	select {
-	case <-ctx.Done():
+	// start a server to serve webtransport
+	serverWT := &http.Server{Handler: proxy}
+	g.Go(func() error {
+		if err := serverWT.Serve(lwt); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("WebTransport server error: %w", err)
+		}
+		return nil
+	})
+
+	// handle graceful shutdown
+	g.Go(func() error {
+		<-ctx.Done()
 		common.Debug("Shutting down...")
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		if err := server.Shutdown(ctx); err != nil {
-			common.Debugf("Error shutting down server: %v", err)
+		if err := serverWS.Shutdown(shutdownCtx); err != nil && !errors.Is(err, net.ErrClosed) {
+			common.Debugf("Error shutting down WebSocket server: %v", err)
 		}
-	case err := <-serverErr:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("Failed to start HTTP proxy: %v", err)
+		if err := serverWT.Shutdown(shutdownCtx); err != nil && !errors.Is(err, net.ErrClosed) {
+			common.Debugf("Error shutting down WebTransport server: %v", err)
 		}
-		ll.Close()
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		log.Fatalf("Egress server exited with error: %v", err)
 	}
-	wg.Wait()
+	common.Debug("Egress server exited.")
 }


### PR DESCRIPTION
This PR is part of [#1393](https://github.com/getlantern/engineering/issues/1393) that:
- makes the standalone Egress server listen both WebSocket and WebTransport
- where WebSocket will listen on `PORT` and WebTransport on `PORT+1` (environment variable `PORT`)
- and removes `WEBTRANSPORT` environment variable (that if ==1, was used to switch to WebTransport instead of the default WebSocekt)

Note that this PR does not change the following behaviors which stay true: 
1. the standalone uncensored peer (`clientType == "widget"` in [client_default_impl.go](https://github.com/getlantern/unbounded/blob/main/cmd/client_default_impl.go) still uses `WEBTRANSPORT=1` to reach the Egress server.
2. the web peer [will check if the browser supports WebTransport](https://github.com/getlantern/unbounded/blob/e61151b1851558e229f4efef2858a0170a36b5eb/ui/src/constants/index.ts#L127) and use WebTransport if supported. Otherwise fall back to WebSocket.