### PR TITLE
Fix simple embed width shift and stale off-state

### DIFF
--- a/ui/src/components/molecules/notification/index.tsx
+++ b/ui/src/components/molecules/notification/index.tsx
@@ -5,6 +5,7 @@ import {Ellipse} from '../../atoms/ellipse'
 import Explosion from './explosion'
 import {AppContext} from '../../../context'
 import {Layouts} from '../../../constants'
+import {sharingEmitter} from '../../../utils/wasmInterface'
 
 interface NotificationType {
 	id: number
@@ -34,6 +35,7 @@ export const removeNotification = (id: number) => {
 export const Notification = () => {
 	const {theme, layout} = useContext(AppContext).settings
 	const notifications = useEmitterState(notificationQueue)
+	const sharing = useEmitterState(sharingEmitter)
 	const [notification, setNotification] = useState<NotificationType | null>(null)
 	const show = notification?.show ?? false
 	const simple = layout === Layouts.SIMPLE
@@ -42,6 +44,21 @@ export const Notification = () => {
 	// globe-to-control gap is 24px, so -12 puts the notification 12px above the control
 	const bottomShown = simple ? -12 : 0
 	const bottomHidden = simple ? -22 : -10
+
+	// turning sharing off dismisses everything: flush the queue, cancel any
+	// pending hide/remove timers, and drop the visible notification. Without
+	// this, a non-autoHide notification (e.g. "waiting for connections") only
+	// ever clears when another notification arrives, so it outlives a quick
+	// on -> off toggle indefinitely.
+	useEffect(() => {
+		if (sharing) return
+		setNotification(current => {
+			if (current?.timeoutHide) clearTimeout(current.timeoutHide)
+			if (current?.timeoutRemove) clearTimeout(current.timeoutRemove)
+			return null
+		})
+		if (notificationQueue.state.length) notificationQueue.update([])
+	}, [sharing])
 
 	useEffect(() => {
 		if (!notifications.length) return setNotification(null)

--- a/ui/src/components/molecules/notification/index.tsx
+++ b/ui/src/components/molecules/notification/index.tsx
@@ -1,6 +1,6 @@
 import {Container, Text} from './styles'
 import {StateEmitter, useEmitterState} from '../../../hooks/useStateEmitter'
-import {useContext, useEffect, useState} from 'react'
+import {useContext, useEffect, useRef, useState} from 'react'
 import {Ellipse} from '../../atoms/ellipse'
 import Explosion from './explosion'
 import {AppContext} from '../../../context'
@@ -37,6 +37,10 @@ export const Notification = () => {
 	const notifications = useEmitterState(notificationQueue)
 	const sharing = useEmitterState(sharingEmitter)
 	const [notification, setNotification] = useState<NotificationType | null>(null)
+	// ref mirror so the flush effect can reach the current notification's
+	// timers without depending on it (and without side effects in an updater)
+	const notificationRef = useRef<NotificationType | null>(null)
+	useEffect(() => { notificationRef.current = notification }, [notification])
 	const show = notification?.show ?? false
 	const simple = layout === Layouts.SIMPLE
 	const fontSize = layout === Layouts.BANNER ? 14 : 12
@@ -52,11 +56,10 @@ export const Notification = () => {
 	// on -> off toggle indefinitely.
 	useEffect(() => {
 		if (sharing) return
-		setNotification(current => {
-			if (current?.timeoutHide) clearTimeout(current.timeoutHide)
-			if (current?.timeoutRemove) clearTimeout(current.timeoutRemove)
-			return null
-		})
+		const current = notificationRef.current
+		if (current?.timeoutHide) clearTimeout(current.timeoutHide)
+		if (current?.timeoutRemove) clearTimeout(current.timeoutRemove)
+		setNotification(null)
 		if (notificationQueue.state.length) notificationQueue.update([])
 	}, [sharing])
 

--- a/ui/src/components/organisms/simple/index.tsx
+++ b/ui/src/components/organisms/simple/index.tsx
@@ -52,7 +52,7 @@ const Simple = () => {
 			{
 				!sharing ? (
 					<OffPill>
-						<PanelLeft style={{gap: 16}}>
+						<PanelLeft>
 							<HeartIcon/>
 							<BarText>{t('enableActionMode')}</BarText>
 						</PanelLeft>

--- a/ui/src/components/organisms/simple/index.tsx
+++ b/ui/src/components/organisms/simple/index.tsx
@@ -52,8 +52,10 @@ const Simple = () => {
 			{
 				!sharing ? (
 					<OffPill>
-						<HeartIcon/>
-						<BarText>{t('enableActionMode')}</BarText>
+						<PanelLeft style={{gap: 16}}>
+							<HeartIcon/>
+							<BarText>{t('enableActionMode')}</BarText>
+						</PanelLeft>
 						<Switch {...switchProps}/>
 					</OffPill>
 				) : (

--- a/ui/src/components/organisms/simple/styles.tsx
+++ b/ui/src/components/organisms/simple/styles.tsx
@@ -35,7 +35,11 @@ const OffPill = styled.div`
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 16px;
+  // fill the card interior (overriding the Container's align-items: center)
+  // so the pill and the on panel are always the same width
+  align-self: stretch;
   padding: 8px 16px;
   background-color: ${COLORS.blue5};
   border-radius: 8px; // match the on panel

--- a/ui/src/components/organisms/simple/styles.tsx
+++ b/ui/src/components/organisms/simple/styles.tsx
@@ -36,7 +36,7 @@ const OffPill = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 8px; // minimum only — space-between stretches it; 16px wouldn't fit
   // fill the card interior (overriding the Container's align-items: center)
   // so the pill and the on panel are always the same width
   align-self: stretch;

--- a/ui/src/hooks/useGeoFuture.ts
+++ b/ui/src/hooks/useGeoFuture.ts
@@ -241,6 +241,7 @@ export const useGeo = () => {
 				const countryName = (countries[iso] || countries[CENSORED_ISO_FALLBACK]).name
 				if (!countryName) return
 				if (target === Targets.EXTENSION_POPUP && startTs.current + 1000 > performance.now()) return // don't show notifications on initial load because of initial sync w/ bg script
+				if (!sharingEmitter.state) return // this job's lookup outlived a stop; don't announce a connection the user already ended
 				pushNotification({
 					id: ++nextNotificationId.current,
 					// text: `Helping a new person in ${countryName.split(',')[0]}`,
@@ -271,6 +272,20 @@ export const useGeo = () => {
 		// pending set to decide what actually needs work.
 		updateArcs(connections)
 	}, [connections, updateArcs])
+
+	useEffect(() => {
+		if (sharing) return
+		// stop()'s synthetic state:-1 broadcast can't remove an arc whose add
+		// job is still awaiting its geo lookup (the -1 diffs against arcs that
+		// aren't committed yet and is dropped). Chain a full clear behind the
+		// lock so it runs after every in-flight job has settled; adds enqueued
+		// by a subsequent restart chain after the clear, so they're safe.
+		updateLock.current = updateLock.current.then(() => {
+			pendingAdds.current.clear()
+			pendingRemoves.current.clear()
+			setArcs(prev => prev.length ? [] : prev)
+		})
+	}, [sharing])
 
 	useEffect(() => {
 		if (sharing && !active) pushNotification({

--- a/ui/src/layout/styles.tsx
+++ b/ui/src/layout/styles.tsx
@@ -26,9 +26,10 @@ const AppWrapper = styled.section`
   display: flex;
   // simple gets a definite width: in shrink-to-fit hosts (flex/inline-block
   // slots) width:100% collapses to max-content, which differs between the
-  // off/on control bars and makes the card resize when toggled
+  // off/on control bars and makes the card resize when toggled. Its
+  // max-width:100% still lets hosts narrower than 344px shrink the card.
   width: ${({layout}: Props) => layout === Layouts.SIMPLE ? '344px' : '100%'};
-  max-width: ${({layout}: Props) => layout === Layouts.PANEL ? '330px' : layout === Layouts.FLOATING ? '360px' : layout === Layouts.SIMPLE ? '344px' : 'unset'};
+  max-width: ${({layout}: Props) => layout === Layouts.PANEL ? '330px' : layout === Layouts.FLOATING ? '360px' : layout === Layouts.SIMPLE ? '100%' : 'unset'};
   border-radius: ${({ layout }: Props) => getBorderRadius(layout)};
   background-color: ${({theme, $menu}: Props) => theme === Themes.DARK ? COLORS.grey5 : $menu ? COLORS.grey1 : COLORS.white };
   box-sizing: content-box;

--- a/ui/src/layout/styles.tsx
+++ b/ui/src/layout/styles.tsx
@@ -24,7 +24,10 @@ export const getBorderRadius = (layout: Layouts) => {
 const AppWrapper = styled.section`
   font-family: 'Urbanist', sans-serif;
   display: flex;
-  width: 100%;
+  // simple gets a definite width: in shrink-to-fit hosts (flex/inline-block
+  // slots) width:100% collapses to max-content, which differs between the
+  // off/on control bars and makes the card resize when toggled
+  width: ${({layout}: Props) => layout === Layouts.SIMPLE ? '344px' : '100%'};
   max-width: ${({layout}: Props) => layout === Layouts.PANEL ? '330px' : layout === Layouts.FLOATING ? '360px' : layout === Layouts.SIMPLE ? '344px' : 'unset'};
   border-radius: ${({ layout }: Props) => getBorderRadius(layout)};
   background-color: ${({theme, $menu}: Props) => theme === Themes.DARK ? COLORS.grey5 : $menu ? COLORS.grey1 : COLORS.white };

--- a/ui/src/utils/wasmInterface.ts
+++ b/ui/src/utils/wasmInterface.ts
@@ -201,8 +201,10 @@ export class WasmInterface {
 			// clear on stop instead of lingering until the workers wind down.
 			// (emitting an empty array would NOT clear arcs: useGeo's updateArcs
 			// only removes arcs for connections it sees with state -1)
-			this.connectionMap = {}
-			this.connections = this.connections.map(c => ({...c, state: -1}))
+			const stopped: { [key: number]: Connection } = {}
+			this.connections.forEach(c => stopped[c.workerIdx] = {...c, state: -1})
+			this.connectionMap = stopped
+			this.connections = this.idxMapToArr(this.connectionMap)
 			connectionsEmitter.update(this.connections)
 		}
 	}
@@ -230,6 +232,13 @@ export class WasmInterface {
 	}
 
 	handleConnection = (e: { detail: Connection }) => {
+		// on web the wasm client's workers wind down asynchronously after
+		// stop(), and its listeners stay attached; stop() already broadcast
+		// the disconnected state, so drop late events — otherwise an in-flight
+		// state:1 event re-activates an arc/count while the widget is off and
+		// double-increments lifetimeConnections against the reset map. (the
+		// extension popup receives synced state instead, so it is exempt)
+		if (this.target !== Targets.EXTENSION_POPUP && !sharingEmitter.state) return
 		const {detail: connection} = e
 		const {state, workerIdx} = connection
 		const existingState = this.connectionMap[workerIdx]?.state || -1

--- a/ui/src/utils/wasmInterface.ts
+++ b/ui/src/utils/wasmInterface.ts
@@ -197,6 +197,13 @@ export class WasmInterface {
 			readyEmitter.update(this.ready)
 			this.wasmClient.stop()
 			sharingEmitter.update(false)
+			// mark every connection disconnected so arcs and the helping count
+			// clear on stop instead of lingering until the workers wind down.
+			// (emitting an empty array would NOT clear arcs: useGeo's updateArcs
+			// only removes arcs for connections it sees with state -1)
+			this.connectionMap = {}
+			this.connections = this.connections.map(c => ({...c, state: -1}))
+			connectionsEmitter.update(this.connections)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Follow-up polish to #370, fixing two bugs in the simple embed layout:

**1. Widget width changed when toggling sharing on/off.**
Root cause: the `<browsers-unbounded>` custom element is unregistered (`display: inline`), so in shrink-to-fit host contexts (flex/inline-block slots) `AppWrapper`'s `width: 100%` collapses to max-content — which differs between the off pill and the on panel. Fix:
- `AppWrapper` gets a definite `width: 344px` for the simple layout (other layouts unchanged)
- The off pill stretches to the card interior (`align-self: stretch`, heart+label left / switch right), so both control bars are always the same 270px width in every state and host context

**2. Toggling off left stale state on the globe.**
- The "Waiting for connections…" notification has no auto-hide and was only cleared when the *next* notification arrived — a quick on→off before any peer connected left it up forever. The notification component now subscribes to `sharingEmitter` and flushes its queue + pending timers when sharing stops.
- Arcs and the helping count also lingered, since `stop()` never reset connection state. `stop()` now re-emits all connections with `state: -1` — which is what actually unwinds arcs through `useGeo`'s diff (emitting an empty array removes nothing) — so the globe clears immediately on off.

## Test plan
- `cd ui && yarn && yarn dev:web`, set `data-layout="simple" data-mock="true"` in `ui/public/index.html` (ships untouched)
- Width: card stays 344px and both bars 270px in off/on states — including with `document.body.style.display = 'inline-flex'` (shrink-to-fit host simulation)
- Toggle on → "Waiting for connections…" appears → toggle off immediately → pill clears
- Toggle on, let mock connections build arcs/hearts/count → toggle off → globe and notifications fully clear
- Other layouts unaffected (width change is gated to `Layouts.SIMPLE`; notification flush is driven by `sharingEmitter`, which matches existing toast behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications are now automatically dismissed when sharing ends, including queued notifications.
  * Connection statuses now correctly reset when stopping a session.
* **Style**
  * Improved spacing and alignment in the sharing-disabled panel.
  * The simple layout now maintains a consistent width and better fills its available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->