### PR TITLE
egress: suppress per-request HTTP metrics on /ws to fix SigNoz cardinality spike

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/getlantern/broflake/common"
 	"github.com/getlantern/telemetry"
@@ -291,7 +292,17 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 	// panic on duplicate `/ws` registration, which broke tests, graceful
 	// restarts, and any host that embeds multiple egress listeners.
 	mux := http.NewServeMux()
-	mux.Handle("/ws", otelhttp.NewHandler(http.HandlerFunc(l.handleWebsocket), "/ws"))
+	// Wrap the handler for span propagation only — explicitly attach a noop
+	// MeterProvider so otelhttp does NOT emit http.server.* histograms here.
+	// The default attribute set on those histograms includes net.sock.peer.addr,
+	// net.sock.peer.port and http.user_agent, which together create a fresh
+	// time series for every WebSocket connection (~thousands/day on a single
+	// egress) and blow up SigNoz cardinality. The four ObservableUpDownCounters
+	// above already cover the only useful signals (concurrent ws/quic/streams,
+	// ingress bytes); per-request HTTP metrics on a single upgrade endpoint
+	// add no information.
+	mux.Handle("/ws", otelhttp.NewHandler(http.HandlerFunc(l.handleWebsocket), "/ws",
+		otelhttp.WithMeterProvider(metricnoop.NewMeterProvider())))
 
 	srv := &http.Server{
 		Handler:      mux,


### PR DESCRIPTION
## Summary

Fixes the 2× SigNoz ingestion spike the vendor flagged on May 20 ([Slack thread](https://wdynhnkxvsdx.slack.com/archives/C07D1E52PN3/p1779360399870729)), traced to the \`unbounded-egress\` service.

\`otelhttp.NewHandler\` on the \`/ws\` upgrade endpoint emits \`http.server.duration.*\` histograms with these attributes:

| Attribute | Cardinality |
|---|---|
| \`net.sock.peer.addr\` | unique per peer |
| \`net.sock.peer.port\` | **unique per TCP connection** (ephemeral port) |
| \`http.user_agent\` | high cardinality |
| \`http.client_ip\` | unique per peer |
| \`le\` | per histogram bucket boundary |

Every WebSocket upgrade creates a fresh time series across all five histogram components (\`.bucket\`, \`.count\`, \`.max\`, \`.min\`, \`.sum\`), plus the \`http.server.request_content_length.*\` / \`http.server.response_content_length.*\` families. For a service with the throughput pattern of unbounded-egress this lands as thousands of stale time series per day per metric — exactly the 2× ingestion shape SigNoz observed.

SigNoz query confirms the volume: \`http.server.duration.count\` from \`service.name = 'unbounded-egress'\` is reporting **2,087 samples/sec rate** (~180M samples/day) for a service that has 1–7 concurrent WebSocket connections. The arithmetic doesn't match — almost all of that volume is new-series-per-connection, not per-sample value.

## Fix

Attach a noop \`MeterProvider\` to the \`/ws\` handler so \`otelhttp\` doesn't emit any \`http.server.*\` histograms there. Tracing/span propagation still works — the handler still wraps the context. The four \`ObservableUpDownCounters\` declared above (\`concurrent-websockets\`, \`concurrent-quic-connections\`, \`concurrent-quic-streams\`, \`ingress-bytes\`) already cover the only signals worth keeping for this endpoint.

## What we lose

Per-request HTTP latency/size histograms scoped to this exact \`/ws\` route. On a single upgrade endpoint where every request is GET → 101 Switching Protocols, these were:

- Method: always GET (no useful variance)
- Status code: always 101 (no useful variance)
- Duration: handshake-only, not the WebSocket lifetime
- Size: tiny request body, tiny response body, no useful signal

So we lose ~zero useful information and reclaim the SigNoz budget.

## Follow-up

Going to open a defensive PR on \`getlantern/telemetry\` next, adding a metric \`View\` with an \`AttributeFilter\` that strips \`net.sock.peer.*\`, \`http.client_ip\`, and \`http.user_agent\` from \`http.server.*\` metrics at the SDK layer. That way if another service in the org adds \`otelhttp.NewHandler\` later, the cardinality explosion can't recur.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./egress/...\` passes (2.047s, 0 failures)
- [ ] Deploy unbounded-egress with this fix and confirm SigNoz \`http.server.duration.*\` series for \`service.name = 'unbounded-egress'\` drop to near-zero within the periodic-reader interval (60s default)
- [ ] Confirm \`concurrent-websockets\` and the other custom counters continue to report normally

cc Reflog (replying in the Slack thread once this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)