### PR TITLE
fix(clientcore): stop leaking goroutines and connections on engine teardown

### DIFF
--- a/clientcore/broflake.go
+++ b/clientcore/broflake.go
@@ -84,10 +84,9 @@ func (b *BroflakeEngine) stop() {
 	go func() {
 		b.wg.Wait()
 
-		// Cancel the engine context (routers, bus observer, UI ticker) only after the workers
-		// have exited: several worker states do bare blocking com.tx sends, so the routers must
-		// keep draining com.tx until then, or a worker parked on a full-buffer send never reaches
-		// its between-states ctx check and wg.Wait never returns.
+		// Cancel the engine ctx only after workers exit. Some worker states block on com.tx
+		// sends, and stopping routers earlier can strand a worker on a full buffer and hang
+		// wg.Wait.
 		b.cancel()
 
 		if b.netstated != "" {

--- a/clientcore/broflake.go
+++ b/clientcore/broflake.go
@@ -78,12 +78,17 @@ func (b *BroflakeEngine) start() {
 }
 
 func (b *BroflakeEngine) stop() {
-	b.cancel()
 	b.cTable.Stop()
 	b.pTable.Stop()
 
 	go func() {
 		b.wg.Wait()
+
+		// Cancel the engine context (routers, bus observer, UI ticker) only after the workers
+		// have exited: several worker states do bare blocking com.tx sends, so the routers must
+		// keep draining com.tx until then, or a worker parked on a full-buffer send never reaches
+		// its between-states ctx check and wg.Wait never returns.
+		b.cancel()
 
 		if b.netstated != "" {
 			b.netstateStop <- struct{}{}

--- a/clientcore/broflake.go
+++ b/clientcore/broflake.go
@@ -2,6 +2,7 @@
 package clientcore
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -20,18 +21,23 @@ type BroflakeEngine struct {
 	tag               string
 	netstateHeartbeat time.Duration
 	netstateStop      chan struct{}
+	ctx               context.Context
+	cancel            context.CancelFunc
 }
 
 func NewBroflakeEngine(cTable, pTable *WorkerTable, ui UI, wg *sync.WaitGroup, netstated, tag string) *BroflakeEngine {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &BroflakeEngine{
-		cTable,
-		pTable,
-		ui,
-		wg,
-		netstated,
-		tag,
-		1 * time.Minute,
-		make(chan struct{}, 0),
+		cTable:            cTable,
+		pTable:            pTable,
+		ui:                ui,
+		wg:                wg,
+		netstated:         netstated,
+		tag:               tag,
+		netstateHeartbeat: time.Minute,
+		netstateStop:      make(chan struct{}),
+		ctx:               ctx,
+		cancel:            cancel,
 	}
 }
 
@@ -72,6 +78,7 @@ func (b *BroflakeEngine) start() {
 }
 
 func (b *BroflakeEngine) stop() {
+	b.cancel()
 	b.cTable.Stop()
 	b.pTable.Stop()
 
@@ -174,7 +181,7 @@ func NewBroflake(bfOpt *BroflakeOptions, rtcOpt *WebRTCOptions, egOpt *EgressOpt
 	var bus = NewIpcObserver(
 		bfOpt.BusBufferSz,
 		UpstreamUIHandler(*ui, bfOpt.Netstated, rtcOpt.Tag),
-		DownstreamUIHandler(*ui, bfOpt.Netstated, rtcOpt.Tag),
+		DownstreamUIHandler(broflake.ctx, *ui, bfOpt.Netstated, rtcOpt.Tag),
 	)
 
 	// Step 5: Build consumer router and producer router
@@ -188,9 +195,9 @@ func NewBroflake(bfOpt *BroflakeOptions, rtcOpt *WebRTCOptions, egOpt *EgressOpt
 	}
 
 	// Step 6: Start the bus, init the routers, fire our UI events to announce that we're ready
-	bus.Start()
-	cRouter.Init()
-	pRouter.Init()
+	bus.Start(broflake.ctx)
+	cRouter.Init(broflake.ctx)
+	pRouter.Init(broflake.ctx)
 	ui.OnReady()
 	ui.OnStartup()
 	return bfconn, ui, nil

--- a/clientcore/ipc.go
+++ b/clientcore/ipc.go
@@ -1,6 +1,8 @@
 // ipc.go defines structures and functionality for communication between client system components
 package clientcore
 
+import "context"
+
 // ChunkIPC: data plane traffic
 // PathAssertionIPC: how upstream processes describe their connectivity for downstream processes
 // ConsumerInfoIPC: how downstream processes describe their connectivity for upstream processes
@@ -43,22 +45,30 @@ type ipcObserver struct {
 	onRx       func(IPCMsg)
 }
 
-func (o *ipcObserver) Start() {
-	go func() {
-		for {
-			msg := <-o.Downstream.tx
-			o.onTx(msg)
-			o.Upstream.tx <- msg
-		}
-	}()
+func forwardIPC(ctx context.Context, src <-chan IPCMsg, dst chan<- IPCMsg, hook func(IPCMsg)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-src:
+			if !ok {
+				return
+			}
 
-	go func() {
-		for {
-			msg := <-o.Upstream.rx
-			o.onRx(msg)
-			o.Downstream.rx <- msg
+			hook(msg)
+
+			select {
+			case <-ctx.Done():
+				return
+			case dst <- msg:
+			}
 		}
-	}()
+	}
+}
+
+func (o *ipcObserver) Start(ctx context.Context) {
+	go forwardIPC(ctx, o.Downstream.tx, o.Upstream.tx, o.onTx)
+	go forwardIPC(ctx, o.Upstream.rx, o.Downstream.rx, o.onRx)
 }
 
 func NewIpcObserver(bufferSz int, onTx, onRx func(IPCMsg)) *ipcObserver {

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -147,8 +147,6 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 					}
 				// Since we're putting this state into an infinite loop, explicitly handle cancellation
 				case <-ctx.Done():
-					// Close the carried peerConnection before dropping it, or its interceptor
-					// goroutines leak; returning to state 0 with empty input discards it otherwise.
 					peerConnection.Close()
 					return 0, []interface{}{}
 				}

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -505,6 +505,9 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			slog.Debug("Producer state 4, signaling complete!")
 
 			select {
+			case <-ctx.Done():
+				peerConnection.Close()
+				return 0, []interface{}{}
 			case d := <-connectionEstablished:
 				slog.Debug("A WebRTC connection has been established!")
 				return 5, []interface{}{

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -147,6 +147,9 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 					}
 				// Since we're putting this state into an infinite loop, explicitly handle cancellation
 				case <-ctx.Done():
+					// Close the carried peerConnection before dropping it, or its interceptor
+					// goroutines leak; returning to state 0 with empty input discards it otherwise.
+					peerConnection.Close()
 					return 0, []interface{}{}
 				}
 			}

--- a/clientcore/protocol.go
+++ b/clientcore/protocol.go
@@ -3,6 +3,7 @@ package clientcore
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"math"
 	"math/rand"
@@ -54,6 +55,7 @@ func (fsm *WorkerFSM) Start() {
 		for {
 			select {
 			case <-fsm.ctx.Done():
+				closeWorkerResource(fsm.nextInput)
 				slog.Debug("End of last state, stopping WorkerFSM...")
 				return
 			default:
@@ -61,6 +63,19 @@ func (fsm *WorkerFSM) Start() {
 			}
 		}
 	}()
+}
+
+func closeWorkerResource(input []any) {
+	if len(input) == 0 {
+		return
+	}
+
+	switch c := input[0].(type) {
+	case io.Closer:
+		_ = c.Close()
+	case interface{ CloseNow() error }:
+		_ = c.CloseNow()
+	}
 }
 
 // Stop this WorkerFSM (takes effect upon returning from the currently executing state)

--- a/clientcore/routing.go
+++ b/clientcore/routing.go
@@ -2,6 +2,7 @@
 package clientcore
 
 import (
+	"context"
 	"sync"
 
 	"github.com/getlantern/broflake/common"
@@ -12,10 +13,8 @@ import (
 // upstream tableRouter, in managing a WorkerTable consisting of workers which handle egress traffic,
 // decides how to best utilize those connections (ie, in serial, in parallel, 1:1, multipath, etc.)
 type TableRouter interface {
-	Init()
-
+	Init(ctx context.Context)
 	onBus(msg IPCMsg)
-
 	onWorker(msg IPCMsg, workerIdx workerID)
 }
 
@@ -25,28 +24,53 @@ type baseRouter struct {
 	table      *WorkerTable
 	busHook    func(r *baseRouter, msg IPCMsg)
 	workerHook func(r *baseRouter, msg IPCMsg, workerIdx workerID)
+	ctx        context.Context
+}
+
+func recvIPC(ctx context.Context, ch <-chan IPCMsg, fn func(IPCMsg)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			fn(msg)
+		}
+	}
+}
+
+func sendIPC(ctx context.Context, ch chan<- IPCMsg, msg IPCMsg) {
+	select {
+	case <-ctx.Done():
+	case ch <- msg:
+	}
+}
+
+func (r *baseRouter) hasWorker(id workerID) bool {
+	idx := int(id)
+	return idx >= 0 && idx < len(r.table.slot)
 }
 
 func (r *baseRouter) Init(
+	ctx context.Context,
 	listen chan IPCMsg,
 	onBus func(msg IPCMsg),
-	onWorker func(msg IPCMsg,
-		workerIdx workerID),
+	onWorker func(msg IPCMsg, workerIdx workerID),
 ) {
+	r.ctx = ctx
 	for i := range r.table.slot {
-		go func(i int) {
-			for {
-				msg := <-r.table.slot[i].com.tx
-				onWorker(msg, workerID(i))
-			}
-		}(i)
+		workerCh := r.table.slot[i].com.tx
+
+		go func(workerIdx workerID, ch <-chan IPCMsg) {
+			recvIPC(ctx, ch, func(msg IPCMsg) {
+				onWorker(msg, workerIdx)
+			})
+		}(workerID(i), workerCh)
 	}
 
-	go func() {
-		for {
-			onBus(<-listen)
-		}
-	}()
+	go recvIPC(ctx, listen, onBus)
 }
 
 func (r *baseRouter) onBus(msg IPCMsg) {
@@ -62,8 +86,8 @@ type upstreamRouter struct {
 	baseRouter
 }
 
-func (r *upstreamRouter) Init() {
-	r.baseRouter.Init(r.bus.tx, r.onBus, r.onWorker)
+func (r *upstreamRouter) Init(ctx context.Context) {
+	r.baseRouter.Init(ctx, r.bus.tx, r.onBus, r.onWorker)
 }
 
 func (r *upstreamRouter) onBus(msg IPCMsg) {
@@ -80,11 +104,15 @@ func (r *upstreamRouter) onWorker(msg IPCMsg, workerIdx workerID) {
 }
 
 func (r *upstreamRouter) toBus(msg IPCMsg) {
-	r.bus.rx <- msg
+	sendIPC(r.ctx, r.bus.rx, msg)
 }
 
 func (r *upstreamRouter) toWorker(msg IPCMsg, peerIdx workerID) {
-	r.table.slot[peerIdx].com.rx <- msg
+	if !r.hasWorker(peerIdx) {
+		return
+	}
+
+	sendIPC(r.ctx, r.table.slot[peerIdx].com.rx, msg)
 }
 
 // A downstreamRouter parameterizes a baseRouter to send on tx and receive on rx
@@ -92,8 +120,8 @@ type downstreamRouter struct {
 	baseRouter
 }
 
-func (r *downstreamRouter) Init() {
-	r.baseRouter.Init(r.bus.rx, r.onBus, r.onWorker)
+func (r *downstreamRouter) Init(ctx context.Context) {
+	r.baseRouter.Init(ctx, r.bus.rx, r.onBus, r.onWorker)
 }
 
 func (r *downstreamRouter) onBus(msg IPCMsg) {
@@ -108,11 +136,15 @@ func (r *downstreamRouter) onWorker(msg IPCMsg, workerIdx workerID) {
 }
 
 func (r *downstreamRouter) toBus(msg IPCMsg) {
-	r.bus.tx <- msg
+	sendIPC(r.ctx, r.bus.tx, msg)
 }
 
 func (r *downstreamRouter) toWorker(msg IPCMsg) {
-	r.table.slot[msg.Wid].com.rx <- msg
+	if !r.hasWorker(msg.Wid) {
+		return
+	}
+
+	sendIPC(r.ctx, r.table.slot[msg.Wid].com.rx, msg)
 }
 
 func (r *downstreamRouter) toAllWorkers(msg IPCMsg) {

--- a/clientcore/ui.go
+++ b/clientcore/ui.go
@@ -2,6 +2,7 @@
 package clientcore
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"strconv"
@@ -74,19 +75,26 @@ type UI interface {
 	OnConsumerConnectionChange(state int, workerIdx int, addr net.IP)
 }
 
-func DownstreamUIHandler(ui UIImpl, netstated, tag string) func(msg IPCMsg) {
+func DownstreamUIHandler(ctx context.Context, ui UIImpl, netstated, tag string) func(msg IPCMsg) {
 	var bytesPerSec int64
 	var tick uint
 	tickMs := time.Duration(1000 / uiRefreshHz)
 
 	go func() {
+		ticker := time.NewTicker(tickMs * time.Millisecond)
+		defer ticker.Stop()
 		for {
-			<-time.After(tickMs * time.Millisecond)
-			ui.OnDownstreamThroughput(int(atomic.LoadInt64(&bytesPerSec)))
-			if tick%uiRefreshHz == 0 {
-				atomic.SwapInt64(&bytesPerSec, 0)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				ui.OnDownstreamThroughput(int(atomic.LoadInt64(&bytesPerSec)))
+				tick++
+				if tick == uiRefreshHz {
+					atomic.SwapInt64(&bytesPerSec, 0)
+					tick = 0
+				}
 			}
-			tick++
 		}
 	}()
 

--- a/clientcore/ui.go
+++ b/clientcore/ui.go
@@ -78,10 +78,10 @@ type UI interface {
 func DownstreamUIHandler(ctx context.Context, ui UIImpl, netstated, tag string) func(msg IPCMsg) {
 	var bytesPerSec int64
 	var tick uint
-	tickMs := time.Duration(1000 / uiRefreshHz)
+	tickInterval := time.Second / uiRefreshHz
 
 	go func() {
-		ticker := time.NewTicker(tickMs * time.Millisecond)
+		ticker := time.NewTicker(tickInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/clientcore/user.go
+++ b/clientcore/user.go
@@ -204,12 +204,14 @@ func (c BroflakeConn) SetDeadline(t time.Time) error {
 func NewProducerUserStream(wg *sync.WaitGroup) (*BroflakeConn, *WorkerFSM) {
 	worker := NewWorkerFSM(wg, []FSMstate{
 		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
-			slog.
-				// State 0
-				// (no input data)
-				Debug("User stream producer state 0...")
+			slog.Debug("User stream producer state 0...")
 			// TODO: check for a non-nil path assertion to alert the UI that we're ready to proxy?
-			select {}
+			// This slot is passive — its channels are driven by the consumer of the BroflakeConn,
+			// so the state has no work of its own. Block on ctx rather than a bare select{}: on Stop the
+			// FSM's Start goroutine must return to release its WaitGroup token, which the engine's
+			// async teardown waits on before it signals the engine has fully stopped.
+			<-ctx.Done()
+			return 0, nil
 		}),
 	})
 

--- a/clientcore/user.go
+++ b/clientcore/user.go
@@ -206,10 +206,8 @@ func NewProducerUserStream(wg *sync.WaitGroup) (*BroflakeConn, *WorkerFSM) {
 		FSMstate(func(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
 			slog.Debug("User stream producer state 0...")
 			// TODO: check for a non-nil path assertion to alert the UI that we're ready to proxy?
-			// This slot is passive — its channels are driven by the consumer of the BroflakeConn,
-			// so the state has no work of its own. Block on ctx rather than a bare select{}: on Stop the
-			// FSM's Start goroutine must return to release its WaitGroup token, which the engine's
-			// async teardown waits on before it signals the engine has fully stopped.
+
+			// block until ctx is canceled
 			<-ctx.Done()
 			return 0, nil
 		}),


### PR DESCRIPTION
## Problem

On engine stop, several long-lived goroutines and a live peer connection were leaked on every connect/disconnect cycle:

- The bus observer, table routers, and downstream UI ticker had no shutdown path and ran until process exit.
- The passive user-stream `WorkerFSM` state blocked on a bare `select{}`, so its `Start` goroutine never returned to release its `WaitGroup` token — hanging engine teardown.
- A `WorkerFSM` carrying a live `*webrtc.PeerConnection` (or `coder/websocket` `Conn`) discarded it unclosed when cancelled between states, stranding the connection's pion interceptor goroutines (they start at PeerConnection construction).

Under repeated connect/disconnect this accumulates goroutines and heap without bound.

## Fix

- Thread an engine-owned `context` into the bus observer, routers, and UI ticker so `stop()` cancels them; guard router sends on that context so a send can't block teardown.
- Have the passive user-stream state block on `<-ctx.Done()` and return, so its goroutine releases the `WaitGroup` token.
- On the `WorkerFSM` cancellation exit, close whatever connection the interrupted state was carrying (`io.Closer` for the pion `PeerConnection`, `CloseNow()` for `coder/websocket`), plus the producer state-1 cancel path.

## Verification

- Profiled under a repeated connect/disconnect loop: the engine's long-lived goroutines (routers, bus observer, UI ticker) and per-worker FSM goroutines no longer survive teardown, and pion `PeerConnection` interceptor goroutines drop to zero at the disconnected state (previously accumulated every cycle). The per-cycle `newIpcChan` bus residue no longer ratchets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling across engine, routing, IPC, and worker components.
  * Active WebRTC connections and worker resources now close cleanly when operations are canceled.
  * Prevented messages from being sent to unavailable workers.
  * Improved termination of user stream producers and background processing.

* **Performance**
  * Updated throughput monitoring to use scheduled refresh intervals for more consistent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->