### PR TITLE
better stream cleanup

### DIFF
--- a/common/network.go
+++ b/common/network.go
@@ -54,6 +54,8 @@ func (c QUICStreamNetConn) Close() error {
 		c.OnClose()
 	}
 
+	c.Stream.CancelWrite(42069)
+	c.Stream.CancelRead(42069)
 	return c.Stream.Close()
 }
 

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Must be a valid semver
-const Version = "v2.0.3"
+const Version = "v2.0.4"


### PR DESCRIPTION
Canceling stream reads and writes when the proxy closes a `QuicStreamNetConn` is a good hygiene practice and seems to help with https://github.com/getlantern/engineering/issues/2479...