### PR TITLE
covertdtls: restore the widget wasm build, and add CI that would have caught it

### DIFF
--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -1,0 +1,66 @@
+name: Build widget (wasm)
+
+# The browser widget is compiled to js/wasm from ./cmd (see cmd/build_web.sh),
+# but nothing in CI built that target, and ui/public/widget.wasm is a committed
+# prebuilt binary. Between them, a source change could break the widget build
+# and every check would still pass — which is exactly what happened: covertdtls
+# landed in clientcore without wasm build tags and broke `GOOS=js GOARCH=wasm
+# go build ./cmd` on main, undetected.
+#
+# This job exists so that failure mode cannot recur silently. It only compiles;
+# it deliberately does not regenerate or commit widget.wasm, since publishing a
+# binary is a release decision, not a CI side effect.
+#
+# Build only, no `go vet`: vetting under wasm tags currently reports four
+# pre-existing findings in clientcore (user.go lostcancel x2, unreachable code in
+# egress_consumer.go and webrtc_api_js.go) that native vet never type-checks.
+# Adding the step would land this job red on arrival. Worth fixing separately,
+# then enabling here.
+#
+# No step interpolates event data (issue/PR titles, branch names, commit
+# messages) into a run: command, so there is no workflow-injection surface here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'clientcore/**'
+      - 'common/**'
+      - 'cmd/**'
+      - 'netstate/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/build-widget-wasm.yml'
+  pull_request:
+    paths:
+      - 'clientcore/**'
+      - 'common/**'
+      - 'cmd/**'
+      - 'netstate/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/build-widget-wasm.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-wasm:
+    name: go build js/wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build widget for js/wasm
+        env:
+          GOOS: js
+          GOARCH: wasm
+        # Mirrors cmd/build_web.sh, minus the output path: we only care that it
+        # compiles. -o /dev/null keeps the artifact out of the workspace so it
+        # can't be mistaken for something publishable.
+        run: go build -ldflags "-s -w" -o /dev/null ./cmd

--- a/common/covertdtls/apply.go
+++ b/common/covertdtls/apply.go
@@ -1,0 +1,52 @@
+//go:build !wasm
+
+// Apply lives in its own build-tagged file because the pion SettingEngine hooks
+// it installs (SetSRTPProtectionProfiles, SetDTLSClientHelloMessageHook) do not
+// exist on js/wasm: in a browser the DTLS handshake belongs to the browser's own
+// WebRTC stack, not to pion, so there is no ClientHello for us to shape.
+//
+// Before this split the package compiled unconditionally and broke the widget's
+// wasm build outright. That went unnoticed because no CI job builds the wasm
+// widget and ui/public/widget.wasm is a committed prebuilt binary, so nothing
+// ever exercised the source path.
+
+package covertdtls
+
+import (
+	"errors"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/theodorsm/covert-dtls/pkg/mimicry"
+	"github.com/theodorsm/covert-dtls/pkg/randomize"
+	"github.com/theodorsm/covert-dtls/pkg/utils"
+)
+
+// Apply installs the configured ClientHello hook on the given SettingEngine.
+// Returns nil if the config has no effect (Enabled() == false).
+func Apply(cfg Config, s *webrtc.SettingEngine) error {
+	if s == nil {
+		return errors.New("covertdtls: nil SettingEngine")
+	}
+	switch {
+	case cfg.Fingerprint != "":
+		mimic := &mimicry.MimickedClientHello{}
+		if err := mimic.LoadFingerprint(cfg.Fingerprint); err != nil {
+			return err
+		}
+		s.SetSRTPProtectionProfiles(utils.DefaultSRTPProtectionProfiles()...)
+		s.SetDTLSClientHelloMessageHook(mimic.Hook)
+	case cfg.Mimic:
+		mimic := &mimicry.MimickedClientHello{}
+		if cfg.Randomize {
+			if err := mimic.LoadRandomFingerprint(); err != nil {
+				return err
+			}
+		}
+		s.SetSRTPProtectionProfiles(utils.DefaultSRTPProtectionProfiles()...)
+		s.SetDTLSClientHelloMessageHook(mimic.Hook)
+	case cfg.Randomize:
+		rand := randomize.RandomizedMessageClientHello{RandomALPN: true}
+		s.SetDTLSClientHelloMessageHook(rand.Hook)
+	}
+	return nil
+}

--- a/common/covertdtls/apply_test.go
+++ b/common/covertdtls/apply_test.go
@@ -1,0 +1,72 @@
+package covertdtls
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// Apply's contract has to hold identically under both build tags, because a
+// caller writing against it cannot see which implementation it will link. This
+// test compiles for native and for js/wasm and asserts the parts that must not
+// diverge; the wasm CI job (.github/workflows/build-widget-wasm.yml) only builds
+// ./cmd, so run it explicitly for wasm with:
+//
+//	GOOS=js GOARCH=wasm go vet ./common/covertdtls/
+//
+// (Go cannot *execute* js/wasm tests without a JS host, so the wasm side is
+// compile-checked rather than run.)
+func TestApply_NilSettingEngineIsAnErrorUnderEveryBuildTag(t *testing.T) {
+	// A nil engine is a caller bug, not a platform limitation, so both
+	// implementations must reject it. Validation that fires under only one build
+	// tag means the bug is caught on native and passes silently in the widget.
+	if err := Apply(Config{Randomize: true}, nil); err == nil {
+		t.Error("Apply(cfg, nil) returned nil; a nil SettingEngine must be an error on every platform")
+	}
+	if err := Apply(Config{}, nil); err == nil {
+		t.Error("Apply(zero cfg, nil) returned nil; the nil check must not depend on the config")
+	}
+}
+
+// A config asking for fingerprint shaping must never fail startup. On native it
+// installs hooks; on wasm it is a documented no-op. Either way, success.
+func TestApply_ConfiguredModesDoNotError(t *testing.T) {
+	for name, cfg := range map[string]Config{
+		"disabled":       {},
+		"randomize":      {Randomize: true},
+		"mimic":          {Mimic: true},
+		"randomizemimic": {Randomize: true, Mimic: true},
+	} {
+		if err := Apply(cfg, &webrtc.SettingEngine{}); err != nil {
+			t.Errorf("Apply(%s) = %v, want nil: a covertdtls mode must not fail startup", name, err)
+		}
+	}
+}
+
+// ParseModeString and Enabled are platform-independent and deliberately stayed in
+// the shared file rather than being split by build tag. Pin that they behave the
+// same, so a future split doesn't quietly move them.
+func TestParseModeString(t *testing.T) {
+	for _, mode := range []string{ModeRandomize, ModeMimic, ModeRandomizeMimic} {
+		cfg, err := ParseModeString(mode)
+		if err != nil {
+			t.Errorf("ParseModeString(%q) errored: %v", mode, err)
+			continue
+		}
+		if !cfg.Enabled() {
+			t.Errorf("ParseModeString(%q) produced a disabled config", mode)
+		}
+	}
+
+	cfg, err := ParseModeString(ModeDisable)
+	if err != nil {
+		t.Errorf("ParseModeString(%q) errored: %v", ModeDisable, err)
+	}
+	if cfg.Enabled() {
+		t.Errorf("ParseModeString(%q) produced an enabled config", ModeDisable)
+	}
+
+	if _, err := ParseModeString("nonsense"); err == nil {
+		t.Error("ParseModeString(\"nonsense\") = nil error, want a rejection")
+	}
+}

--- a/common/covertdtls/apply_wasm.go
+++ b/common/covertdtls/apply_wasm.go
@@ -2,20 +2,29 @@
 
 package covertdtls
 
-import "github.com/pion/webrtc/v4"
+import (
+	"errors"
+
+	"github.com/pion/webrtc/v4"
+)
 
 // Apply is a no-op on js/wasm. This is not a temporary shim: browser WebRTC
 // performs its own DTLS handshake, so a widget running in a browser has no
 // ability to randomize or mimic its ClientHello fingerprint no matter what the
-// config asks for.
+// config asks for. See the package doc for what that means for coverage.
 //
-// Worth stating plainly, because the native build uses this to evade the DPI
-// filtering described in the package doc: **browser widgets do not get that
-// protection**, and a config that sets randomize/mimic is silently ineffective
-// there. Callers wanting fingerprint control must run a native producer.
+// Returns nil for every configured mode rather than an error, so a shared config
+// carrying a covertdtls mode does not fail widget startup over a capability the
+// platform cannot provide.
 //
-// Returns nil rather than an error so a shared config carrying a covertdtls mode
-// does not fail widget startup over a capability the platform cannot provide.
+// The nil-SettingEngine check is kept identical to the native implementation on
+// purpose. A nil engine is a caller bug rather than a platform limitation, and
+// validation that fires under only one build tag means such a bug is caught on
+// native and passes silently in the widget. That divergence costs more than the
+// three lines it takes to avoid.
 func Apply(cfg Config, s *webrtc.SettingEngine) error {
+	if s == nil {
+		return errors.New("covertdtls: nil SettingEngine")
+	}
 	return nil
 }

--- a/common/covertdtls/apply_wasm.go
+++ b/common/covertdtls/apply_wasm.go
@@ -1,0 +1,21 @@
+//go:build wasm
+
+package covertdtls
+
+import "github.com/pion/webrtc/v4"
+
+// Apply is a no-op on js/wasm. This is not a temporary shim: browser WebRTC
+// performs its own DTLS handshake, so a widget running in a browser has no
+// ability to randomize or mimic its ClientHello fingerprint no matter what the
+// config asks for.
+//
+// Worth stating plainly, because the native build uses this to evade the DPI
+// filtering described in the package doc: **browser widgets do not get that
+// protection**, and a config that sets randomize/mimic is silently ineffective
+// there. Callers wanting fingerprint control must run a native producer.
+//
+// Returns nil rather than an error so a shared config carrying a covertdtls mode
+// does not fail widget startup over a capability the platform cannot provide.
+func Apply(cfg Config, s *webrtc.SettingEngine) error {
+	return nil
+}

--- a/common/covertdtls/covertdtls.go
+++ b/common/covertdtls/covertdtls.go
@@ -12,11 +12,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/pion/webrtc/v4"
 	"github.com/theodorsm/covert-dtls/pkg/fingerprints"
-	"github.com/theodorsm/covert-dtls/pkg/mimicry"
-	"github.com/theodorsm/covert-dtls/pkg/randomize"
-	"github.com/theodorsm/covert-dtls/pkg/utils"
 )
 
 // Mode names accepted by ParseModeString.
@@ -66,34 +62,4 @@ func ParseModeString(s string) (Config, error) {
 		return cfg, errors.New("covertdtls: unknown mode (want randomize, mimic, randomizemimic, or disable)")
 	}
 	return cfg, nil
-}
-
-// Apply installs the configured ClientHello hook on the given SettingEngine.
-// Returns nil if the config has no effect (Enabled() == false).
-func Apply(cfg Config, s *webrtc.SettingEngine) error {
-	if s == nil {
-		return errors.New("covertdtls: nil SettingEngine")
-	}
-	switch {
-	case cfg.Fingerprint != "":
-		mimic := &mimicry.MimickedClientHello{}
-		if err := mimic.LoadFingerprint(cfg.Fingerprint); err != nil {
-			return err
-		}
-		s.SetSRTPProtectionProfiles(utils.DefaultSRTPProtectionProfiles()...)
-		s.SetDTLSClientHelloMessageHook(mimic.Hook)
-	case cfg.Mimic:
-		mimic := &mimicry.MimickedClientHello{}
-		if cfg.Randomize {
-			if err := mimic.LoadRandomFingerprint(); err != nil {
-				return err
-			}
-		}
-		s.SetSRTPProtectionProfiles(utils.DefaultSRTPProtectionProfiles()...)
-		s.SetDTLSClientHelloMessageHook(mimic.Hook)
-	case cfg.Randomize:
-		rand := randomize.RandomizedMessageClientHello{RandomALPN: true}
-		s.SetDTLSClientHelloMessageHook(rand.Hook)
-	}
-	return nil
 }

--- a/common/covertdtls/covertdtls.go
+++ b/common/covertdtls/covertdtls.go
@@ -1,8 +1,18 @@
 // Package covertdtls wraps github.com/theodorsm/covert-dtls so broflake
-// widgets can randomize or mimic their DTLS ClientHello fingerprint. The
+// producers can randomize or mimic their DTLS ClientHello fingerprint. The
 // default pion/dtls fingerprint was being DPI-filtered in Russia starting
 // 2026-03-30 (net4people/bbs#603), blocking Snowflake and, by extension, any
 // pion-based WebRTC transport — including unbounded.
+//
+// NATIVE PRODUCERS ONLY. Fingerprint shaping works by installing hooks on
+// pion's DTLS handshake, so it applies only where pion performs that handshake.
+// In a browser the handshake belongs to the browser's own WebRTC stack, so
+// Apply is a no-op on js/wasm (see apply_wasm.go) and a browser widget gets no
+// fingerprint protection whatever its config says. A config setting
+// randomize/mimic is therefore silently ineffective in the widget — deliberately
+// silent, so a shared config does not fail widget startup over a capability the
+// platform cannot provide. Read that as a coverage gap, not a bug: DPI filtering
+// of the kind described above is not something a browser widget can evade.
 //
 // The API mirrors the equivalent package in Snowflake v2.13.1 so operators
 // familiar with one project can drop into the other.


### PR DESCRIPTION
## The widget cannot be built from source on `main`

```
$ GOOS=js GOARCH=wasm go build ./cmd
common/covertdtls/covertdtls.go:83:5: s.SetSRTPProtectionProfiles undefined
common/covertdtls/covertdtls.go:84:5: s.SetDTLSClientHelloMessageHook undefined
exit 1
```

`covertdtls` is imported by `clientcore/producer.go` and `clientcore/settings.go` — core widget code, not a side path — and carried no build tags, so it compiled for `js/wasm` too. The pion `SettingEngine` hooks it installs don't exist there: in a browser the DTLS handshake belongs to the browser's own WebRTC stack, so there is no ClientHello for us to shape.

**Two things kept this invisible:** no CI job builds the wasm widget, and `ui/public/widget.wasm` is a committed prebuilt binary. Between them the source path was never exercised and every check stayed green.

I found this while trying to add freeze instrumentation to the widget — I couldn't compile-verify anything for wasm.

## Fix

Split `Apply` into `apply.go` (`!wasm`, unchanged) and `apply_wasm.go` (`wasm`, no-op). Only `Apply` touches the unavailable API; `Config`, `ParseModeString` and `Enabled` are platform-independent and stay shared, so this is a narrow split rather than tagging out the package.

## ⚠️ An implication worth stating outright

The package doc explains covertdtls exists because the default pion/dtls fingerprint was being DPI-filtered in Russia from 2026-03-30 (net4people/bbs#603), blocking Snowflake and any pion-based WebRTC transport.

**That evasion has never applied to browser widgets, and cannot** — browsers control DTLS. A widget config setting `randomize`/`mimic` is silently ineffective; fingerprint control requires a native producer. This isn't introduced here, it's just now explicit in the code. Flagging it because it affects what we believe about our own coverage in Russia, where we currently have live consumers.

The wasm stub returns `nil` rather than an error so a shared config carrying a covertdtls mode doesn't fail widget startup over a capability the platform can't provide.

## CI

Adds `.github/workflows/build-widget-wasm.yml`, compiling `./cmd` for `js/wasm` on PRs and pushes touching `clientcore`/`common`/`cmd`/`netstate`.

**Build only, no `go vet`:** vetting under wasm tags currently reports four pre-existing `clientcore` findings that native vet never type-checks (`user.go` lostcancel ×2, unreachable code in `egress_consumer.go` and `webrtc_api_js.go`). Including it would land the job red on arrival. Noted in the workflow for follow-up.

The job deliberately does **not** regenerate or commit `widget.wasm` — publishing a binary is a release decision, not a CI side effect. Worth deciding separately whether that committed binary should exist at all, since it's what let this hide.

## Verification

- `GOOS=js GOARCH=wasm go build -ldflags "-s -w" -o /dev/null ./cmd` → **exit 0** (was exit 1)
- Native `go build ./...` and `go test ./common/...` unaffected
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
