### PR TITLE
release-egress: add workflow_dispatch so the release can be triggered

### DIFF
--- a/.github/workflows/release-egress.yml
+++ b/.github/workflows/release-egress.yml
@@ -24,6 +24,18 @@ on:
       - 'go.sum'
       - '.github/workflows/release-egress.yml'
 
+  # Manual trigger. The push trigger above is the normal path, but it leaves no
+  # way to retry: on 2026-08-03 it silently did not fire on a merge that touched
+  # this very file, and with no dispatch there was no way to re-run it or to cut a
+  # release on demand. It also means the bump-PR path added in #377 cannot be
+  # exercised without manufacturing a qualifying merge.
+  #
+  # Dispatch runs ignore the path filter, so this always runs the version job. It
+  # is safe to run repeatedly: if version.go already matches the latest release it
+  # opens (or refreshes) the bump PR and releases nothing, and if version.go is
+  # ahead it publishes that version. Neither path force-pushes to main.
+  workflow_dispatch:
+
 # Serialize so two back-to-back merges can't race on the version bump.
 # cancel-in-progress: false — we want every merge to produce a release,
 # not to let a later merge skip the earlier one's artifacts.


### PR DESCRIPTION
## Why

The push trigger is the normal path, but it leaves **no way to retry**. On 2026-08-03 it silently did not fire on a merge that touched this very file — so there was no way to re-run it, no way to cut a release on demand, and no way to exercise the bump-PR path added in #377 without manufacturing a qualifying merge.

That's blocking something concrete: the latest egress release is **v2.3.3 from 2026-06-20**, so the session instrumentation merged in #375 is not in any released binary and has not reached the VMs. `/update-egress-server` can't deploy what was never published.

## Behaviour

Dispatch runs ignore the path filter, so the `version` job always runs. It's safe to run repeatedly:

| `common/version.go` vs latest release | result |
|---|---|
| equal | opens (or refreshes) the `chore/egress-release-vX.Y.Z` bump PR, releases nothing |
| ahead | publishes that version |

Neither path force-pushes to main, so a stray dispatch can't do worse than leave an extra PR to close.

## Verification

- YAML parses (js-yaml); triggers are `push, workflow_dispatch`
- The 5-entry push path filter is unchanged
- `release` job still gated on `needs.version.outputs.release == 'true'`

## Next step after merge

Dispatch it. `version.go` is `v2.3.3` and the latest release is `v2.3.3`, so it should take the auto-bump path and open `chore/egress-release-v2.3.4` — which also finally validates #377's fix. Merging that publishes v2.3.4, and then `/update-egress-server v2.3.4` can deploy it.

⚠️ That deploy restarts the **single** egress instance (`unbounded-us-linode-nj.iantem.io`) with no graceful drain, dropping every live WebSocket/QUIC connection — check `concurrent-websockets` in SigNoz first, and remember to divide by 3 for the `via` collector fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the ability to manually run the release process on demand.
  - Manual releases now support either preparing an updated version change or publishing a specified newer version.
  - Improved release workflow reliability by allowing manual runs regardless of affected file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->