### PR TITLE
send teamID as a few bytes at the start of a stream

### DIFF
--- a/clientcore/egress_consumer_wt.go
+++ b/clientcore/egress_consumer_wt.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -76,6 +77,10 @@ func NewEgressConsumerWebTransport(options *EgressOptions, wg *sync.WaitGroup) *
 				<-time.After(options.ErrorBackoff)
 				return 0, []interface{}{}
 			}
+
+			teamId := "12345"
+			teamInfo := []byte(fmt.Sprintf("teamId:%v_end_id", teamId))
+			pconn.WriteTo(teamInfo, nil) // send some info as the first few bytes
 
 			return 1, []interface{}{pconn}
 		}),

--- a/common/network.go
+++ b/common/network.go
@@ -9,9 +9,10 @@ import (
 
 var (
 	// Must be a valid semver
-	Version       = "v0.0.2"
-	VersionHeader = "X-BF-Version"
-	TeamIdPrefix  = "unbounded-team:"
+	Version        = "v0.0.2"
+	VersionHeader  = "X-BF-Version"
+	TeamIdPrefix   = "unbounded-team:"
+	InfoPrefixSize = 19
 )
 
 var QUICCfg = quic.Config{


### PR DESCRIPTION
This is one way I came up with to send that teamId info from the client to the egress server. I also added some webtransport related commands to the quickstart script. @Jovis7 do you think this will work with what you are doing or have any feedback on this idea? 