### PR TITLE
fix(clientcore): make consumer signaling backoff context-aware

### DIFF
--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -223,6 +223,12 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 					if err != nil {
 						slog.Debug("Error decoding signal message", "error", err, "msg", string(rawMsg))
 						sleepOrDone(ctx, options.ErrorBackoff)
+						if ctx.Err() != nil {
+							// Cancelled during backoff: hand control back to the FSM
+							// runner (which only observes cancellation between states)
+							// rather than spinning this inner listen loop.
+							return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
+						}
 						// Take the error in stride, continue listening to our existing HTTP request stream
 						continue
 					}

--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -25,6 +25,21 @@ import (
 	"github.com/getlantern/broflake/common"
 )
 
+// sleepOrDone waits for d, returning early if ctx is cancelled. The consumer
+// FSM's error-backoff sleeps use this instead of a bare <-time.After so a
+// WorkerFSM stopped mid-backoff (e.g. an unbounded outbound being torn down on
+// a network change) exits promptly rather than lingering a full ErrorBackoff.
+// Without it, rapid outbound rebuilds stack overlapping FSMs whose backoffs
+// haven't elapsed. See getlantern/engineering#3698.
+func sleepOrDone(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}
+
 func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 	var scache STUNCache
 
@@ -155,7 +170,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				slog.Debug("Couldn't subscribe to genesis stream", "url", options.DiscoverySrv+options.Endpoint, "error", err)
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			}
 			defer res.Body.Close()
@@ -163,7 +178,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			// Handle bad protocol version
 			if res.StatusCode == http.StatusTeapot {
 				slog.Debug("Received 'bad protocol version' response")
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			}
 
@@ -207,7 +222,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 					rt, _, err := common.DecodeSignalMsg(rawMsg)
 					if err != nil {
 						slog.Debug("Error decoding signal message", "error", err, "msg", string(rawMsg))
-						<-time.After(options.ErrorBackoff)
+						sleepOrDone(ctx, options.ErrorBackoff)
 						// Take the error in stride, continue listening to our existing HTTP request stream
 						continue
 					}
@@ -298,7 +313,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				slog.Debug("Couldn't signal offer SDP", "url", options.DiscoverySrv+options.Endpoint, "error", err)
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			}
 			defer res.Body.Close()
@@ -306,7 +321,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			switch res.StatusCode {
 			case http.StatusTeapot:
 				slog.Debug("Received 'bad protocol version' response")
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			case http.StatusNotFound:
 				slog.Debug("Too late for genesis message", "reply_to", replyTo, "status", res.Status)
@@ -315,7 +330,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 				// We won the connection, proceed
 			default:
 				slog.Debug("Unexpected http status code", "status_code", res.StatusCode)
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}
 			}
 
@@ -456,7 +471,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			res, err := options.HTTPClient.Do(req)
 			if err != nil {
 				slog.Debug("Couldn't signal ICE candidates", "url", options.DiscoverySrv+options.Endpoint, "error", err)
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				// Borked!
 				peerConnection.Close() // TODO: there's an err we should handle here
 				return 0, []interface{}{}
@@ -466,7 +481,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			switch res.StatusCode {
 			case http.StatusTeapot:
 				slog.Debug("Received 'bad protocol version' response")
-				<-time.After(options.ErrorBackoff)
+				sleepOrDone(ctx, options.ErrorBackoff)
 				// Borked!
 				peerConnection.Close() // TODO: there's an err we should handle here
 				return 0, []interface{}{}

--- a/clientcore/consumer_test.go
+++ b/clientcore/consumer_test.go
@@ -1,0 +1,26 @@
+package clientcore
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSleepOrDoneReturnsEarlyOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	sleepOrDone(ctx, time.Hour)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("sleepOrDone did not return promptly on a cancelled context: waited %s", elapsed)
+	}
+}
+
+func TestSleepOrDoneWaitsWhenNotCancelled(t *testing.T) {
+	start := time.Now()
+	sleepOrDone(context.Background(), 20*time.Millisecond)
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Fatalf("sleepOrDone returned before the timer elapsed: waited %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Problem

The consumer WebRTC FSM's genesis/offer retry paths in `consumer.go` slept on a bare `<-time.After(options.ErrorBackoff)` (default 5s) that ignored the FSM's `ctx`. `WorkerFSM.Stop()` cancels that ctx, but the run loop only checks it *between* states — so an FSM parked in a backoff sleep lingers up to a full `ErrorBackoff` before it can exit.

That matters under **rapid outbound rebuilds**: when a client roams across networks, the unbounded outbound is torn down and re-created repeatedly. Each stopped FSM that's mid-backoff keeps its goroutine (and the signaling/connection resources it holds) alive for the remainder of the backoff, so overlapping FSMs stack up. This was a contributor to the iOS memory/goroutine growth in getlantern/engineering#3698 (ticket 180321: freddie signaling was failing 453×, so the FSM was almost always sitting in exactly these backoff sleeps).

## Fix

Add a `sleepOrDone(ctx, d)` helper that waits for `d` **or** `ctx.Done()`, and use it for all 8 backoff sleeps in the consumer FSM. Steady-state reconnection cadence is unchanged; only the cancellation path is faster (prompt instead of up-to-5s).

## Relationship to #371

Complementary, non-overlapping. #371 (`garmr/fix-engine-teardown-leak`) closes connections/goroutines on FSM cancel but does not touch `consumer.go`. This PR removes the backoff *delay* before that cancel is observed on the consumer path. Both are wanted.

## Verification

- `go build ./clientcore/` clean; `go test ./clientcore/` passes.
- Added `TestSleepOrDoneReturnsEarlyOnCancel` / `TestSleepOrDoneWaitsWhenNotCancelled`.

Refs getlantern/engineering#3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consumer FSM responsiveness so error-backoff pauses end promptly when cancellation is requested.
  * Corrected genesis-related and signaling-related backoff behavior to respect cancellation and avoid continuing in stalled loops.
* **Tests**
  * Added unit tests validating the cancellation-fast path and the expected backoff timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->