### PR TITLE
fix(clientcore): init QUICLayer ctx/cancel in constructor (Close race + leak)

### DIFF
--- a/clientcore/quic.go
+++ b/clientcore/quic.go
@@ -19,11 +19,21 @@ type ReliableStreamLayer interface {
 }
 
 func NewQUICLayer(bfconn *BroflakeConn, tlsConfig *tls.Config) (*QUICLayer, error) {
+	// ctx/cancel are set here, not in ListenAndMaintainQUICConnection, so they
+	// exist before that goroutine starts and before any Close() can race it.
+	// If they were initialized inside the goroutine, a Close() that landed
+	// first would read a nil cancel and no-op, and the goroutine would then run
+	// quic.Listen/Accept on a context that never gets cancelled — leaking the
+	// listener, the maintain goroutine, and bfconn on every teardown that beats
+	// the goroutine's first line.
+	ctx, cancel := context.WithCancel(context.Background())
 	q := &QUICLayer{
 		bfconn:       bfconn,
 		t:            &quic.Transport{Conn: bfconn},
 		tlsConfig:    tlsConfig,
 		eventualConn: newEventualConn(),
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 
 	return q, nil
@@ -40,8 +50,6 @@ type QUICLayer struct {
 }
 
 func (c *QUICLayer) ListenAndMaintainQUICConnection() {
-	c.ctx, c.cancel = context.WithCancel(context.Background())
-
 	for {
 		// Bail out if Close() cancelled the context. Without this check
 		// the outer loop would spin-create a new quic.Listen → Accept

--- a/clientcore/quic.go
+++ b/clientcore/quic.go
@@ -50,12 +50,14 @@ type QUICLayer struct {
 }
 
 func (c *QUICLayer) ListenAndMaintainQUICConnection() {
-	// ctx is set by NewQUICLayer (the only supported constructor). Guard
-	// against a QUICLayer built via struct literal: refuse to start rather
-	// than nil-deref on c.ctx.Err() below. We deliberately do NOT lazily
-	// init ctx/cancel here — that would put the write back in this goroutine
-	// and reintroduce the Close() race NewQUICLayer exists to prevent.
-	if c.ctx == nil {
+	// ctx and cancel are set together by NewQUICLayer (the only supported
+	// constructor). Guard against a QUICLayer built via struct literal:
+	// refuse to start if either is missing, rather than nil-deref on
+	// c.ctx.Err() below (nil ctx) or run an uncancellable loop that Close()
+	// can never stop (nil cancel). We deliberately do NOT lazily init them
+	// here — that would put the write back in this goroutine and reintroduce
+	// the Close() race NewQUICLayer exists to prevent.
+	if c.ctx == nil || c.cancel == nil {
 		slog.Error("QUICLayer.ListenAndMaintainQUICConnection called on a layer not built via NewQUICLayer; refusing to start")
 		return
 	}

--- a/clientcore/quic.go
+++ b/clientcore/quic.go
@@ -50,6 +50,16 @@ type QUICLayer struct {
 }
 
 func (c *QUICLayer) ListenAndMaintainQUICConnection() {
+	// ctx is set by NewQUICLayer (the only supported constructor). Guard
+	// against a QUICLayer built via struct literal: refuse to start rather
+	// than nil-deref on c.ctx.Err() below. We deliberately do NOT lazily
+	// init ctx/cancel here — that would put the write back in this goroutine
+	// and reintroduce the Close() race NewQUICLayer exists to prevent.
+	if c.ctx == nil {
+		slog.Error("QUICLayer.ListenAndMaintainQUICConnection called on a layer not built via NewQUICLayer; refusing to start")
+		return
+	}
+
 	for {
 		// Bail out if Close() cancelled the context. Without this check
 		// the outer loop would spin-create a new quic.Listen → Accept

--- a/clientcore/quic_close_test.go
+++ b/clientcore/quic_close_test.go
@@ -40,3 +40,26 @@ func TestQUICLayerCloseBeforeListen(t *testing.T) {
 		t.Fatal("ListenAndMaintainQUICConnection did not return after Close()")
 	}
 }
+
+// TestQUICLayerListenWithoutConstructor guards the struct-literal case: a
+// QUICLayer built without NewQUICLayer has a nil ctx, and
+// ListenAndMaintainQUICConnection must refuse to start rather than nil-deref on
+// c.ctx.Err().
+func TestQUICLayerListenWithoutConstructor(t *testing.T) {
+	q := &QUICLayer{} // no ctx/cancel
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("ListenAndMaintainQUICConnection panicked on a nil-ctx layer: %v", r)
+			}
+			close(done)
+		}()
+		q.ListenAndMaintainQUICConnection()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndMaintainQUICConnection did not return on a nil-ctx layer")
+	}
+}

--- a/clientcore/quic_close_test.go
+++ b/clientcore/quic_close_test.go
@@ -47,18 +47,18 @@ func TestQUICLayerCloseBeforeListen(t *testing.T) {
 // c.ctx.Err().
 func TestQUICLayerListenWithoutConstructor(t *testing.T) {
 	q := &QUICLayer{} // no ctx/cancel
-	done := make(chan struct{})
+	// Convey any panic back over a channel rather than calling t.* from the
+	// goroutine, which could otherwise fire after the test completed.
+	result := make(chan any, 1)
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("ListenAndMaintainQUICConnection panicked on a nil-ctx layer: %v", r)
-			}
-			close(done)
-		}()
+		defer func() { result <- recover() }()
 		q.ListenAndMaintainQUICConnection()
 	}()
 	select {
-	case <-done:
+	case r := <-result:
+		if r != nil {
+			t.Errorf("ListenAndMaintainQUICConnection panicked on a nil-ctx layer: %v", r)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("ListenAndMaintainQUICConnection did not return on a nil-ctx layer")
 	}

--- a/clientcore/quic_close_test.go
+++ b/clientcore/quic_close_test.go
@@ -1,0 +1,42 @@
+package clientcore
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+)
+
+// TestQUICLayerCloseBeforeListen guards the ctx/cancel initialization fix: a
+// QUICLayer must be cancellable via Close() even if Close() runs before
+// ListenAndMaintainQUICConnection's goroutine has started. Previously ctx/cancel
+// were set at the top of that goroutine, so a Close() that beat it read a nil
+// cancel, no-op'd, and the goroutine then ran quic.Listen/Accept on a context
+// that never got cancelled — leaking the listener, the goroutine, and bfconn.
+func TestQUICLayerCloseBeforeListen(t *testing.T) {
+	q, err := NewQUICLayer(&BroflakeConn{}, &tls.Config{})
+	if err != nil {
+		t.Fatalf("NewQUICLayer: %v", err)
+	}
+	if q.ctx == nil || q.cancel == nil {
+		t.Fatal("NewQUICLayer must initialize ctx/cancel before the maintain goroutine can run")
+	}
+
+	// Close before the maintain loop ever starts must cancel the context.
+	q.Close()
+	if q.ctx.Err() == nil {
+		t.Fatal("Close() before ListenAndMaintainQUICConnection did not cancel the context")
+	}
+
+	// The maintain loop must then observe the cancelled context and return
+	// immediately via its ctx.Err() bailout, rather than spinning quic.Listen.
+	done := make(chan struct{})
+	go func() {
+		q.ListenAndMaintainQUICConnection()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndMaintainQUICConnection did not return after Close()")
+	}
+}


### PR DESCRIPTION
## Problem

`ListenAndMaintainQUICConnection` initialized `c.ctx`/`c.cancel` on its **first line**, but `Close()` reads `c.cancel` from a different goroutine. Two bugs:

1. **Data race** on `c.ctx`/`c.cancel` (writer = the maintain goroutine, reader = `Close()`), flagged by `-race`.
2. **Lost cancel → permanent leak.** If `Close()` runs *before* the maintain goroutine executes its first line (e.g. an unbounded outbound created and torn down in quick succession during a network change), `c.cancel` is still nil, so `Close()` no-ops. The goroutine then sets its own ctx/cancel and runs `quic.Listen` / `Accept(c.ctx)` forever on a context nobody holds the cancel for — orphaning the QUIC listener, the maintain goroutine, and the underlying `bfconn` (the WebRTC data channels). Under the connect/disconnect churn of a roaming iOS client this accumulates. Part of getlantern/engineering#3698.

## Fix

Initialize `ctx`/`cancel` in `NewQUICLayer`, so they exist before the goroutine starts and before any `Close()` can race them. `Close()` keeps its `nil` guard for direct struct-literal construction.

## Verification

- `go test -race ./clientcore/` passes.
- Added `TestQUICLayerCloseBeforeListen`: constructs a layer, calls `Close()` **before** the maintain loop starts, asserts the context is cancelled and that `ListenAndMaintainQUICConnection` then returns promptly (via its existing `ctx.Err()` bailout) instead of spinning.

Refs getlantern/engineering#3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QUIC connection lifecycle handling when connections are closed before listening begins.
  - Prevented startup failures when the connection layer is not initialized through its standard setup process.
  - Ensured the connection maintenance loop exits safely during early cancellation.

- **Tests**
  - Added coverage for early closure and safe startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->