### PR TITLE
egress: bump version to v2.3.2 for SigNoz cardinality fix

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Must be a valid semver
-const Version = "v2.3.1"
+const Version = "v2.3.2"


### PR DESCRIPTION
## Why

The auto-bump step in release-egress.yml failed on the #365 merge — the workflow's GITHUB_TOKEN can't push directly to \`main\` (branch protection requires PRs):

\`\`\`
auto patch-bump: v2.3.1 -> v2.3.2
[main 5e5a271] chore: bump egress version to v2.3.2 [skip ci]
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
\`\`\`

## Fix

The workflow already handles manual bumps via PR (takes the \"manual bump detected\" branch, skips auto-commit/push). Bumping via this PR is the path of least resistance.

When merged: the next workflow run reads \`current=v2.3.2 != last_tag=v2.3.1\`, picks the manual-bump branch, skips the protected-branch fight, builds linux/amd64+arm64, publishes the v2.3.2 GitHub Release.

Then the running egress can be updated to pick up the otelhttp metric suppression from #365 and the SigNoz cardinality spike subsides.

## Permanent fix (separate PR)

Branch protection will keep biting future releases. Options: allowlist github-actions[bot] for direct push, switch the workflow to open a PR instead, or use a GitHub App with bypass permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)