### PR TITLE
bring back team tracking via websockets

### DIFF
--- a/clientcore/egress_consumer_ws.go
+++ b/clientcore/egress_consumer_ws.go
@@ -6,6 +6,7 @@ package clientcore
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -39,8 +40,20 @@ func NewEgressConsumerWebSocket(options *EgressOptions, wg *sync.WaitGroup) *Wor
 			ctx, cancel := context.WithTimeout(ctx, options.ConnectTimeout)
 			defer cancel()
 
+			teamId := "team_not_set"
+			// TODO: get the teamId or userId from somewhere.
+			// This will most likely be a lantern userId, if the user is signed in
+
+			// This is a way to pass metadata from widget -> egress,
+			// the websocket package doesn't support sending other headers, so it is passed
+			// through the "Sec-WebSocket-Protocol" header with a prefix, so it can be read later in the egress server
+			// and then attached to the QUIC stream that is created there
+			wsDialOpts := &websocket.DialOptions{
+				Subprotocols: []string{fmt.Sprintf("%v%v", common.TeamIdPrefix, teamId)},
+			}
+
 			// TODO: WSS
-			c, _, err := websocket.Dial(ctx, options.Addr+options.Endpoint, nil)
+			c, _, err := websocket.Dial(ctx, options.Addr+options.Endpoint, wsDialOpts)
 			if err != nil {
 				common.Debugf("Couldn't connect to egress server at %v: %v", options.Addr, err)
 				<-time.After(options.ErrorBackoff)

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -151,11 +152,28 @@ func generateTLSConfig() *tls.Config {
 	}
 }
 
+func extractTeamId(r *http.Request) string {
+	v := r.Header.Values("Sec-Websocket-Protocol")
+	for _, s := range v {
+		if strings.HasPrefix(s, common.TeamIdPrefix) {
+			return strings.TrimPrefix(s, common.TeamIdPrefix)
+		}
+	}
+	return ""
+}
+
 func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	// TODO: InsecureSkipVerify=true just disables origin checking, we need to instead add origin
 	// patterns as strings using AcceptOptions.OriginPattern
 	// TODO: disabling compression is a workaround for a WebKit bug:
 	// https://github.com/getlantern/broflake/issues/45
+
+	teamId := extractTeamId(r)
+	if teamId == "" {
+		teamId = "no_team_recieved"
+	}
+	common.Debugf("WebSocket connection request from %v with teamId %v", r.RemoteAddr, teamId)
+
 	c, err := websocket.Accept(
 		w,
 		r,
@@ -184,10 +202,6 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	defer wspconn.Close()
 
-	if err != nil {
-		return
-	}
-
 	common.Debugf("Accepted a new WebSocket connection! (%v total)", atomic.AddUint64(&nClients, 1))
 	nClientsCounter.Add(context.Background(), 1)
 
@@ -200,7 +214,12 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	for {
 		conn, err := listener.Accept(context.Background())
 		if err != nil {
-			common.Debugf("%v QUIC listener error (%v), closing!", wspconn.addr, err)
+			switch websocket.CloseStatus(err) {
+			case websocket.StatusNormalClosure, websocket.StatusGoingAway:
+				common.Debugf("%v closed normally", wspconn.addr)
+			default:
+				common.Debugf("%v QUIC listener error (%v), closing!", wspconn.addr, err)
+			}
 			listener.Close()
 			break
 		}
@@ -233,6 +252,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 					},
 					AddrLocal:  l.addr,
 					AddrRemote: tcpAddr,
+					TeamId:     teamId,
 				}
 			}
 		}()
@@ -302,7 +322,7 @@ func NewListener(ctx context.Context, ll net.Listener, certPEM, keyPEM string) (
 
 	// We use this wrapped listener to enable our local HTTP proxy to listen for WebSocket connections
 	l := proxyListener{
-		Listener:     &net.TCPListener{},
+		Listener:     ll,
 		connections:  make(chan net.Conn, 2048),
 		tlsConfig:    tlsConfig,
 		addr:         ll.Addr(),

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -159,10 +159,12 @@ elif [ "$1" == "egress" ]; then
     echo "Using custom egress option"
     commands=("${custom_egress_commands[@]}")
 elif [ "$1" == "wt" ]; then
-    #create a self-signed certificate for localhost
-    openssl req -x509 -newkey rsa:2048 -nodes -keyout localhost.key -out localhost.crt -subj '/CN=localhost' -addext 'subjectAltName = DNS:localhost'
-    echo "Using webtransports option"
-    commands=("${wt_commands[@]}")
+    echo "webtransports not supported"
+    usage;
+    # #create a self-signed certificate for localhost
+    # openssl req -x509 -newkey rsa:2048 -nodes -keyout localhost.key -out localhost.crt -subj '/CN=localhost' -addext 'subjectAltName = DNS:localhost'
+    # echo "Using webtransports option"
+    # commands=("${wt_commands[@]}")
 else
     echo "Unknown option $1";
     usage;


### PR DESCRIPTION
this brings back the idea of sending teamid tracking info through the websocket dial from widget -> egress.