### PR TITLE
Better ICE outcome handling

### DIFF
--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -395,7 +395,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			if !hasNonHostCandidate {
 				common.Debugf("ICE failed to gather any non-host candidates, aborting!")
 				scache.drop()
-				common.Debugf("Dropped the current STUN cohort")
+				common.Debugf("Dropped the current STUN cohort (reason: ICE failed)")
 
 				// Borked!
 				peerConnection.Close() // TODO: there's an err we should handle here
@@ -472,9 +472,16 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 
 				// XXX: if our signaling partner hung up while we were gathering ICE candidates, we
 				// interpret that signal to mean that our current STUN cohort is too slow, and we should
-				// take our chances with a new cohort.
+				// take our chances with a new cohort. It's a pretty weak signal, considering that our
+				// signaling partner may have hung up for many other reasons. And "too slow" is a bit of
+				// an ambiguous idea, because every censored peer's STUN cohort is *expected* to contain
+				// one or more unreachable STUN server at all times, which means that a censored peer's ICE
+				// gathering duration is *expected* to be the worst case every time. So if our network is
+				// functioning coherently, nobody should be hanging up so hastily while their signaling partner
+				// is performing the ICE gathering step. Thus, dropping the cohort here is basically just
+				// voodoo, but it's probably harmless voodoo.
 				scache.drop()
-				common.Debugf("Dropped the current STUN cohort")
+				common.Debugf("Dropped the current STUN cohort (reason: signaling partner hung up)")
 
 				// Borked!
 				peerConnection.Close() // TODO: there's an err we should handle here

--- a/clientcore/settings.go
+++ b/clientcore/settings.go
@@ -13,7 +13,6 @@ type WebRTCOptions struct {
 	Endpoint       string
 	GenesisAddr    string
 	NATFailTimeout time.Duration
-	ICEFailTimeout time.Duration
 	STUNBatch      func(size uint32) (batch []string, err error)
 	STUNBatchSize  uint32
 	Tag            string
@@ -28,7 +27,6 @@ func NewDefaultWebRTCOptions() *WebRTCOptions {
 		Endpoint:       "/v1/signal",
 		GenesisAddr:    "genesis",
 		NATFailTimeout: 5 * time.Second,
-		ICEFailTimeout: 5 * time.Second,
 		STUNBatch:      DefaultSTUNBatchFunc,
 		STUNBatchSize:  5,
 		Tag:            "",


### PR DESCRIPTION
This is WIP to fix https://github.com/getlantern/engineering/issues/2312

We eliminate the `ICEFailTimeout` param, which enabled peers to give up trying to gather local ICE candidates if it seemed like it was taking too long. 

Now, all peers always fully complete ICE gathering, and they evaluate the success or failure of ICE gathering in the idiomatic way, by post facto examination of the candidates slice.

If while Bob is gathering ICE candidates, Alice gives up waiting for him and goes away, Bob uses that signal to decide that his STUN cohort is probably too slow, and he drops it, taking his chances with the next cohort in the STUN cache.

There are some interactions with Freddie that need to get sorted out before this gets merged, which I'll write up below...