### PR TITLE
egress: attribute traffic per donor country and per session

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -229,6 +229,15 @@ func ParseSubprotocolsRequest(s []string) (csid string, version string, ok bool)
 // ParseSubprotocolsRequestWithCountry additionally returns the consumer country
 // when the peer supplied one; country is "" for the 3-element form.
 func ParseSubprotocolsRequestWithCountry(s []string) (csid, version, country string, ok bool) {
+	// Validate the magic cookie rather than only the arity. The previous parser
+	// checked length alone, so any 3-element Sec-Websocket-Protocol list parsed
+	// as ok and the mismatch surfaced later as a vaguer websocket.Accept failure.
+	// The cookie is a single shared constant that has never changed, so nothing
+	// that has ever spoken this protocol is affected by rejecting a wrong one.
+	if len(s) < 1 || s[0] != subprotocolsMagicCookie {
+		return "", "", "", false
+	}
+
 	switch len(s) {
 	case 3:
 		return s[1], s[2], "", true

--- a/common/resource.go
+++ b/common/resource.go
@@ -192,11 +192,51 @@ func NewSubprotocolsRequest(csid, version string) []string {
 	return []string{subprotocolsMagicCookie, csid, version}
 }
 
-func ParseSubprotocolsRequest(s []string) (csid string, version string, ok bool) {
-	if len(s) != 3 {
-		return "", "", false
+// NewSubprotocolsRequestWithCountry is NewSubprotocolsRequest plus an optional
+// consumer country, so the egress can attribute a session to the region it is
+// actually serving. The egress otherwise only ever sees the *donor's* address:
+// the consumer sits behind the donor's WebRTC data channel, so nothing about
+// where a session terminates is observable server-side without being told.
+//
+// Deliberately a separate constructor rather than a new parameter on
+// NewSubprotocolsRequest: callers that have no country to offer, or that choose
+// not to disclose one, should keep emitting the 3-element form and stay
+// byte-identical on the wire to every release before this one.
+//
+// Privacy note: this travels consumer -> donor -> egress, so a donor forwarding
+// it can read it. A donor already learns far more than a country code from ICE
+// candidate exchange (the consumer's public IP), so the marginal disclosure to
+// the donor is small — but it is not zero, and an empty country is always a
+// valid choice. Pass a country only when the consumer has consented to it.
+func NewSubprotocolsRequestWithCountry(csid, version, country string) []string {
+	if country == "" {
+		return NewSubprotocolsRequest(csid, version)
 	}
-	return s[1], s[2], true
+	return []string{subprotocolsMagicCookie, csid, version, country}
+}
+
+// ParseSubprotocolsRequest accepts both the 3-element form and the 4-element
+// form that carries a consumer country, so a new egress keeps serving old
+// donors. Because the field is trailing and optional, an old egress also keeps
+// serving new donors only if it tolerates the extra element — it does not (it
+// requires exactly 3), so donors must not emit the 4-element form until the
+// egress fleet has been upgraded past this commit.
+func ParseSubprotocolsRequest(s []string) (csid string, version string, ok bool) {
+	csid, version, _, ok = ParseSubprotocolsRequestWithCountry(s)
+	return csid, version, ok
+}
+
+// ParseSubprotocolsRequestWithCountry additionally returns the consumer country
+// when the peer supplied one; country is "" for the 3-element form.
+func ParseSubprotocolsRequestWithCountry(s []string) (csid, version, country string, ok bool) {
+	switch len(s) {
+	case 3:
+		return s[1], s[2], "", true
+	case 4:
+		return s[1], s[2], s[3], true
+	default:
+		return "", "", "", false
+	}
 }
 
 func NewSubprotocolsResponse() []string {

--- a/common/resource.go
+++ b/common/resource.go
@@ -242,10 +242,42 @@ func ParseSubprotocolsRequestWithCountry(s []string) (csid, version, country str
 	case 3:
 		return s[1], s[2], "", true
 	case 4:
-		return s[1], s[2], s[3], true
+		return s[1], s[2], normalizeCountry(s[3]), true
 	default:
 		return "", "", "", false
 	}
+}
+
+// normalizeCountry bounds an untrusted country to a two-letter ISO-3166-1 alpha-2
+// code, uppercased, or returns "" to mean "not supplied".
+//
+// This value arrives in a client-controlled Sec-Websocket-Protocol element and
+// flows into span attributes. Passing it through verbatim would let any peer
+// mint arbitrarily long or arbitrarily many distinct attribute values, which is
+// a cardinality and payload amplification attack on the tracing backend rather
+// than merely bad data. Dropping unparseable values is deliberate: a session
+// labelled "not supplied" is a small loss, whereas a session that can label
+// itself anything is a liability.
+//
+// Rejecting rather than truncating, because a truncated garbage value is
+// indistinguishable from a real code and would silently pollute the same
+// dimension.
+func normalizeCountry(country string) string {
+	if len(country) != 2 {
+		return ""
+	}
+	out := []byte(country)
+	for i, c := range out {
+		switch {
+		case c >= 'a' && c <= 'z':
+			out[i] = c - ('a' - 'A')
+		case c >= 'A' && c <= 'Z':
+			// already canonical
+		default:
+			return ""
+		}
+	}
+	return string(out)
 }
 
 func NewSubprotocolsResponse() []string {

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -87,6 +88,38 @@ func TestParseSubprotocolsRequest_RejectsWrongMagicCookie(t *testing.T) {
 	}
 	if _, _, _, ok := ParseSubprotocolsRequestWithCountry(NewSubprotocolsRequestWithCountry("csid", "v2.3.1", "CN")); !ok {
 		t.Error("rejected our own 4-element request")
+	}
+}
+
+// The country element is client-controlled and flows into span attributes, so an
+// unbounded value would be a cardinality/payload attack on the tracing backend
+// rather than just bad data. Anything that isn't a 2-letter ASCII code must come
+// back as "not supplied" rather than truncated, since a truncated garbage value
+// is indistinguishable from a real code.
+func TestParseSubprotocolsRequestWithCountry_BoundsUntrustedCountry(t *testing.T) {
+	cookie := NewSubprotocolsRequest("csid", "v2.3.1")[0]
+
+	for _, tc := range []struct{ in, want string }{
+		{"CN", "CN"},
+		{"cn", "CN"},                    // normalized
+		{"Cn", "CN"},                    // normalized
+		{"", ""},                        // absent
+		{"C", ""},                       // too short
+		{"CHN", ""},                     // too long
+		{"C1", ""},                      // digit
+		{"C-", ""},                      // punctuation
+		{"日本", ""},                      // multibyte: 2 runes but 6 bytes
+		{strings.Repeat("A", 4096), ""}, // payload amplification attempt
+		{"cn\nX-Injected: 1", ""},       // header-injection shaped
+	} {
+		_, _, got, ok := ParseSubprotocolsRequestWithCountry([]string{cookie, "csid", "v2.3.1", tc.in})
+		if !ok {
+			t.Errorf("country %q: parse failed outright; the request should still be accepted with no country", tc.in)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("country %q: got %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The 3-element form is what every release before the consumer-country field
+// emits, so a new egress must keep parsing it. This is the compatibility
+// direction that actually matters in production: donors (browser widgets) are
+// upgraded independently of, and typically later than, the egress fleet.
+func TestParseSubprotocolsRequest_ThreeElementFormStillParses(t *testing.T) {
+	in := NewSubprotocolsRequest("csid-abc", "v2.3.1")
+	if len(in) != 3 {
+		t.Fatalf("NewSubprotocolsRequest must stay 3 elements on the wire, got %d: %v", len(in), in)
+	}
+
+	csid, version, ok := ParseSubprotocolsRequest(in)
+	if !ok {
+		t.Fatal("ParseSubprotocolsRequest rejected the legacy 3-element form")
+	}
+	if csid != "csid-abc" || version != "v2.3.1" {
+		t.Fatalf("got csid=%q version=%q", csid, version)
+	}
+
+	csid, version, country, ok := ParseSubprotocolsRequestWithCountry(in)
+	if !ok || csid != "csid-abc" || version != "v2.3.1" {
+		t.Fatalf("got csid=%q version=%q ok=%v", csid, version, ok)
+	}
+	if country != "" {
+		t.Fatalf("legacy form must yield an empty country, got %q", country)
+	}
+}
+
+func TestParseSubprotocolsRequest_FourElementFormCarriesCountry(t *testing.T) {
+	in := NewSubprotocolsRequestWithCountry("csid-xyz", "v2.3.1", "CN")
+	if len(in) != 4 {
+		t.Fatalf("expected 4 elements, got %d: %v", len(in), in)
+	}
+
+	csid, version, country, ok := ParseSubprotocolsRequestWithCountry(in)
+	if !ok {
+		t.Fatal("ParseSubprotocolsRequestWithCountry rejected the 4-element form")
+	}
+	if csid != "csid-xyz" || version != "v2.3.1" || country != "CN" {
+		t.Fatalf("got csid=%q version=%q country=%q", csid, version, country)
+	}
+
+	// The 3-return shim must tolerate the longer form too, so callers that don't
+	// care about country keep working against new donors.
+	csid, version, ok = ParseSubprotocolsRequest(in)
+	if !ok || csid != "csid-xyz" || version != "v2.3.1" {
+		t.Fatalf("3-return shim mishandled the 4-element form: csid=%q version=%q ok=%v", csid, version, ok)
+	}
+}
+
+// An empty country must produce a byte-identical request to the legacy
+// constructor. Otherwise "decline to disclose a country" would still be
+// distinguishable on the wire from "an old client", which defeats the point.
+func TestNewSubprotocolsRequestWithCountry_EmptyCountryIsWireIdentical(t *testing.T) {
+	legacy := NewSubprotocolsRequest("csid-1", "v2.3.1")
+	withEmpty := NewSubprotocolsRequestWithCountry("csid-1", "v2.3.1", "")
+	if !reflect.DeepEqual(legacy, withEmpty) {
+		t.Fatalf("empty country changed the wire form:\n legacy=%v\n  empty=%v", legacy, withEmpty)
+	}
+}
+
+func TestParseSubprotocolsRequest_RejectsWrongArity(t *testing.T) {
+	for _, in := range [][]string{
+		nil,
+		{},
+		{"magic"},
+		{"magic", "csid"},
+		{"magic", "csid", "version", "CN", "extra"},
+	} {
+		if _, _, ok := ParseSubprotocolsRequest(in); ok {
+			t.Errorf("ParseSubprotocolsRequest(%v) = ok, want rejected", in)
+		}
+		if _, _, _, ok := ParseSubprotocolsRequestWithCountry(in); ok {
+			t.Errorf("ParseSubprotocolsRequestWithCountry(%v) = ok, want rejected", in)
+		}
+	}
+}

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -65,6 +65,31 @@ func TestNewSubprotocolsRequestWithCountry_EmptyCountryIsWireIdentical(t *testin
 	}
 }
 
+// A correctly-sized list bearing the wrong cookie must be rejected here rather
+// than passed through to fail later inside websocket.Accept with a vaguer error.
+func TestParseSubprotocolsRequest_RejectsWrongMagicCookie(t *testing.T) {
+	for _, in := range [][]string{
+		{"not-the-cookie", "csid", "v2.3.1"},
+		{"not-the-cookie", "csid", "v2.3.1", "CN"},
+		{"", "csid", "v2.3.1"},
+	} {
+		if _, _, ok := ParseSubprotocolsRequest(in); ok {
+			t.Errorf("ParseSubprotocolsRequest(%v) = ok, want rejected on cookie mismatch", in)
+		}
+		if _, _, _, ok := ParseSubprotocolsRequestWithCountry(in); ok {
+			t.Errorf("ParseSubprotocolsRequestWithCountry(%v) = ok, want rejected on cookie mismatch", in)
+		}
+	}
+
+	// And the constructors' own output must still be accepted.
+	if _, _, ok := ParseSubprotocolsRequest(NewSubprotocolsRequest("csid", "v2.3.1")); !ok {
+		t.Error("rejected our own 3-element request")
+	}
+	if _, _, _, ok := ParseSubprotocolsRequestWithCountry(NewSubprotocolsRequestWithCountry("csid", "v2.3.1", "CN")); !ok {
+		t.Error("rejected our own 4-element request")
+	}
+}
+
 func TestParseSubprotocolsRequest_RejectsWrongArity(t *testing.T) {
 	for _, in := range [][]string{
 		nil,

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -143,7 +143,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	// The donor country is not known until the peer address resolves after
 	// Accept, so it is attached further down.
 	_, span := tracer.Start(r.Context(), spanWebSocketSession, oteltrace.WithAttributes(
-		attribute.String(attrConsumerSessionID, consumerSessionID),
+		attribute.String(attrConsumerSessionID, csidPrefix(consumerSessionID)),
 		attribute.String(attrProtocolVersion, version),
 	))
 	if consumerCountry != "" {
@@ -213,7 +213,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer wspconn.Close()
-	slog.Debug("Accepted a new WebSocket connection!", "csid", consumerSessionID, "donor_country", donorCC, "total", atomic.AddUint64(&nClients, 1))
+	slog.Debug("Accepted a new WebSocket connection!", "csid", csidPrefix(consumerSessionID), "donor_country", donorCC, "total", atomic.AddUint64(&nClients, 1))
 
 	conn, err := l.connectionManager.createOrMigrate(consumerSessionID, &wspconn)
 	if err != nil {

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -154,8 +154,14 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	// actually carry traffic?", which the fleet-wide counters cannot.
 	var sessionBytes int64
 	var sessionStreams int64
+	var keepaliveFailed atomic.Bool
 	teardownReason := "websocket_closed"
 	defer func() {
+		// A wedged peer is distinguishable from a disconnected one only by an
+		// unanswered keepalive, so let that outrank the generic close reason.
+		if keepaliveFailed.Load() {
+			teardownReason = "keepalive_timeout"
+		}
 		span.SetAttributes(
 			attribute.Int64(attrIngressBytes, atomic.LoadInt64(&sessionBytes)),
 			attribute.Int64(attrQUICStreams, atomic.LoadInt64(&sessionStreams)),
@@ -187,6 +193,11 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	tcpAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
 	if err != nil {
+		// c is already accepted at this point but wspconn — and its deferred
+		// Close — is not built until below, so this path leaked the connection
+		// and its goroutines. Pre-existing on main; closing it here since this
+		// branch is being touched anyway.
+		c.CloseNow()
 		teardownReason = "peer_addr_unresolvable"
 		span.RecordError(err)
 		slog.Debug("Error resolving TCPAddr", "error", err)
@@ -203,13 +214,14 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	defer atomic.AddInt64(&stats.clients, -1)
 
 	wspconn := errorlessWebSocketPacketConn{
-		w:            c,
-		addr:         common.DebugAddr(fmt.Sprintf("WebSocket connection %v", uuid.NewString())),
-		keepalive:    websocketKeepalive,
-		tcpAddr:      tcpAddr,
-		readError:    make(chan error),
-		stats:        stats,
-		sessionBytes: &sessionBytes,
+		w:               c,
+		addr:            common.DebugAddr(fmt.Sprintf("WebSocket connection %v", uuid.NewString())),
+		keepalive:       websocketKeepalive,
+		tcpAddr:         tcpAddr,
+		readError:       make(chan error),
+		stats:           stats,
+		sessionBytes:    &sessionBytes,
+		keepaliveFailed: &keepaliveFailed,
 	}
 
 	defer wspconn.Close()

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -43,9 +43,6 @@ var nQUICStreams uint64
 // nQUICConnections is the number of open QUIC connections
 var nQUICConnections uint64
 
-// nIngressBytes is the number of bytes received over all WebSocket connections since the last otel measurement callback
-var nIngressBytes uint64
-
 var nClientsCounter metric.Int64ObservableUpDownCounter
 var nQUICStreamsCounter metric.Int64ObservableUpDownCounter
 var nQUICConnectionsCounter metric.Int64ObservableUpDownCounter
@@ -289,13 +286,22 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (net.Listener, error) {
-	closeFuncMetric := telemetry.EnableOTELMetrics(ctx)
+	closeFuncMetrics := telemetry.EnableOTELMetrics(ctx)
 
 	// Tracing powers the per-session spans in handleWebsocket. Enabled alongside
 	// metrics rather than instead of them: the counters answer "is the fleet
 	// carrying traffic", the spans answer "did this particular consumer session
 	// get served", and neither substitutes for the other.
-	telemetry.EnableOTELTracing(ctx)
+	closeFuncTracing := telemetry.EnableOTELTracing(ctx)
+
+	// Shut both down together on listener close. Dropping the tracing shutdown
+	// would leak the provider and discard whatever spans were still buffered,
+	// which on a low-traffic egress could be most of them.
+	closeFuncMetric := func(ctx context.Context) error {
+		errMetrics := closeFuncMetrics(ctx)
+		errTracing := closeFuncTracing(ctx)
+		return errors.Join(errMetrics, errTracing)
+	}
 
 	// Geolocation is optional; without GEODB every series is labelled "unknown".
 	initDonorGeo()

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -16,8 +16,11 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/getlantern/broflake/common"
 	"github.com/getlantern/telemetry"
@@ -47,6 +50,25 @@ var nClientsCounter metric.Int64ObservableUpDownCounter
 var nQUICStreamsCounter metric.Int64ObservableUpDownCounter
 var nQUICConnectionsCounter metric.Int64ObservableUpDownCounter
 var nIngressBytesCounter metric.Int64ObservableUpDownCounter
+
+// tracer emits one span per WebSocket session. Sessions are the unit an
+// operator actually asks about ("did this consumer get served?"), and a span
+// per session carries the consumer session ID without the unbounded-cardinality
+// problem that the same ID would cause as a metric label.
+var tracer = otel.Tracer("github.com/getlantern/broflake/egress")
+
+// Span and attribute names for the per-session spans.
+const (
+	spanWebSocketSession = "egress.websocket_session"
+
+	attrConsumerSessionID = "broflake.consumer_session_id"
+	attrDonorCountry      = "broflake.donor_country"
+	attrConsumerCountry   = "broflake.consumer_country"
+	attrIngressBytes      = "broflake.session_ingress_bytes"
+	attrQUICStreams       = "broflake.session_quic_streams"
+	attrTeardownReason    = "broflake.teardown_reason"
+	attrProtocolVersion   = "broflake.protocol_version"
+)
 
 type proxyListener struct {
 	net.Listener
@@ -88,7 +110,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	consumerSessionID, version, ok := common.ParseSubprotocolsRequest(subprotocols)
+	consumerSessionID, version, consumerCountry, ok := common.ParseSubprotocolsRequestWithCountry(subprotocols)
 	if !ok {
 		slog.Debug("Refused WebSocket connection, missing subprotocols")
 		return
@@ -114,6 +136,42 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// One span per WebSocket session. Started before websocket.Accept so that a
+	// failed accept is still visible rather than vanishing, and parented to the
+	// otelhttp request span. We discard the returned context deliberately: the
+	// QUIC stream goroutine below runs on its own lifecycle (wsContext), and
+	// threading a request-scoped context into it would tie stream teardown to
+	// this handler's span rather than to the migration window.
+	//
+	// The donor country is not known until the peer address resolves after
+	// Accept, so it is attached further down.
+	_, span := tracer.Start(r.Context(), spanWebSocketSession, oteltrace.WithAttributes(
+		attribute.String(attrConsumerSessionID, consumerSessionID),
+		attribute.String(attrProtocolVersion, version),
+	))
+	if consumerCountry != "" {
+		span.SetAttributes(attribute.String(attrConsumerCountry, consumerCountry))
+	}
+
+	// Per-session counters. These are the numbers that answer "did this session
+	// actually carry traffic?", which the fleet-wide counters cannot.
+	var sessionBytes int64
+	var sessionStreams int64
+	teardownReason := "websocket_closed"
+	defer func() {
+		span.SetAttributes(
+			attribute.Int64(attrIngressBytes, atomic.LoadInt64(&sessionBytes)),
+			attribute.Int64(attrQUICStreams, atomic.LoadInt64(&sessionStreams)),
+			attribute.String(attrTeardownReason, teardownReason),
+		)
+		// A session that moved no bytes is the failure mode worth finding, so
+		// mark it on the span rather than leaving every session status Unset.
+		if atomic.LoadInt64(&sessionBytes) == 0 {
+			span.SetStatus(otelcodes.Error, "session carried no ingress bytes")
+		}
+		span.End()
+	}()
+
 	c, err := websocket.Accept(
 		w,
 		r,
@@ -124,29 +182,46 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if err != nil {
+		teardownReason = "websocket_accept_failed"
+		span.RecordError(err)
 		slog.Debug("Error accepting WebSocket connection", "error", err)
 		return
 	}
 
 	tcpAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
 	if err != nil {
+		teardownReason = "peer_addr_unresolvable"
+		span.RecordError(err)
 		slog.Debug("Error resolving TCPAddr", "error", err)
 		return
 	}
 
+	// Resolved once per session, never per packet: this is a database lookup and
+	// the read path is hot.
+	donorCC := donorCountry(tcpAddr)
+	stats := statsFor(donorCC)
+	span.SetAttributes(attribute.String(attrDonorCountry, donorCC))
+
+	atomic.AddInt64(&stats.clients, 1)
+	defer atomic.AddInt64(&stats.clients, -1)
+
 	wspconn := errorlessWebSocketPacketConn{
-		w:         c,
-		addr:      common.DebugAddr(fmt.Sprintf("WebSocket connection %v", uuid.NewString())),
-		keepalive: websocketKeepalive,
-		tcpAddr:   tcpAddr,
-		readError: make(chan error),
+		w:            c,
+		addr:         common.DebugAddr(fmt.Sprintf("WebSocket connection %v", uuid.NewString())),
+		keepalive:    websocketKeepalive,
+		tcpAddr:      tcpAddr,
+		readError:    make(chan error),
+		stats:        stats,
+		sessionBytes: &sessionBytes,
 	}
 
 	defer wspconn.Close()
-	slog.Debug("Accepted a new WebSocket connection!", "csid", consumerSessionID, "total", atomic.AddUint64(&nClients, 1))
+	slog.Debug("Accepted a new WebSocket connection!", "csid", consumerSessionID, "donor_country", donorCC, "total", atomic.AddUint64(&nClients, 1))
 
 	conn, err := l.connectionManager.createOrMigrate(consumerSessionID, &wspconn)
 	if err != nil {
+		teardownReason = "create_or_migrate_failed"
+		span.RecordError(err)
 		slog.Debug("createOrMigrate error, closing!", "error", err)
 		return
 	}
@@ -178,6 +253,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 				close(QUICLayerError)
 				return
 			}
+			atomic.AddInt64(&sessionStreams, 1)
 			slog.Debug("Accepted a new QUIC stream!", "total", atomic.AddUint64(&nQUICStreams, 1))
 
 			l.connections <- common.QUICStreamNetConn{
@@ -214,6 +290,16 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (net.Listener, error) {
 	closeFuncMetric := telemetry.EnableOTELMetrics(ctx)
+
+	// Tracing powers the per-session spans in handleWebsocket. Enabled alongside
+	// metrics rather than instead of them: the counters answer "is the fleet
+	// carrying traffic", the spans answer "did this particular consumer session
+	// get served", and neither substitutes for the other.
+	telemetry.EnableOTELTracing(ctx)
+
+	// Geolocation is optional; without GEODB every series is labelled "unknown".
+	initDonorGeo()
+
 	m := otel.Meter("github.com/getlantern/broflake/egress")
 	var err error
 	nClientsCounter, err = m.Int64ObservableUpDownCounter("concurrent-websockets")
@@ -242,19 +328,28 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 
 	_, err = m.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
-			c := atomic.LoadUint64(&nClients)
-			o.ObserveInt64(nClientsCounter, int64(c))
-
 			q := atomic.LoadUint64(&nQUICConnections)
 			o.ObserveInt64(nQUICConnectionsCounter, int64(q))
 
 			s := atomic.LoadUint64(&nQUICStreams)
 			o.ObserveInt64(nQUICStreamsCounter, int64(s))
 
-			b := atomic.LoadUint64(&nIngressBytes)
-			o.ObserveInt64(nIngressBytesCounter, int64(b))
-
-			atomic.StoreUint64(&nIngressBytes, uint64(0))
+			// concurrent-websockets and ingress-bytes are now reported per donor
+			// country rather than as a single unlabelled series. Totals are
+			// preserved: summing across the country dimension gives the same
+			// number the unlabelled series carried, so queries that don't group
+			// by country are unaffected. Anything that reduced with max/latest
+			// instead of sum needs a spaceAggregation of sum to stay correct.
+			//
+			// Note these counts come from per-session counters incremented and
+			// decremented exactly once around the handler, whereas the legacy
+			// global nClients decrements in the conn's Close(). nClients is now
+			// only used for the log lines.
+			eachCountryStats(func(cc string, clients, ingressBytes int64) {
+				attrs := metric.WithAttributes(attribute.String(attrDonorCountry, cc))
+				o.ObserveInt64(nClientsCounter, clients, attrs)
+				o.ObserveInt64(nIngressBytesCounter, ingressBytes, attrs)
+			})
 			return nil
 		},
 		nClientsCounter,

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -347,6 +347,14 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 			// by country are unaffected. Anything that reduced with max/latest
 			// instead of sum needs a spaceAggregation of sum to stay correct.
 			//
+			// CAUTION when summing: these datapoints also carry a `via` resource
+			// attribute identifying the telemetry collector that forwarded them
+			// (ops-0/1/2), and the same datapoint arrives once per collector. The
+			// egress is a single instance — instance.id has exactly one value,
+			// unbounded-us-linode-nj.iantem.io — so summing across `via` triples
+			// the real figure. Sum across donor_country, but filter or average
+			// across `via`.
+			//
 			// Note these counts come from per-session counters incremented and
 			// decremented exactly once around the handler, whereas the legacy
 			// global nClients decrements in the conn's Close(). nClients is now

--- a/egress/geo.go
+++ b/egress/geo.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/geo"
@@ -25,7 +26,30 @@ const unknownCountry = "unknown"
 // unchanged when GEODB is unset — every series is simply labelled
 // unknownCountry. Geolocation is observability, never a gate on serving
 // traffic.
-var donorGeo geo.CountryLookup = geo.NoLookup{}
+//
+// Held in an atomic pointer rather than a plain package variable. initDonorGeo's
+// sync.Once already makes the write happen once, before the first listener serves
+// anything, so today every read is ordered after it by a happens-before chain
+// through goroutine creation — but that argument is subtle, invisible at the read
+// site, and silently broken by any future caller that writes this from elsewhere.
+// donorCountry runs once per WebSocket session rather than per packet, so an
+// atomic load costs nothing worth measuring and makes the safety local.
+var donorGeo atomic.Pointer[geo.CountryLookup]
+
+func init() {
+	var l geo.CountryLookup = geo.NoLookup{}
+	donorGeo.Store(&l)
+}
+
+// setDonorGeo swaps in a new lookup.
+func setDonorGeo(l geo.CountryLookup) {
+	donorGeo.Store(&l)
+}
+
+// lookupDonorGeo returns the current lookup, never nil (init seeds NoLookup).
+func lookupDonorGeo() geo.CountryLookup {
+	return *donorGeo.Load()
+}
 
 // initDonorGeoOnce guards initDonorGeo. NewListener is deliberately safe to call
 // more than once per process (multiple embedded listeners, graceful restarts,
@@ -58,7 +82,7 @@ func initDonorGeoLocked() {
 		slog.Debug(fmt.Sprintf("Cannot derive a database name from GEODB %q, donor country will be %q", geoDb, unknownCountry))
 		return
 	}
-	donorGeo = geo.FromWeb(geoDb, nameInTarball, 24*time.Hour, nameInTarball, geo.CountryCode)
+	setDonorGeo(geo.FromWeb(geoDb, nameInTarball, 24*time.Hour, nameInTarball, geo.CountryCode))
 	slog.Debug(fmt.Sprintf("Using %v to geolocate donors", geoDb))
 }
 
@@ -111,7 +135,7 @@ func donorCountry(addr net.Addr) string {
 	if !ok || tcpAddr == nil || tcpAddr.IP == nil {
 		return unknownCountry
 	}
-	if cc := donorGeo.CountryCode(tcpAddr.IP); cc != "" {
+	if cc := lookupDonorGeo().CountryCode(tcpAddr.IP); cc != "" {
 		return cc
 	}
 	return unknownCountry

--- a/egress/geo.go
+++ b/egress/geo.go
@@ -1,0 +1,70 @@
+package egress
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/getlantern/geo"
+)
+
+// unknownCountry labels traffic we could not geolocate. It is deliberately a
+// real value rather than an empty string: an absent attribute silently drops
+// the series out of grouped queries, which makes "we don't know" look identical
+// to "no traffic".
+const unknownCountry = "unknown"
+
+// donorGeo resolves the country of a connecting donor. It defaults to
+// geo.NoLookup, whose CountryCode always returns "", so the egress runs
+// unchanged when GEODB is unset — every series is simply labelled
+// unknownCountry. Geolocation is observability, never a gate on serving
+// traffic.
+var donorGeo geo.CountryLookup = geo.NoLookup{}
+
+// initDonorGeo configures donorGeo from the GEODB environment variable, which
+// should be a URL to a gzipped MaxMind tarball. Mirrors netstated's
+// configuration (see netstate/d/netstated.go) so operators have one convention
+// to learn rather than two.
+//
+// This intentionally does not block on geolookup.Ready(): the database download
+// can take a while, and until it lands CountryCode returns "" and connections
+// are labelled unknownCountry. Refusing to serve donors while a telemetry
+// database downloads would be the wrong trade.
+func initDonorGeo() {
+	geoDb := os.Getenv("GEODB")
+	if geoDb == "" {
+		slog.Debug("GEODB not specified, egress metrics will not carry donor country")
+		return
+	}
+
+	if _, err := url.ParseRequestURI(geoDb); err != nil {
+		slog.Debug(fmt.Sprintf("GEODB %q is not a valid URL, donor country will be %q", geoDb, unknownCountry))
+		return
+	}
+
+	// The geo API wants the tarball URL, the member filename, and a local cache
+	// path as three separate arguments; netstated derives the latter two from
+	// the first and we do the same for consistency.
+	nameInTarball := strings.ReplaceAll(path.Base(geoDb), ".tar.gz", "")
+	donorGeo = geo.FromWeb(geoDb, nameInTarball, 24*time.Hour, nameInTarball, geo.CountryCode)
+	slog.Debug(fmt.Sprintf("Using %v to geolocate donors", geoDb))
+}
+
+// donorCountry returns the ISO country code for a donor address, or
+// unknownCountry. Callers should resolve this once per WebSocket rather than
+// per packet: it is a database lookup, and the read path is hot.
+func donorCountry(addr net.Addr) string {
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok || tcpAddr == nil || tcpAddr.IP == nil {
+		return unknownCountry
+	}
+	if cc := donorGeo.CountryCode(tcpAddr.IP); cc != "" {
+		return cc
+	}
+	return unknownCountry
+}

--- a/egress/geo.go
+++ b/egress/geo.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getlantern/geo"
@@ -26,33 +27,80 @@ const unknownCountry = "unknown"
 // traffic.
 var donorGeo geo.CountryLookup = geo.NoLookup{}
 
+// initDonorGeoOnce guards initDonorGeo. NewListener is deliberately safe to call
+// more than once per process (multiple embedded listeners, graceful restarts,
+// tests), and without this each call would kick off another database download
+// and swap donorGeo out from under live connections.
+var initDonorGeoOnce sync.Once
+
 // initDonorGeo configures donorGeo from the GEODB environment variable, which
 // should be a URL to a gzipped MaxMind tarball. Mirrors netstated's
 // configuration (see netstate/d/netstated.go) so operators have one convention
-// to learn rather than two.
+// to learn rather than two. Safe to call repeatedly; only the first call acts.
 //
 // This intentionally does not block on geolookup.Ready(): the database download
 // can take a while, and until it lands CountryCode returns "" and connections
 // are labelled unknownCountry. Refusing to serve donors while a telemetry
 // database downloads would be the wrong trade.
 func initDonorGeo() {
+	initDonorGeoOnce.Do(initDonorGeoLocked)
+}
+
+func initDonorGeoLocked() {
 	geoDb := os.Getenv("GEODB")
 	if geoDb == "" {
 		slog.Debug("GEODB not specified, egress metrics will not carry donor country")
 		return
 	}
 
-	if _, err := url.ParseRequestURI(geoDb); err != nil {
-		slog.Debug(fmt.Sprintf("GEODB %q is not a valid URL, donor country will be %q", geoDb, unknownCountry))
+	nameInTarball, ok := dbNameFromURL(geoDb)
+	if !ok {
+		slog.Debug(fmt.Sprintf("Cannot derive a database name from GEODB %q, donor country will be %q", geoDb, unknownCountry))
 		return
 	}
-
-	// The geo API wants the tarball URL, the member filename, and a local cache
-	// path as three separate arguments; netstated derives the latter two from
-	// the first and we do the same for consistency.
-	nameInTarball := strings.ReplaceAll(path.Base(geoDb), ".tar.gz", "")
 	donorGeo = geo.FromWeb(geoDb, nameInTarball, 24*time.Hour, nameInTarball, geo.CountryCode)
 	slog.Debug(fmt.Sprintf("Using %v to geolocate donors", geoDb))
+}
+
+// dbNameFromURL derives the MaxMind member filename (also used as the local
+// cache path) from a GEODB URL.
+//
+// It reads the URL's *path* rather than the raw string, because MaxMind's own
+// download endpoint carries the edition in the query rather than the path:
+//
+//	https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=...&suffix=tar.gz
+//
+// A naive path.Base over the whole URL folds the query string into the filename
+// and yields an unusable member name and cache path. TrimSuffix rather than
+// ReplaceAll so a name containing ".tar.gz" mid-string survives intact.
+//
+// netstated derives these the naive way (netstate/d/netstated.go) and carries the
+// same latent problem; it happens to work there only because its GEODB is a plain
+// .tar.gz URL.
+func dbNameFromURL(geoDb string) (string, bool) {
+	// url.Parse rather than url.ParseRequestURI: the latter is defined over
+	// request URIs, which by construction have no fragment, so it leaves "#frag"
+	// embedded in Path. url.Parse splits the fragment off properly, at the cost
+	// of also accepting relative references — hence the explicit scheme/host
+	// check to keep rejecting bare filenames.
+	u, err := url.Parse(geoDb)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", false
+	}
+
+	// Fall back to the edition_id query parameter, which is how the MaxMind
+	// permalink names the database when the path cannot.
+	base := path.Base(u.Path)
+	if editionID := u.Query().Get("edition_id"); editionID != "" {
+		base = editionID
+	}
+
+	name := strings.TrimSuffix(base, ".tar.gz")
+	switch name {
+	case "", ".", "/", "..":
+		return "", false
+	}
+	return name, true
 }
 
 // donorCountry returns the ISO country code for a donor address, or

--- a/egress/migration_test.go
+++ b/egress/migration_test.go
@@ -389,4 +389,3 @@ func generateTestCert() {
 		PrivateKey:  priv,
 	}
 }
-

--- a/egress/stats.go
+++ b/egress/stats.go
@@ -5,6 +5,18 @@ import (
 	"sync/atomic"
 )
 
+// csidPrefix shortens a consumer session ID for telemetry. Mirrors the helper of
+// the same name in clientcore/jit_egress_consumer.go, whose comment states the
+// intent: enough to correlate a session within a time window "without leaking the
+// full session identifier". Eight characters is ample against the low tens of
+// concurrent sessions this fleet carries, and nothing joins on the full value.
+func csidPrefix(csid string) string {
+	if len(csid) <= 8 {
+		return csid
+	}
+	return csid[:8]
+}
+
 // countryStats accumulates per-donor-country counters. Each live WebSocket holds
 // a pointer to the entry for its own country, so the read path does one atomic
 // add against memory it already has rather than taking a lock or hashing a map

--- a/egress/stats.go
+++ b/egress/stats.go
@@ -25,11 +25,21 @@ var (
 )
 
 // statsFor returns the counter block for a country, creating it on first use.
-// Entries are never removed: the set of countries that have ever connected is
-// small and bounded, and keeping them means a country that drops to zero
-// clients keeps reporting 0 instead of vanishing from the series.
+// Entries are never removed — the set of countries that have ever connected is
+// small and bounded, so reclaiming them would buy nothing — but note that a
+// retained entry is not the same as a retained series: eachCountryStats skips
+// countries that are fully idle for an interval, so a country that drops to zero
+// clients does stop reporting until it next sees traffic. Only unknownCountry is
+// guaranteed to report every interval.
 func statsFor(cc string) *countryStats {
-	if cc == "" {
+	// Both the empty string and the literal unknownCountry route to the same
+	// block. donorCountry never returns "" — it returns unknownCountry — so
+	// without that second case the map would gain an "unknown" key while
+	// eachCountryStats also appends its own unknownCountry row, emitting two
+	// observations with an identical donor_country attribute in a single otel
+	// callback. That is a duplicate series, and the real traffic would land in
+	// the map entry while the always-reported row sat at zero.
+	if cc == "" || cc == unknownCountry {
 		return unknownCCs
 	}
 	statsMx.Lock()

--- a/egress/stats.go
+++ b/egress/stats.go
@@ -1,0 +1,76 @@
+package egress
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// countryStats accumulates per-donor-country counters. Each live WebSocket holds
+// a pointer to the entry for its own country, so the read path does one atomic
+// add against memory it already has rather than taking a lock or hashing a map
+// key per packet.
+type countryStats struct {
+	// clients is the number of currently open WebSockets from this country.
+	clients int64
+	// ingressBytes is bytes received from this country since the last otel
+	// callback, which resets it — matching the pre-existing semantics of the
+	// global nIngressBytes it replaces.
+	ingressBytes int64
+}
+
+var (
+	statsMx    sync.Mutex
+	statsByCC  = map[string]*countryStats{}
+	unknownCCs = &countryStats{}
+)
+
+// statsFor returns the counter block for a country, creating it on first use.
+// Entries are never removed: the set of countries that have ever connected is
+// small and bounded, and keeping them means a country that drops to zero
+// clients keeps reporting 0 instead of vanishing from the series.
+func statsFor(cc string) *countryStats {
+	if cc == "" {
+		return unknownCCs
+	}
+	statsMx.Lock()
+	defer statsMx.Unlock()
+	s, ok := statsByCC[cc]
+	if !ok {
+		s = &countryStats{}
+		statsByCC[cc] = s
+	}
+	return s
+}
+
+// eachCountryStats calls f for every known country. It snapshots under the lock
+// so the otel callback never holds statsMx while observing.
+func eachCountryStats(f func(cc string, clients, ingressBytes int64)) {
+	type row struct {
+		cc string
+		s  *countryStats
+	}
+	statsMx.Lock()
+	rows := make([]row, 0, len(statsByCC)+1)
+	for cc, s := range statsByCC {
+		rows = append(rows, row{cc, s})
+	}
+	statsMx.Unlock()
+	rows = append(rows, row{unknownCountry, unknownCCs})
+
+	for _, r := range rows {
+		clients := atomic.LoadInt64(&r.s.clients)
+		// Swap rather than load-then-store: a concurrent read adding bytes
+		// between the two would otherwise be silently discarded.
+		bytes := atomic.SwapInt64(&r.s.ingressBytes, 0)
+		// Skip countries that are entirely idle this interval so a long tail of
+		// historical countries doesn't inflate the series count — but never skip
+		// unknownCountry, so at least one series is always reported. Emitting
+		// nothing at all would make "no donors connected" indistinguishable from
+		// "the egress stopped reporting", which is precisely the outage we most
+		// need to be able to see.
+		if clients == 0 && bytes == 0 && r.cc != unknownCountry {
+			continue
+		}
+		f(r.cc, clients, bytes)
+	}
+}

--- a/egress/stats_test.go
+++ b/egress/stats_test.go
@@ -1,0 +1,160 @@
+package egress
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// resetStats isolates tests from each other and from any package-level state
+// left behind by the egress tests that spin up real listeners.
+func resetStats(t *testing.T) {
+	t.Helper()
+	statsMx.Lock()
+	statsByCC = map[string]*countryStats{}
+	statsMx.Unlock()
+	atomic.StoreInt64(&unknownCCs.clients, 0)
+	atomic.StoreInt64(&unknownCCs.ingressBytes, 0)
+}
+
+func collect(t *testing.T) map[string][2]int64 {
+	t.Helper()
+	out := map[string][2]int64{}
+	eachCountryStats(func(cc string, clients, bytes int64) {
+		out[cc] = [2]int64{clients, bytes}
+	})
+	return out
+}
+
+func TestStatsFor_SameCountrySharesOneEntry(t *testing.T) {
+	resetStats(t)
+	a, b := statsFor("CN"), statsFor("CN")
+	if a != b {
+		t.Fatal("statsFor returned distinct entries for the same country")
+	}
+	if statsFor("RU") == a {
+		t.Fatal("statsFor returned the same entry for different countries")
+	}
+}
+
+// An empty country must land in the unknown bucket rather than creating a
+// series keyed by the empty string, which reads as missing data in queries.
+func TestStatsFor_EmptyCountryGoesToUnknown(t *testing.T) {
+	resetStats(t)
+	if statsFor("") != unknownCCs {
+		t.Fatal("empty country did not map to the unknown bucket")
+	}
+}
+
+func TestEachCountryStats_ReportsPerCountryAndDrainsBytes(t *testing.T) {
+	resetStats(t)
+	cn, ru := statsFor("CN"), statsFor("RU")
+	atomic.AddInt64(&cn.clients, 2)
+	atomic.AddInt64(&cn.ingressBytes, 500)
+	atomic.AddInt64(&ru.clients, 1)
+	atomic.AddInt64(&ru.ingressBytes, 100)
+
+	got := collect(t)
+	if got["CN"] != [2]int64{2, 500} {
+		t.Errorf("CN = %v, want [2 500]", got["CN"])
+	}
+	if got["RU"] != [2]int64{1, 100} {
+		t.Errorf("RU = %v, want [1 100]", got["RU"])
+	}
+
+	// Bytes are interval-scoped and must drain, while client counts persist
+	// because they describe currently-open connections.
+	got = collect(t)
+	if got["CN"] != [2]int64{2, 0} {
+		t.Errorf("after drain CN = %v, want [2 0]", got["CN"])
+	}
+	if got["RU"] != [2]int64{1, 0} {
+		t.Errorf("after drain RU = %v, want [1 0]", got["RU"])
+	}
+}
+
+// Idle countries are skipped to bound series count, but "unknown" must always
+// report so the metric never disappears entirely. A vanished series is
+// indistinguishable from a dead exporter, which is the outage we most need to
+// be able to see.
+func TestEachCountryStats_AlwaysReportsUnknownEvenWhenIdle(t *testing.T) {
+	resetStats(t)
+	statsFor("CN") // known but idle
+
+	got := collect(t)
+	if _, ok := got[unknownCountry]; !ok {
+		t.Fatalf("unknown country series missing from an idle report: %v", got)
+	}
+	if _, ok := got["CN"]; ok {
+		t.Errorf("idle country CN should have been skipped, got %v", got["CN"])
+	}
+}
+
+// The read path adds bytes concurrently from many connections; the reporting
+// callback drains concurrently. No byte may be lost or double counted.
+func TestEachCountryStats_NoLostBytesUnderConcurrency(t *testing.T) {
+	resetStats(t)
+	const writers, perWriter = 8, 1000
+	cn := statsFor("CN")
+
+	var drained int64
+	stop := make(chan struct{})
+	var drainWg sync.WaitGroup
+	drainWg.Add(1)
+	go func() {
+		defer drainWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				eachCountryStats(func(cc string, _, bytes int64) {
+					if cc == "CN" {
+						atomic.AddInt64(&drained, bytes)
+					}
+				})
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				atomic.AddInt64(&cn.ingressBytes, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	drainWg.Wait()
+
+	// Final drain to sweep anything added after the last concurrent pass.
+	eachCountryStats(func(cc string, _, bytes int64) {
+		if cc == "CN" {
+			atomic.AddInt64(&drained, bytes)
+		}
+	})
+
+	if got := atomic.LoadInt64(&drained); got != writers*perWriter {
+		t.Fatalf("drained %d bytes, want %d (lost or double-counted)", got, writers*perWriter)
+	}
+}
+
+// With no GEODB configured the lookup is geo.NoLookup, whose CountryCode returns
+// "". That must surface as unknownCountry, never as an empty label.
+func TestDonorCountry_DefaultsToUnknown(t *testing.T) {
+	for _, addr := range []net.Addr{
+		&net.TCPAddr{IP: net.ParseIP("8.8.8.8"), Port: 443},
+		&net.TCPAddr{}, // no IP
+		nil,
+		&net.UDPAddr{IP: net.ParseIP("8.8.8.8")}, // not a TCPAddr
+	} {
+		if got := donorCountry(addr); got != unknownCountry {
+			t.Errorf("donorCountry(%v) = %q, want %q", addr, got, unknownCountry)
+		}
+	}
+}

--- a/egress/stats_test.go
+++ b/egress/stats_test.go
@@ -188,6 +188,52 @@ func TestEachCountryStats_NoLostBytesUnderConcurrency(t *testing.T) {
 	}
 }
 
+// Telemetry must never carry the full session identifier, matching the practice
+// established by csidPrefix in clientcore/jit_egress_consumer.go. Short inputs
+// pass through rather than panicking on the slice bound.
+func TestCsidPrefix(t *testing.T) {
+	for in, want := range map[string]string{
+		"":                                     "",
+		"abc":                                  "abc",
+		"12345678":                             "12345678",
+		"123456789":                            "12345678",
+		"0f8b2c1e-4a5d-4c9f-8e7a-1b2c3d4e5f60": "0f8b2c1e",
+	} {
+		if got := csidPrefix(in); got != want {
+			t.Errorf("csidPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// donorGeo is swapped behind an atomic pointer, and the read path must never see
+// a nil lookup — including before any listener has run initDonorGeo.
+func TestDonorGeoAccessors(t *testing.T) {
+	orig := lookupDonorGeo()
+	t.Cleanup(func() { setDonorGeo(orig) })
+
+	if lookupDonorGeo() == nil {
+		t.Fatal("lookupDonorGeo returned nil; init should seed geo.NoLookup")
+	}
+	if got := lookupDonorGeo().CountryCode(net.ParseIP("8.8.8.8")); got != "" {
+		t.Errorf("default lookup returned %q, want \"\" (NoLookup)", got)
+	}
+
+	setDonorGeo(stubCountryLookup{cc: "CN"})
+	if got := donorCountry(&net.TCPAddr{IP: net.ParseIP("8.8.8.8")}); got != "CN" {
+		t.Errorf("donorCountry after swap = %q, want CN", got)
+	}
+}
+
+// stubCountryLookup is a minimal geo.CountryLookup for exercising the swap.
+type stubCountryLookup struct{ cc string }
+
+func (s stubCountryLookup) CountryCode(net.IP) string { return s.cc }
+func (s stubCountryLookup) Ready() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
 func TestDBNameFromURL(t *testing.T) {
 	for _, tc := range []struct {
 		name, in, want string

--- a/egress/stats_test.go
+++ b/egress/stats_test.go
@@ -47,6 +47,50 @@ func TestStatsFor_EmptyCountryGoesToUnknown(t *testing.T) {
 	}
 }
 
+// donorCountry returns the literal unknownCountry, never "", so statsFor must
+// route that value to the same block as "". Otherwise the map gains an "unknown"
+// key while eachCountryStats also appends its own unknownCountry row, emitting
+// two observations with an identical donor_country attribute in one otel
+// callback — a duplicate series, with the real traffic in the map entry and the
+// always-reported row stuck at zero.
+func TestStatsFor_UnknownLiteralRoutesToUnknownBucket(t *testing.T) {
+	resetStats(t)
+	if statsFor(unknownCountry) != unknownCCs {
+		t.Fatal("unknownCountry did not map to the unknown bucket")
+	}
+	statsMx.Lock()
+	_, leaked := statsByCC[unknownCountry]
+	statsMx.Unlock()
+	if leaked {
+		t.Fatalf("statsFor(%q) created a map entry; it must reuse the unknown bucket", unknownCountry)
+	}
+}
+
+// Whatever donorCountry produces for an unresolvable peer must survive a round
+// trip through statsFor and eachCountryStats as exactly one series.
+func TestEachCountryStats_UnknownEmittedExactlyOnce(t *testing.T) {
+	resetStats(t)
+	s := statsFor(donorCountry(&net.TCPAddr{IP: net.ParseIP("8.8.8.8"), Port: 443}))
+	atomic.AddInt64(&s.clients, 1)
+	atomic.AddInt64(&s.ingressBytes, 42)
+
+	counts := map[string]int{}
+	var bytesSeen int64
+	eachCountryStats(func(cc string, _, bytes int64) {
+		counts[cc]++
+		if cc == unknownCountry {
+			bytesSeen += bytes
+		}
+	})
+
+	if counts[unknownCountry] != 1 {
+		t.Fatalf("unknown series emitted %d times, want exactly 1 (duplicate attribute set)", counts[unknownCountry])
+	}
+	if bytesSeen != 42 {
+		t.Fatalf("unknown series reported %d bytes, want 42 — traffic landed in the wrong bucket", bytesSeen)
+	}
+}
+
 func TestEachCountryStats_ReportsPerCountryAndDrainsBytes(t *testing.T) {
 	resetStats(t)
 	cn, ru := statsFor("CN"), statsFor("RU")
@@ -141,6 +185,36 @@ func TestEachCountryStats_NoLostBytesUnderConcurrency(t *testing.T) {
 
 	if got := atomic.LoadInt64(&drained); got != writers*perWriter {
 		t.Fatalf("drained %d bytes, want %d (lost or double-counted)", got, writers*perWriter)
+	}
+}
+
+func TestDBNameFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"plain tarball", "https://example.com/dbs/GeoLite2-Country.tar.gz", "GeoLite2-Country", true},
+		{"no suffix in path", "https://example.com/dbs/GeoLite2-Country", "GeoLite2-Country", true},
+		{
+			// The case that motivated this: MaxMind's real permalink puts the
+			// edition in the query, so path.Base over the raw URL would have
+			// produced "geoip_download?edition_id=...&license_key=..." and used
+			// it as both a tarball member name and a local filename.
+			"maxmind permalink",
+			"https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=secret&suffix=tar.gz",
+			"GeoLite2-Country", true,
+		},
+		{"signed url with query", "https://cdn.example.com/GeoLite2-Country.tar.gz?X-Amz-Signature=deadbeef", "GeoLite2-Country", true},
+		{"fragment", "https://example.com/GeoLite2-Country.tar.gz#frag", "GeoLite2-Country", true},
+		{"suffix mid-string preserved", "https://example.com/my.tar.gz.db.tar.gz", "my.tar.gz.db", true},
+		{"not a url", "GeoLite2-Country.tar.gz", "", false},
+		{"no path", "https://example.com", "", false},
+		{"root path", "https://example.com/", "", false},
+	} {
+		got, ok := dbNameFromURL(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("%s: dbNameFromURL(%q) = (%q, %v), want (%q, %v)", tc.name, tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }
 

--- a/egress/tracer_test.go
+++ b/egress/tracer_test.go
@@ -1,0 +1,61 @@
+package egress
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// The package-level `tracer` is created at init, before NewListener calls
+// telemetry.EnableOTELTracing (which installs the real TracerProvider via
+// otel.SetTracerProvider). That ordering looks like it should leave every session
+// span permanently no-op, and it would if we had captured a provider directly.
+//
+// It doesn't, because otel's global TracerProvider hands out delegating tracers:
+// SetTracerProvider walks the tracers it has already returned and repoints them
+// at the new provider (otel/internal/global/trace.go, tracerProvider.setDelegate).
+// A package-level tracer var is the pattern that machinery exists to support.
+//
+// This test pins that behaviour, because the failure mode is silent — spans would
+// simply never appear, with nothing logged — and it depends on a guarantee from a
+// dependency rather than on our own code.
+func TestPackageLevelTracerRecordsAfterProviderInstalledLater(t *testing.T) {
+	// Sanity check the premise: before any provider is installed, the global
+	// no-op provider produces non-recording spans.
+	_, preSpan := tracer.Start(context.Background(), "before-provider")
+	preRecording := preSpan.IsRecording()
+	preSpan.End()
+
+	// Now do what NewListener does, after `tracer` was already created at init.
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSyncer(exporter),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	_, span := tracer.Start(context.Background(), spanWebSocketSession)
+	if !span.IsRecording() {
+		t.Fatal("package-level tracer produced a non-recording span after a provider was installed; " +
+			"global tracer delegation is not working and session spans would be silently dropped")
+	}
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("exported %d spans, want 1", len(spans))
+	}
+	if spans[0].Name != spanWebSocketSession {
+		t.Errorf("span name = %q, want %q", spans[0].Name, spanWebSocketSession)
+	}
+
+	t.Logf("pre-provider span recording=%v (expected false), post-provider span exported OK", preRecording)
+}

--- a/egress/websocket.go
+++ b/egress/websocket.go
@@ -96,10 +96,13 @@ func (q errorlessWebSocketPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, 
 	}
 
 	copy(p, b)
-	atomic.AddUint64(&nIngressBytes, uint64(len(b)))
-	// Attribute the same bytes to this connection's donor country and to its
-	// session. Both are nil-checked because migration_test and other callers
-	// construct this type directly without the instrumentation fields.
+	// Attribute bytes to this connection's donor country and to its session.
+	// Both are nil-checked because migration_test and other callers construct
+	// this type directly without the instrumentation fields.
+	//
+	// The former global nIngressBytes add is gone: ingress-bytes is now observed
+	// from the per-country blocks, so incrementing a global nothing reads would
+	// be a pointless atomic on the hot read path.
 	if q.stats != nil {
 		atomic.AddInt64(&q.stats.ingressBytes, int64(len(b)))
 	}

--- a/egress/websocket.go
+++ b/egress/websocket.go
@@ -40,6 +40,10 @@ type errorlessWebSocketPacketConn struct {
 	// session span. Separate from stats.ingressBytes, which the otel callback
 	// resets every interval.
 	sessionBytes *int64
+	// keepaliveFailed is set when a keepalive ping goes unanswered, which is the
+	// signature of a wedged peer rather than one that disconnected. The handler
+	// reports it as the session's teardown reason.
+	keepaliveFailed *atomic.Bool
 }
 
 func (q errorlessWebSocketPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
@@ -57,7 +61,25 @@ func (q errorlessWebSocketPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, 
 			select {
 			case <-time.After(q.keepalive):
 				slog.Debug("PING", "addr", q.addr)
-				q.w.Ping(context.Background())
+				// Bound the ping and record its failure. coder/websocket's Ping
+				// waits for the matching pong, so with the previous
+				// context.Background() a peer that stops answering — the exact
+				// signature of a frozen browser widget — wedged this goroutine
+				// forever and discarded the error, making a freeze invisible.
+				// A timed-out ping is a *positive* freeze signal, as opposed to
+				// the mere absence of traffic, which is indistinguishable from a
+				// user closing the tab.
+				pingCtx, cancel := context.WithTimeout(context.Background(), q.keepalive)
+				err := q.w.Ping(pingCtx)
+				cancel()
+				if err != nil {
+					if q.keepaliveFailed != nil {
+						q.keepaliveFailed.Store(true)
+					}
+					slog.Debug("PING failed", "addr", q.addr, "error", err)
+					// The read below will fail once the peer is gone; leave
+					// teardown to it rather than racing it from here.
+				}
 			case <-readDone:
 				return
 			}

--- a/egress/websocket.go
+++ b/egress/websocket.go
@@ -29,6 +29,17 @@ type errorlessWebSocketPacketConn struct {
 	keepalive time.Duration
 	tcpAddr   *net.TCPAddr
 	readError chan error
+
+	// stats accumulates this connection's bytes against its donor country. It is
+	// a pointer so the read path does a single atomic add against memory it
+	// already holds, rather than hashing a map key per packet. Methods on this
+	// type use value receivers, so mutable per-session state must be behind a
+	// pointer to be shared with the handler.
+	stats *countryStats
+	// sessionBytes is the handler's per-session byte counter, reported on the
+	// session span. Separate from stats.ingressBytes, which the otel callback
+	// resets every interval.
+	sessionBytes *int64
 }
 
 func (q errorlessWebSocketPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
@@ -86,6 +97,15 @@ func (q errorlessWebSocketPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, 
 
 	copy(p, b)
 	atomic.AddUint64(&nIngressBytes, uint64(len(b)))
+	// Attribute the same bytes to this connection's donor country and to its
+	// session. Both are nil-checked because migration_test and other callers
+	// construct this type directly without the instrumentation fields.
+	if q.stats != nil {
+		atomic.AddInt64(&q.stats.ingressBytes, int64(len(b)))
+	}
+	if q.sessionBytes != nil {
+		atomic.AddInt64(q.sessionBytes, int64(len(b)))
+	}
 	return len(b), q.tcpAddr, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/metric v1.36.0
+	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	golang.org/x/mod v0.32.0
 )
@@ -70,7 +71,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect


### PR DESCRIPTION
## Why

The egress could tell us the fleet was carrying traffic, but nothing about *who* it was carrying it for. `concurrent-websockets` and `ingress-bytes` were single unlabelled series, and the consumer session ID — the one per-session identifier that exists — appeared nowhere in telemetry.

This was load-bearing today. The bandit reaper reports **0 callbacks and 100% probe expiry** for `unbounded-linode-free` (3,092 assignments in 24h, 2,514 of them CN), while the egress counters and `netstated` independently showed live traffic from CN/RU consumers. Telling "the transport is broken" apart from "the transport works and the bandit can't see it" required correlating three systems by hand. Refs getlantern/engineering#3698.

## What

**Donor country on metrics.** `concurrent-websockets` and `ingress-bytes` now carry a `donor_country` attribute.

- Totals are preserved: summing across the country dimension equals what the unlabelled series reported, so queries that don't group by country are unaffected. ⚠️ Anything reducing with `max`/`latest` rather than `sum` needs `spaceAggregation=sum` to stay correct.
- Reuses `getlantern/geo` and netstated's `GEODB` convention — one thing to configure, not two. Degrades to `"unknown"` when `GEODB` is unset, and deliberately does **not** block on the DB download: geolocation is observability, never a gate on serving traffic.
- Resolved once per WebSocket, never per packet. Each connection holds a pointer to its own country's counter block, so the read path is one atomic add against memory it already has — no lock, no per-packet map hash.
- Idle countries are skipped to bound series count, **except `unknown`, which always reports**. A vanished series is indistinguishable from a dead exporter, which is exactly the outage worth seeing.
- Bytes drain via atomic *swap*, not load-then-store, so a concurrent read can't be silently dropped. There's a race-detector test for that specifically.

**Per-session spans.** One span per WebSocket session with a **truncated** consumer session ID (first 8 chars, matching the `csidPrefix` practice in `clientcore/jit_egress_consumer.go` — enough to correlate within a time window without emitting the full identifier; the full ID is still what `createOrMigrate` keys on), donor country, bytes, QUIC stream count, protocol version, and teardown reason. Traces absorb cardinality the session ID could never have as a metric label. Spans start before `websocket.Accept` so failed accepts stay visible, and a session that moved **zero bytes is marked `Error`** — that silent case is the failure mode worth finding.

**Consumer country — egress half only.** The egress only ever sees the *donor's* address; the consumer sits behind the donor's WebRTC data channel, so where a session terminates isn't observable server-side without being told. This adds an optional trailing country element to the subprotocol handshake and labels spans with it when present. **Nothing transmits it yet.**

## The consumer/donor half needs a decision, not a default

I deliberately stopped at the egress. The value would travel consumer → donor → egress, so **a volunteer donor forwarding it can read it**. A donor already learns the consumer's public IP from ICE candidate exchange, so the marginal disclosure is small — but it isn't zero, and this is a censorship-circumvention tool. That's your call, not a default I should pick.

An empty country stays **byte-identical** to the existing 3-element form, so "decline to disclose" is indistinguishable from "old client".

⚠️ **Ordering constraint:** the new parser accepts 3 or 4 elements, but the pre-existing parser required *exactly* 3. Donors must not emit the 4-element form until the egress fleet is past this commit.

The parser also now **validates the magic cookie**, which the previous one did not (it checked arity only and ignored `s[0]`). Safe for every client that has ever spoken this protocol: `subprotocolsMagicCookie` is one shared constant used by both the request and response constructors, unchanged since it was introduced in `c3b5fef`.

## Verification

- `go build ./...` clean; `go test -race ./egress/... ./common/...` all pass.
- New tests cover both wire forms, wire-identical empty country, arity rejection, per-country accounting, byte draining, the always-report-unknown rule, and no lost/double-counted bytes under 8 concurrent writers racing the reporting callback.
- The `lostcancel` vet warning and unformatted `migration_test.go` both reproduce on clean `origin/main` and are untouched here.
- Review rounds fixed three defects found by reviewers and three found re-reading my own diff — most consequentially a duplicate `donor_country="unknown"` series (two observations with an identical attribute set in one callback, with real traffic landing in the wrong bucket) and a dropped tracing shutdown that would have discarded buffered spans.

**Deploy note:** set `GEODB` on the egress to a MaxMind tarball URL to get real country labels; without it everything reports `unknown` and behaviour is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for country information in WebSocket connection metadata while preserving compatibility with existing connections.
  * Added country-aware egress metrics, including client counts and inbound traffic by donor country.
  * Added session tracing with connection details, traffic volumes, stream counts, and termination reasons.
  * Added donor-country detection with an `unknown` fallback when location data is unavailable or unsupported.

* **Bug Fixes**
  * Improved handling of invalid or incomplete country information without interrupting service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
