### PR TITLE
common: route Debugf/Debug through slog.Default()

### DIFF
--- a/common/log.go
+++ b/common/log.go
@@ -1,35 +1,71 @@
 package common
 
 import (
+	"fmt"
 	"log"
-	"os"
+	"log/slog"
 	"sync"
 )
 
+// debugFn handles each formatted debug message broflake produces. It's
+// swappable so embedders can route output anywhere they like.
+//
+// The default routes through slog.Default(), which makes broflake's
+// internals visible in any host that has configured a slog handler — most
+// notably the Lantern client, where radiance calls slog.SetDefault() at
+// startup. Before this default existed, broflake's debug output went to
+// stderr via a private *log.Logger, which the structured-log pipeline never
+// captured (so "Consumer state 0", "Sending genesis offer", and similar
+// breadcrumbs were silently dropped on production clients).
 var (
-	debugLogger = log.New(os.Stderr, "", log.LstdFlags)
-	logMx       sync.RWMutex
+	debugFn = defaultDebugFn
+	logMx   sync.RWMutex
 )
 
-// Override the Logger used by broflake for debug messages
+func defaultDebugFn(msg string) {
+	slog.Default().Debug(msg, "pkg", "broflake")
+}
+
+// SetSlogLogger routes broflake's debug output through the given slog
+// logger. Pass nil to fall back to slog.Default().
+//
+// Prefer this over SetDebugLogger for new callers.
+func SetSlogLogger(l *slog.Logger) {
+	logMx.Lock()
+	defer logMx.Unlock()
+	if l == nil {
+		debugFn = defaultDebugFn
+		return
+	}
+	debugFn = func(msg string) { l.Debug(msg, "pkg", "broflake") }
+}
+
+// SetDebugLogger routes broflake's debug output through the given
+// *log.Logger. Kept for callers that pre-date slog (e.g. flashlight); new
+// callers should use SetSlogLogger or rely on slog.Default(). Pass nil to
+// fall back to slog.Default().
 func SetDebugLogger(l *log.Logger) {
 	logMx.Lock()
 	defer logMx.Unlock()
-	debugLogger = l
+	if l == nil {
+		debugFn = defaultDebugFn
+		return
+	}
+	debugFn = func(msg string) { l.Println(msg) }
 }
 
-// Log a debug level message
+// Debugf logs a formatted debug-level message.
 func Debugf(format string, args ...interface{}) {
 	logMx.RLock()
-	l := debugLogger
+	fn := debugFn
 	logMx.RUnlock()
-	l.Printf(format+"\n", args...)
+	fn(fmt.Sprintf(format, args...))
 }
 
-// Log a debug level message
+// Debug logs a non-formatted debug-level message.
 func Debug(msg interface{}) {
 	logMx.RLock()
-	l := debugLogger
+	fn := debugFn
 	logMx.RUnlock()
-	l.Println(msg)
+	fn(fmt.Sprint(msg))
 }

--- a/common/log.go
+++ b/common/log.go
@@ -1,29 +1,39 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"log/slog"
+	"os"
 	"sync"
 )
 
 // debugFn handles each formatted debug message broflake produces. It's
 // swappable so embedders can route output anywhere they like.
 //
-// The default routes through slog.Default(), which makes broflake's
-// internals visible in any host that has configured a slog handler — most
-// notably the Lantern client, where radiance calls slog.SetDefault() at
-// startup. Before this default existed, broflake's debug output went to
-// stderr via a private *log.Logger, which the structured-log pipeline never
-// captured (so "Consumer state 0", "Sending genesis offer", and similar
-// breadcrumbs were silently dropped on production clients).
+// The default first tries slog.Default() — which makes broflake's
+// internals visible in any host that has configured a slog handler at
+// LevelDebug, most notably the Lantern client, where radiance calls
+// slog.SetDefault() at startup. If the active slog handler has Debug
+// disabled (true for the stdlib default, which sits at LevelInfo), the
+// message falls back to stderr so the standalone broflake binaries under
+// cmd/ keep the visibility they had before this migration. This dual
+// behavior matters because cmd/client_default_impl.go and friends never
+// explicitly configure slog and would otherwise go silent.
 var (
-	debugFn = defaultDebugFn
-	logMx   sync.RWMutex
+	debugFn      = defaultDebugFn
+	legacyStderr = log.New(os.Stderr, "", log.LstdFlags)
+	logMx        sync.RWMutex
 )
 
 func defaultDebugFn(msg string) {
-	slog.Default().Debug(msg, "pkg", "broflake")
+	h := slog.Default().Handler()
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		slog.Default().Debug(msg, "pkg", "broflake")
+		return
+	}
+	legacyStderr.Println(msg)
 }
 
 // SetSlogLogger routes broflake's debug output through the given slog

--- a/common/log_test.go
+++ b/common/log_test.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestDebug_DefaultRoutesToSlog locks in the load-bearing behavior of the
+// slog migration: with no explicit setter call, Debugf must reach
+// slog.Default(). Lantern's structured logger is installed via
+// slog.SetDefault() in radiance, and that's the path that gets broflake's
+// internals into lantern.log. If this test starts failing, every
+// production client's broflake debug output is silently disappearing.
+func TestDebug_DefaultRoutesToSlog(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	// Reset to default debugFn in case a prior test mutated package state.
+	SetSlogLogger(nil)
+
+	Debugf("hello %s %d", "world", 42)
+	out := buf.String()
+	if !strings.Contains(out, `msg="hello world 42"`) {
+		t.Fatalf("Debugf output not in slog.Default() text handler buffer: %q", out)
+	}
+	if !strings.Contains(out, `pkg=broflake`) {
+		t.Fatalf("expected pkg=broflake attribute in default slog routing, got: %q", out)
+	}
+
+	buf.Reset()
+	Debug("plain message")
+	if !strings.Contains(buf.String(), `msg="plain message"`) {
+		t.Fatalf("Debug() not visible in slog.Default(): %q", buf.String())
+	}
+}
+
+// TestSetSlogLogger_RoutesToProvidedLogger verifies that callers can pin
+// broflake's output to a specific slog.Logger (e.g. a child logger with
+// added attributes) instead of relying on the package default.
+func TestSetSlogLogger_RoutesToProvidedLogger(t *testing.T) {
+	t.Cleanup(func() { SetSlogLogger(nil) })
+
+	var buf bytes.Buffer
+	custom := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})).
+		With("source", "custom-test")
+	SetSlogLogger(custom)
+
+	Debugf("scoped message %v", "x")
+	if !strings.Contains(buf.String(), `source=custom-test`) {
+		t.Fatalf("custom slog.Logger not used: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), `msg="scoped message x"`) {
+		t.Fatalf("formatted message missing: %q", buf.String())
+	}
+}
+
+// TestSetDebugLogger_BackCompat exercises the legacy *log.Logger setter,
+// which flashlight (and any other pre-slog caller) still uses. We need it
+// to keep working unchanged after the slog migration.
+func TestSetDebugLogger_BackCompat(t *testing.T) {
+	t.Cleanup(func() { SetDebugLogger(nil) })
+
+	var buf bytes.Buffer
+	SetDebugLogger(log.New(&buf, "legacy: ", 0))
+
+	Debugf("hello %s", "legacy")
+	if !strings.Contains(buf.String(), "legacy: hello legacy\n") {
+		t.Fatalf("*log.Logger not used: %q", buf.String())
+	}
+}
+
+// TestSetDebugLogger_NilResetsToDefault makes sure passing nil restores
+// slog.Default() routing. This is the path test fixtures use to clean up
+// after themselves.
+func TestSetDebugLogger_NilResetsToDefault(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	// Mute first, then restore.
+	SetDebugLogger(log.New(io.Discard, "", 0))
+	Debugf("muted")
+	if buf.Len() != 0 {
+		t.Fatalf("expected discarded output, got %q", buf.String())
+	}
+
+	SetDebugLogger(nil)
+	Debugf("after reset")
+	if !strings.Contains(buf.String(), `msg="after reset"`) {
+		t.Fatalf("expected slog.Default() to receive output after nil reset, got %q", buf.String())
+	}
+}

--- a/common/log_test.go
+++ b/common/log_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -74,6 +75,60 @@ func TestSetDebugLogger_BackCompat(t *testing.T) {
 	if !strings.Contains(buf.String(), "legacy: hello legacy\n") {
 		t.Fatalf("*log.Logger not used: %q", buf.String())
 	}
+}
+
+// TestDebug_FallsBackToStderrWhenSlogDebugDisabled pins down the second
+// half of the default contract: when the active slog handler drops Debug
+// (true for the stdlib default at LevelInfo, and any host that hasn't
+// opted in to debug), broflake messages must fall back to stderr instead
+// of disappearing. The standalone broflake binaries under cmd/ rely on
+// this — they call common.Debugf for all visibility and never configure
+// slog. Without this fallback they'd go completely silent.
+func TestDebug_FallsBackToStderrWhenSlogDebugDisabled(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	// Reset to default debugFn in case a prior test mutated package state.
+	SetSlogLogger(nil)
+
+	// Slog handler at LevelInfo — Debug records are dropped.
+	var slogBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&slogBuf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	// Redirect the package-level legacyStderr to a buffer so we can assert
+	// fallback delivery without spamming the test runner's stderr.
+	var stderrBuf syncBuffer
+	prevStderr := legacyStderr
+	legacyStderr = log.New(&stderrBuf, "", 0)
+	t.Cleanup(func() { legacyStderr = prevStderr })
+
+	Debugf("fallback %s", "ok")
+
+	if slogBuf.Len() != 0 {
+		t.Fatalf("slog handler at Info should have dropped Debug record; got %q", slogBuf.String())
+	}
+	if !strings.Contains(stderrBuf.String(), "fallback ok") {
+		t.Fatalf("expected stderr fallback to capture message; got %q", stderrBuf.String())
+	}
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer for tests. The fallback test
+// only writes synchronously so the mutex is overkill, but using it
+// pre-empts a flake if a later test exercises a goroutine path.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // TestSetDebugLogger_NilResetsToDefault makes sure passing nil restores


### PR DESCRIPTION
## Summary

Make broflake's `common.Debugf` / `Debug` go through `slog.Default()` by default, so embedders that have configured a slog handler (notably the Lantern client via radiance) get broflake's internal breadcrumbs in their structured log without any bridging.

## Motivation

Production triage today: in `lantern.log` on a real Lantern client, the only `pkg=lantern-box` lines we see for the unbounded outbound are `outbound.go:243` ("unbounded TCP dial start dest …"). There is **zero visibility** into anything broflake itself is doing — Consumer state transitions, datachannel open/close, peer-connection state changes, "Sending genesis offer", freddie signaling errors, etc. all log via `common.Debugf` and never reach the structured-log pipeline.

Why: `common.Debugf` writes to a private `*log.Logger` that defaults to stderr. `SetDebugLogger` is only called by flashlight (legacy) and a lantern-box test fixture that mutes via `io.Discard`. Nothing in the refactored radiance / lantern-box stack wires it up, so on the production VPN process the messages go to a stderr that's not captured.

This makes issues like "no answer for genesis message" impossible to root-cause from production logs — we can see the outbound dialing, but not whether broflake ever got past STUN, ever saw a producer offer, ever opened a datachannel, etc.

## What changed

- Default routing now calls `slog.Default().Debug(msg, "pkg", "broflake")`. Radiance already calls `slog.SetDefault(...)` at startup, so this immediately surfaces broflake internals in `lantern.log` with no host-side change required.
- New `SetSlogLogger(*slog.Logger)` for callers who want a child logger / explicit override.
- Existing `SetDebugLogger(*log.Logger)` is preserved for back-compat (flashlight, lantern-box test fixture) — same signature, same semantics; internally it just installs a `*log.Logger`-flavored dispatch func.
- Both setters accept `nil` to reset to the `slog.Default()` route.
- `Debugf` / `Debug` signatures and call-site behavior are unchanged across the broflake / unbounded codebase.

## Test plan

- [x] `go build ./...` clean
- [x] New `common/log_test.go` covers: default → slog routing, custom `*slog.Logger` override, legacy `*log.Logger` back-compat, nil-reset to default
- [ ] After merging + bumping radiance and lantern, `pkg=broflake` lines appear in `lantern.log` for an active unbounded session

🤖 Generated with [Claude Code](https://claude.com/claude-code)