### PR TITLE
clientcore: handle other http status code as error

### DIFF
--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -194,7 +194,7 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			// Freddie never returns 404s for genesis messages, so we're not catching that case here
 
 			// Handle bad protocol version
-			if res.StatusCode == 418 {
+			if res.StatusCode == http.StatusTeapot {
 				common.Debugf("Received 'bad protocol version' response")
 				<-time.After(options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}


### PR DESCRIPTION
This commit handles other possible http status codes other than 200 as error, and abort early in the `clientcore` package when communicating with the signalling server.

This is related to [#2262](https://github.com/getlantern/engineering/issues/2262).