### PR TITLE
ui: serialize updateArcs to fix globe freeze on rapid connection bursts

### DIFF
--- a/ui/src/hooks/useGeoFuture.ts
+++ b/ui/src/hooks/useGeoFuture.ts
@@ -146,6 +146,19 @@ export const useGeo = () => {
 	// per second until React's error boundary blanked the canvas.
 	const updateLock = useRef<Promise<void>>(Promise.resolve())
 
+	// Mirror the committed arcs in a ref so the enqueue-time dedup
+	// always sees the latest state, even from a stale-closure effect.
+	const arcsRef = useRef<Arch[]>([])
+	useEffect(() => { arcsRef.current = arcs }, [arcs])
+
+	// workerIdx values that are already in a queued/in-flight update.
+	// Serialization alone is not enough: an effect tick that fires
+	// while a lookup is pending would otherwise see the not-yet-
+	// committed arcs and enqueue the same workerIdx a second time,
+	// which would double-count and double-notify on resolution.
+	const pendingAdds = useRef<Set<number>>(new Set())
+	const pendingRemoves = useRef<Set<number>>(new Set())
+
 	const updateArcs = useCallback((connections: Connection[]) => {
 		/***
 			The webgl lib mutates the arcs arr in place. These mutations must be retained so that existing arcs do not
@@ -158,12 +171,34 @@ export const useGeo = () => {
 		  be wasteful of resources. The added benefit is that their current rendering state (as in its animated position)
 		  is also not reset in the process." - https://github.com/vasturiano
 		 ***/
+		// Compute the actual delta against the latest committed arcs
+		// plus the already-queued pending sets, and claim the chosen
+		// workers as pending immediately. This is what prevents a
+		// re-render that fires before the next setArcs commits from
+		// re-enqueueing the same workerIdx.
+		const toRemove: Connection[] = []
+		const toAdd: Connection[] = []
+		for (const con of connections) {
+			if (con.state === -1) {
+				const inArcs = arcsRef.current.some(a => a.workerIdx === con.workerIdx)
+				if (inArcs && !pendingRemoves.current.has(con.workerIdx)) {
+					toRemove.push(con)
+					pendingRemoves.current.add(con.workerIdx)
+				}
+			} else if (con.state === 1) {
+				const inArcs = arcsRef.current.some(a => a.workerIdx === con.workerIdx)
+				if (!inArcs && !pendingAdds.current.has(con.workerIdx)) {
+					toAdd.push(con)
+					pendingAdds.current.add(con.workerIdx)
+				}
+			}
+		}
+		if (toAdd.length === 0 && toRemove.length === 0) return updateLock.current
+
 		const next = updateLock.current.then(async () => {
 			if (!country.current) country.current = await geoLookup(null) // lookup user country first time
 
-			const removedConnections = connections.filter(c => c.state === -1)
-			const addedConnections = connections.filter(c => c.state === 1)
-			const geos = await geoLookupAll(addedConnections)
+			const geos = await geoLookupAll(toAdd)
 
 			setArcs(prev => {
 				// Operate on a shallow copy so the React state's underlying
@@ -172,7 +207,7 @@ export const useGeo = () => {
 				// reference equality to skip WebGL re-creation for arcs that
 				// didn't change.
 				const drafted = [...prev]
-				decrementArcs(drafted, removedConnections)
+				decrementArcs(drafted, toRemove)
 				incrementArcs(drafted, geos)
 
 				const isoCountMap = {} as { [key: string]: number }
@@ -184,9 +219,11 @@ export const useGeo = () => {
 				return [...drafted, ...newArcs]
 			})
 
-			// dispatch push notifications. Use the freshly resolved geo →
-			// country map directly rather than reaching back into the post-
-			// update arcs state, which is racy under serialized updates.
+			// dispatch push notifications. `geos` only contains workers
+			// that this job actually added (they were filtered against the
+			// pending+committed sets at enqueue time), so we won't fire
+			// duplicate "helping" notifications for a worker an earlier
+			// queued job already handled.
 			geos.forEach(geo => {
 				const iso = geo.iso as keyof typeof countries
 				const countryName = (countries[iso] || countries[CENSORED_ISO_FALLBACK]).name
@@ -205,20 +242,23 @@ export const useGeo = () => {
 			// chain — every subsequent updateArcs would be skipped otherwise
 			// because the lock would stay rejected.
 			console.error('updateArcs failed', err)
+		}).finally(() => {
+			// Release the pending claims now that this job has either
+			// committed its setArcs or failed. After this point, arcsRef
+			// (updated by the arcs->ref effect) reflects the new truth.
+			toAdd.forEach(c => pendingAdds.current.delete(c.workerIdx))
+			toRemove.forEach(c => pendingRemoves.current.delete(c.workerIdx))
 		})
 		updateLock.current = next
 		return next
 	}, [target, t])
 
 	useEffect(() => {
-		// check if connections have changed since the last update (using arcs workerIdx)
-		const updatedConnections = connections.filter(con => {
-			if (con.state === -1) return arcs.some(arc => arc.workerIdx === con.workerIdx)
-			return !arcs.some(arc => arc.workerIdx === con.workerIdx)
-		})
-		if (!updatedConnections.length) return // only update on changes
-		updateArcs(updatedConnections)
-	}, [connections, arcs, updateArcs])
+		// Hand the full connections array to updateArcs; it will
+		// internally diff against the latest committed arcs + the
+		// pending set to decide what actually needs work.
+		updateArcs(connections)
+	}, [connections, updateArcs])
 
 	useEffect(() => {
 		if (sharing && !active) pushNotification({

--- a/ui/src/hooks/useGeoFuture.ts
+++ b/ui/src/hooks/useGeoFuture.ts
@@ -134,11 +134,19 @@ export const useGeo = () => {
 	// const connections = useQueueState(rawConnections)
 	const active = connections.some(c => c.state === 1)
 	const sharing = useEmitterState(sharingEmitter)
-	const [updating, setUpdating] = useState(false)
 	const startTs = useRef(performance.now())
 	const {target} = useContext(AppContext).settings
 
-	const updateArcs = useCallback(async (connections: Connection[]) => {
+	// Serialize concurrent updateArcs invocations so the async
+	// geoLookupAll between mutations can't interleave between two
+	// callers and clobber each other's view of `arcs`. Without this,
+	// fast-arriving connections (3 within ~200 ms) raced and produced
+	// an inconsistent arcs array that three.js then tried to render,
+	// throwing "Cannot read properties of undefined (reading 'x')" 60×
+	// per second until React's error boundary blanked the canvas.
+	const updateLock = useRef<Promise<void>>(Promise.resolve())
+
+	const updateArcs = useCallback((connections: Connection[]) => {
 		/***
 			The webgl lib mutates the arcs arr in place. These mutations must be retained so that existing arcs do not
 		  re-animate on state changes. I.e. we can't simply return a new map here. Arcs must be removed/added using the
@@ -150,56 +158,67 @@ export const useGeo = () => {
 		  be wasteful of resources. The added benefit is that their current rendering state (as in its animated position)
 		  is also not reset in the process." - https://github.com/vasturiano
 		 ***/
-		if (!country.current) country.current = await geoLookup(null) // lookup user country first time
+		const next = updateLock.current.then(async () => {
+			if (!country.current) country.current = await geoLookup(null) // lookup user country first time
 
-		const removedConnections = connections.filter(c => c.state === -1)
-		decrementArcs(arcs, removedConnections) // mutate arcs in place
+			const removedConnections = connections.filter(c => c.state === -1)
+			const addedConnections = connections.filter(c => c.state === 1)
+			const geos = await geoLookupAll(addedConnections)
 
-		// removedConnections.forEach(con => {
-		// 	removeNotification(con.workerIdx)
-		// })
+			setArcs(prev => {
+				// Operate on a shallow copy so the React state's underlying
+				// array is never partially mutated mid-render. Inner arc
+				// object identities are preserved — react-globe.gl uses
+				// reference equality to skip WebGL re-creation for arcs that
+				// didn't change.
+				const drafted = [...prev]
+				decrementArcs(drafted, removedConnections)
+				incrementArcs(drafted, geos)
 
-		const addedConnections = connections.filter(c => c.state === 1)
-		const geos = await geoLookupAll(addedConnections)
-		incrementArcs(arcs, geos)
+				const isoCountMap = {} as { [key: string]: number }
+				drafted.forEach(arc => {
+					if (!isoCountMap[arc.iso]) isoCountMap[arc.iso] = arc.count
+				})
 
-		const isoCountMap = {} as { [key: string]: number }
-		arcs.forEach(arc => {
-			if (!isoCountMap[arc.iso]) isoCountMap[arc.iso] = arc.count
-		})
-
-		const newArcs = createArcs(geos, isoCountMap, country.current)
-
-		const updatedArcs = [...arcs, ...newArcs]
-		setArcs(updatedArcs)
-
-		// dispatch push notifications
-		geos.forEach(geo => {
-			const country = updatedArcs.find(a => a.iso === geo.iso)?.country
-			if (!country) return
-			if (target === Targets.EXTENSION_POPUP && startTs.current + 1000 > performance.now()) return // don't show notifications on initial load because of initial sync w/ bg script
-			pushNotification({
-				id: geo.workerIdx,
-				// text: `Helping a new person in ${country.split(',')[0]}`,
-				text: `${t('helping', {country})}`,
-				autoHide: true,
-				heart: true
+				const newArcs = createArcs(geos, isoCountMap, country.current!)
+				return [...drafted, ...newArcs]
 			})
+
+			// dispatch push notifications. Use the freshly resolved geo →
+			// country map directly rather than reaching back into the post-
+			// update arcs state, which is racy under serialized updates.
+			geos.forEach(geo => {
+				const iso = geo.iso as keyof typeof countries
+				const countryName = (countries[iso] || countries[CENSORED_ISO_FALLBACK]).name
+				if (!countryName) return
+				if (target === Targets.EXTENSION_POPUP && startTs.current + 1000 > performance.now()) return // don't show notifications on initial load because of initial sync w/ bg script
+				pushNotification({
+					id: geo.workerIdx,
+					// text: `Helping a new person in ${countryName.split(',')[0]}`,
+					text: `${t('helping', {country: countryName})}`,
+					autoHide: true,
+					heart: true
+				})
+			})
+		}).catch(err => {
+			// Swallow + log so a single update's failure doesn't poison the
+			// chain — every subsequent updateArcs would be skipped otherwise
+			// because the lock would stay rejected.
+			console.error('updateArcs failed', err)
 		})
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [arcs])
+		updateLock.current = next
+		return next
+	}, [target, t])
 
 	useEffect(() => {
-		if (updating) return // don't update while updating 🤪doing so causes a race condition
 		// check if connections have changed since the last update (using arcs workerIdx)
 		const updatedConnections = connections.filter(con => {
 			if (con.state === -1) return arcs.some(arc => arc.workerIdx === con.workerIdx)
 			return !arcs.some(arc => arc.workerIdx === con.workerIdx)
 		})
 		if (!updatedConnections.length) return // only update on changes
-		setUpdating(true)
-		updateArcs(updatedConnections).then(() => setUpdating(false))
-	}, [connections, updateArcs, updating, arcs])
+		updateArcs(updatedConnections)
+	}, [connections, arcs, updateArcs])
 
 	useEffect(() => {
 		if (sharing && !active) pushNotification({


### PR DESCRIPTION
## Summary

Fixes the unbounded.lantern.io UI freeze reported in #lantern-general (Derek's logs: 3 rapid connection events ~200 ms apart → 126× `Uncaught TypeError: Cannot read properties of undefined (reading 'x')` from three.js → React error boundary blanks the canvas).

Root cause is a race in `useGeoFuture.ts::updateArcs`: two effect runs both read the previous render's `updating=false`, both kick off an `updateArcs`, and their `await geoLookupAll` calls interleave around mutations of the closed-over `arcs` array. The result is an arcs entry whose start/end `Vector3` is undefined — three.js then dereferences `.x` on it every frame.

## The race

```mermaid
sequenceDiagram
    autonumber
    participant E1 as Effect tick 1<br/>useGeoFuture.ts:213
    participant E2 as Effect tick 2<br/>useGeoFuture.ts:213
    participant U as updateArcs (old)<br/>useGeoFuture.ts:149
    participant G as react-globe.gl<br/>three.js render
    participant S as React state<br/>arcs[]

    Note over E1,E2: connectionsEmitter fires 3 times within ~200 ms (Derek's logs)

    E1->>U: call 1 with conn A
    Note over U: useGeoFuture.ts:163<br/>await geoLookupAll(A) ⚠️
    E2->>U: call 2 with conn B (updating flag still false this render)
    Note over U: useGeoFuture.ts:163<br/>await geoLookupAll(B) ⚠️

    rect rgba(255, 200, 200, 0.3)
        Note over U: useGeoFuture.ts:166<br/>call 1 resumes — mutates the same arcs<br/>array closure that call 2 also holds 🐛
        Note over U: useGeoFuture.ts:178<br/>call 2 resumes — overwrites with stale view —<br/>new arcs from call 1 are present but their<br/>start/endLat/Lng were never finalized 🐛
    end

    U->>S: setArcs(updatedArcs) — array with partial entries
    S->>G: render
    G --x G: arc.start.x → undefined — TypeError ×126
    Note over G: error boundary unmounts globe → blank canvas
```

## Fix

Landed in two commits:

**299d011** — serialize updateArcs:

- `useRef<Promise<void>>` lock chains `updateArcs` invocations strictly serially. The ref identity is stable across renders, so there is no stale-closure window (unlike the `updating` `useState` it replaces).
- `setArcs(prev => ...)` so each update sees the authoritative latest state instead of a closed-over snapshot.
- Shallow-copy `prev` before mutating so React's state array isn't partially mutated mid-render. Inner arc object identities are preserved — react-globe.gl relies on `===` for the WebGL-reuse optimization (see the existing JSDoc comment above `updateArcs` for the upstream framework note).
- Notification country name is now computed from the freshly resolved `geos` map rather than reaching back into post-update arcs state.
- Errors in the lock chain are caught + logged so a single failed update doesn't poison every subsequent call.

**c2ac7f0** — dedup at enqueue time (addresses Copilot review):

Serialization alone wasn't enough: an effect tick that fires while a geo lookup is pending was recomputing the diff against the not-yet-updated arcs snapshot and re-enqueueing the same workerIdx, causing double-counted arcs and duplicate "helping" notifications.

- `arcsRef` mirrors committed arcs in a ref, synced by a `useEffect` declared **before** the connections effect — so on any render flush the ref is fresh by the time the connections effect re-runs.
- `pendingAdds` / `pendingRemoves` Sets claim workerIdx values at enqueue time and release them in `.finally()` after the queued job's `setArcs` commits (or errors). A second `updateArcs` call for the same workerIdx is filtered at the top.
- The connections effect now just calls `updateArcs(connections)`; the diff happens inside `updateArcs`. The old "diff against rendered arcs" pattern is gone.

## Test plan

- [x] Verified the previously buggy code path locally — `updateArcs` references closed-over `arcs` after `await`, confirming the race.
- [ ] Build + smoke unbounded.lantern.io locally; open with the React devtools profiler and trigger 3+ rapid connection events; canvas must not blank.
- [ ] Compare against Derek's reproduction (3 `play explosion` events in <300 ms).
- [ ] Confirm `react-globe.gl` is still skipping WebGL re-creation for unchanged arcs (no animation reset on existing arcs when a new one is added).
