### PR TITLE
Nits and HTTP body close

### DIFF
--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -150,7 +150,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 
 			req.Header.Add(common.VersionHeader, common.Version)
 
-			res, err := options.HttpClient.Do(req)
+			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				common.Debugf("Couldn't subscribe to genesis stream at %v: %v", options.DiscoverySrv+options.Endpoint, err)
 				<-time.After(options.ErrorBackoff)
@@ -299,7 +299,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			req.Header.Add(common.VersionHeader, common.Version)
 
-			res, err := options.HttpClient.Do(req)
+			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				common.Debugf("Couldn't signal offer SDP to %v: %v", options.DiscoverySrv+options.Endpoint, err)
 				<-time.After(options.ErrorBackoff)
@@ -314,7 +314,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			case http.StatusNotFound:
 				// We didn't win the connection
-				common.Debugf("Too late for genesis message %v!", replyTo)
+				common.Debugf("Too late for genesis message %v! Got %v", replyTo, res.Status)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			case http.StatusOK:
 				// All good
@@ -458,7 +458,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			req.Header.Add(common.VersionHeader, common.Version)
 
-			res, err := options.HttpClient.Do(req)
+			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				common.Debugf("Couldn't signal ICE candidates to %v: %v", options.DiscoverySrv+options.Endpoint, err)
 				<-time.After(options.ErrorBackoff)

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -189,7 +189,7 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			req.Header.Add(common.VersionHeader, common.Version)
 
-			res, err := options.HttpClient.Do(req)
+			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				common.Debugf("Couldn't signal genesis message to %v: %v", options.DiscoverySrv+options.Endpoint, err)
 				<-time.After(options.ErrorBackoff)
@@ -325,7 +325,7 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			req.Header.Add(common.VersionHeader, common.Version)
 
-			res, err := options.HttpClient.Do(req)
+			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				common.Debugf("Couldn't signal answer SDP to %v: %v", options.DiscoverySrv+options.Endpoint, err)
 				<-time.After(options.ErrorBackoff)

--- a/clientcore/settings.go
+++ b/clientcore/settings.go
@@ -33,7 +33,7 @@ func NewDefaultWebRTCOptions() *WebRTCOptions {
 		STUNBatchSize:  5,
 		Tag:            "",
 		HTTPClient:     &http.Client{},
-		Patience:       50 * time.Millisecond,
+		Patience:       500 * time.Millisecond,
 		ErrorBackoff:   5 * time.Second,
 	}
 }

--- a/clientcore/settings.go
+++ b/clientcore/settings.go
@@ -17,7 +17,7 @@ type WebRTCOptions struct {
 	STUNBatch      func(size uint32) (batch []string, err error)
 	STUNBatchSize  uint32
 	Tag            string
-	HttpClient     *http.Client
+	HTTPClient     *http.Client
 	Patience       time.Duration
 	ErrorBackoff   time.Duration
 }
@@ -32,8 +32,8 @@ func NewDefaultWebRTCOptions() *WebRTCOptions {
 		STUNBatch:      DefaultSTUNBatchFunc,
 		STUNBatchSize:  5,
 		Tag:            "",
-		HttpClient:     &http.Client{},
-		Patience:       500 * time.Millisecond,
+		HTTPClient:     &http.Client{},
+		Patience:       50 * time.Millisecond,
 		ErrorBackoff:   5 * time.Second,
 	}
 }
@@ -118,6 +118,7 @@ func DefaultSTUNBatchFunc(size uint32) (batch []string, err error) {
 	if err != nil {
 		return batch, err
 	}
+	defer res.Body.Close()
 
 	candidates := []string{}
 	scanner := bufio.NewScanner(res.Body)
@@ -128,8 +129,6 @@ func DefaultSTUNBatchFunc(size uint32) (batch []string, err error) {
 	if err := scanner.Err(); err != nil {
 		return batch, err
 	}
-
-	rand.Seed(time.Now().Unix())
 
 	for i := 0; i < int(size) && len(candidates) > 0; i++ {
 		idx := rand.Intn(len(candidates))

--- a/freddie/freddie.go
+++ b/freddie/freddie.go
@@ -157,9 +157,9 @@ func New(ctx context.Context, listenAddr string) (*Freddie, error) {
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("freddie (%v)\n", common.Version)))
-		w.Write([]byte(fmt.Sprintf("current GET requests: %d\n", f.currentGets.Load())))
-		w.Write([]byte(fmt.Sprintf("current POST requests: %d\n", f.currentPosts.Load())))
+		fmt.Fprintf(w, "freddie (%v)\n", common.Version)
+		fmt.Fprintf(w, "current GET requests: %d\n", f.currentGets.Load())
+		fmt.Fprintf(w, "current POST requests: %d\n", f.currentPosts.Load())
 	})
 	mux.HandleFunc("/v1/signal", f.handleSignal)
 
@@ -186,7 +186,7 @@ func (f *Freddie) handleSignal(w http.ResponseWriter, r *http.Request) {
 	ctx, span := f.tracer.Start(r.Context(), "handleSignal")
 	defer span.End()
 
-	enableCors(&w)
+	enableCors(w)
 
 	// Handle preflight requests
 	if r.Method == http.MethodOptions {
@@ -242,7 +242,7 @@ func (f *Freddie) handleSignalGet(ctx context.Context, w http.ResponseWriter, r 
 	for {
 		select {
 		case msg := <-consumerChan:
-			w.Write([]byte(fmt.Sprintf("%v\n", msg)))
+			fmt.Fprintf(w, "%v\n", msg)
 			w.(http.Flusher).Flush()
 		case <-timeoutChan:
 			return
@@ -265,7 +265,12 @@ func (f *Freddie) handleSignalPost(ctx context.Context, w http.ResponseWriter, r
 	defer func() { close(reqChan) }()
 	defer signalTable.Delete(reqID)
 
-	r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		span.SetStatus(codes.Error, "failed to parse form")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("400\n"))
+		return
+	}
 	sendTo := r.Form.Get("send-to")
 	data := r.Form.Get("data")
 	msgType, err := strconv.ParseInt(r.Form.Get("type"), 10, 32)
@@ -327,7 +332,7 @@ func (f *Freddie) handleSignalPost(ctx context.Context, w http.ResponseWriter, r
 
 	select {
 	case res := <-reqChan:
-		w.Write([]byte(fmt.Sprintf("%v\n", res)))
+		fmt.Fprintf(w, "%v\n", res)
 	case <-time.After(msgTTL * time.Second):
 		span.AddEvent("timeout waiting for response")
 		w.Write(nil)
@@ -335,16 +340,12 @@ func (f *Freddie) handleSignalPost(ctx context.Context, w http.ResponseWriter, r
 }
 
 // TODO: delete me and replace with a real CORS strategy!
-func enableCors(w *http.ResponseWriter) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+func enableCors(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 }
 
 // Validate the Broflake protocol version header. If the header isn't present, we consider you
 // invalid. Protocol version is currently the major version of Broflake's reference implementation
 func isValidProtocolVersion(r *http.Request) bool {
-	if semver.Major(r.Header.Get(common.VersionHeader)) != semver.Major(common.Version) {
-		return false
-	}
-
-	return true
+	return semver.Major(r.Header.Get(common.VersionHeader)) == semver.Major(common.Version)
 }


### PR DESCRIPTION
This pull request includes updates to improve code consistency, enhance error handling, and optimize response formatting across multiple files. The changes primarily focus on standardizing naming conventions, improving resource management, and refining HTTP response handling.

### Code Consistency Improvements:
* Renamed `HttpClient` to `HTTPClient` in the `WebRTCOptions` struct and updated all references in `clientcore/settings.go`, `clientcore/consumer.go`, and `clientcore/producer.go` for consistency with Go naming conventions. [[1]](diffhunk://#diff-21fc37c991b2e6c2f31b798f31bf7aeef04ad424818980193f75e9386a176999L153-R153) [[2]](diffhunk://#diff-21fc37c991b2e6c2f31b798f31bf7aeef04ad424818980193f75e9386a176999L302-R302) [[3]](diffhunk://#diff-21fc37c991b2e6c2f31b798f31bf7aeef04ad424818980193f75e9386a176999L461-R461) [[4]](diffhunk://#diff-f8b6aadb258be0dab9a906cca36a8895c29586cc3e9c08d2679a48443bbddc47L192-R192) [[5]](diffhunk://#diff-f8b6aadb258be0dab9a906cca36a8895c29586cc3e9c08d2679a48443bbddc47L328-R328) [[6]](diffhunk://#diff-b20a854981454ca0c8c3a1a9b8b2682659092e5349a3874a9389ea38792dd88fL20-R20)

### Resource Management Enhancements:
* Added a `defer res.Body.Close()` statement in `DefaultSTUNBatchFunc` to ensure proper cleanup of HTTP response bodies.

### Response Formatting and Error Handling:
* Replaced multiple `w.Write` calls with `fmt.Fprintf` for cleaner and more concise HTTP response formatting in `freddie/freddie.go`. [[1]](diffhunk://#diff-3ccd25d1375233a4f2fa11b11453ae6d04a0be4d26a084326e0909f41d7675afL160-R162) [[2]](diffhunk://#diff-3ccd25d1375233a4f2fa11b11453ae6d04a0be4d26a084326e0909f41d7675afL245-R245) [[3]](diffhunk://#diff-3ccd25d1375233a4f2fa11b11453ae6d04a0be4d26a084326e0909f41d7675afL330-R350)
* Added error handling for `r.ParseForm()` in `handleSignalPost` to return a `400 Bad Request` status if form parsing fails.

### Minor Optimizations:
* Simplified the `isValidProtocolVersion` function by directly returning the comparison result instead of using conditional statements.
* Removed redundant `rand.Seed` calls in `DefaultSTUNBatchFunc` as they are unnecessary for repeated randomization within the same execution.