### PR TITLE
Downgrade to prior Go because lantern-cloud does not yet support 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getlantern/broflake
 
 go 1.23.6
 
-toolchain go1.23.7
+toolchain go1.23.6
 
 replace github.com/enobufs/go-nats => github.com/noahlevenson/go-nats v0.0.0-20230720174341-49df1f749775
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/getlantern/broflake
 
-go 1.24.2
+go 1.23.6
+
+toolchain go1.23.7
 
 replace github.com/enobufs/go-nats => github.com/noahlevenson/go-nats v0.0.0-20230720174341-49df1f749775
 
@@ -9,7 +11,7 @@ require (
 	github.com/elazarl/goproxy v1.7.2
 	github.com/enobufs/go-nats v0.0.1
 	github.com/getlantern/geo v0.0.0-20240108161311-50692a1b69a9
-	github.com/getlantern/quicwrapper v0.0.0-20250610202231-252f48357c93
+	github.com/getlantern/quicwrapper v0.0.0-20250708190430-efdb145a577e
 	github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5
 	github.com/google/uuid v1.6.0
 	github.com/pion/webrtc/v4 v4.1.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/getlantern/ops v0.0.0-20200403153110-8476b16edcd6/go.mod h1:D5ao98qkA
 github.com/getlantern/ops v0.0.0-20220713155959-1315d978fff7/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20230424193308-26325dfed3cf h1:q8nsH0Lx9fP8HY6T9rA1zogvOzO9JtbUI5BXkh7wxxI=
 github.com/getlantern/ops v0.0.0-20230424193308-26325dfed3cf/go.mod h1:R7HfJVLsnSeqaDWkiUlU+ANBjac4oYmXGrrps8vW7CM=
-github.com/getlantern/quicwrapper v0.0.0-20250610202231-252f48357c93 h1:9jDA8Ojs4j/d4EBd2ap6r7YkGH/YFUccHuDU7DBIs+o=
-github.com/getlantern/quicwrapper v0.0.0-20250610202231-252f48357c93/go.mod h1:8JUff02h2OIo2TSuJDJmTVphoh3MzeE7V5gbjPa+r0w=
+github.com/getlantern/quicwrapper v0.0.0-20250708190430-efdb145a577e h1:iGIgm0kjVhwhjC2Tq/XWrENQ7Kvv2QPI56FqtyfNw7c=
+github.com/getlantern/quicwrapper v0.0.0-20250708190430-efdb145a577e/go.mod h1:ihA+iCYe4AU3tNX4RcdXW5AKuh+4QOiVyNkODqa6/L0=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 h1:6ITBYqNkLbVZ1tQNXwmH8N80rZtvyW6IZa8L6EAhBQo=
 github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5/go.mod h1:gx3dPUhZtQszPX5C+TshhxPXQHlY5t4gMnOOMA+viPA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
I don't believe there's anything in unbounded that's Go 1.24 dependent but we'll find out!