### PR TITLE
egress: count refused connections and log who was refused

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -114,8 +114,20 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	consumerSessionID, version, consumerCountry, ok := common.ParseSubprotocolsRequestWithCountry(subprotocols)
 	if !ok {
-		recordRefusal(refusedMissingSubprotocols)
-		slog.Debug("Refused WebSocket connection, missing subprotocols", peerAttrs(r)...)
+		// ParseSubprotocolsRequestWithCountry returns !ok for an absent header,
+		// a wrong element count, or a magic-cookie mismatch. Reporting all three
+		// as "missing" would point an investigation at the wrong caller, so
+		// split on whether the client sent anything at all.
+		//
+		// The element count is logged; the values are not. They are
+		// client-controlled and unbounded in size, and one of them is a session
+		// identifier.
+		reason, msg := refusedMissingSubprotocols, "Refused WebSocket connection, missing subprotocols"
+		if len(subprotocols) > 0 {
+			reason, msg = refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols"
+		}
+		recordRefusal(reason)
+		slog.Debug(msg, append(peerAttrs(r), "subprotocol_count", len(subprotocols))...)
 		return
 	}
 
@@ -385,9 +397,9 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 			// decremented exactly once around the handler, whereas the legacy
 			// global nClients decrements in the conn's Close(). nClients is now
 			// only used for the log lines.
-			eachRefusal(func(reason string, count int64) {
+			eachRefusal(func(reason refusalReason, count int64) {
 				o.ObserveInt64(refusedCounter, count,
-					metric.WithAttributes(attribute.String("reason", reason)))
+					metric.WithAttributes(attribute.String("reason", string(reason))))
 			})
 
 			eachCountryStats(func(cc string, clients, ingressBytes int64) {

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -122,8 +122,11 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		// The element count is logged; the values are not. They are
 		// client-controlled and unbounded in size, and one of them is a session
 		// identifier.
+		// Test the RAW header, not the filtered list: "Sec-WebSocket-Protocol: ,"
+		// filters down to zero values, so keying off the filtered slice reported a
+		// client that clearly sent something as though it had sent nothing.
 		reason, msg := refusedMissingSubprotocols, "Refused WebSocket connection, missing subprotocols"
-		if len(subprotocols) > 0 {
+		if len(rawSubprotocols) > 0 {
 			reason, msg = refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols"
 		}
 		recordRefusal(reason)

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -138,7 +138,8 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 		w.Write([]byte("418\n"))
 		recordRefusal(refusedBadProtocolVersion)
-		slog.Debug("Refused WebSocket connection, bad protocol version", append(peerAttrs(r), "version", version)...)
+		slog.Debug("Refused WebSocket connection, bad protocol version",
+			append(peerAttrs(r), "version", truncateForLog(version))...)
 		return
 	}
 

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -48,6 +48,11 @@ var nQUICStreamsCounter metric.Int64ObservableUpDownCounter
 var nQUICConnectionsCounter metric.Int64ObservableUpDownCounter
 var nIngressBytesCounter metric.Int64ObservableUpDownCounter
 
+// refusedCounter tallies connections turned away before a session span exists.
+// A monotonic Counter, not an UpDownCounter: it is a cumulative tally meant to be
+// rate()'d, unlike the concurrency gauges above.
+var refusedCounter metric.Int64ObservableCounter
+
 // tracer emits one span per WebSocket session. Sessions are the unit an
 // operator actually asks about ("did this consumer get served?"), and a span
 // per session carries the consumer session ID without the unbounded-cardinality
@@ -109,7 +114,8 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	consumerSessionID, version, consumerCountry, ok := common.ParseSubprotocolsRequestWithCountry(subprotocols)
 	if !ok {
-		slog.Debug("Refused WebSocket connection, missing subprotocols")
+		recordRefusal(refusedMissingSubprotocols)
+		slog.Debug("Refused WebSocket connection, missing subprotocols", peerAttrs(r)...)
 		return
 	}
 
@@ -119,7 +125,8 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	if !common.IsValidProtocolVersion(versionHeader) {
 		w.WriteHeader(http.StatusTeapot)
 		w.Write([]byte("418\n"))
-		slog.Debug("Refused WebSocket connection, bad protocol version")
+		recordRefusal(refusedBadProtocolVersion)
+		slog.Debug("Refused WebSocket connection, bad protocol version", append(peerAttrs(r), "version", version)...)
 		return
 	}
 
@@ -129,7 +136,8 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	// https://github.com/getlantern/broflake/issues/45
 
 	if consumerSessionID == "" {
-		slog.Debug("Refused WebSocket connection, missing consumer session ID")
+		recordRefusal(refusedMissingCSID)
+		slog.Debug("Refused WebSocket connection, missing consumer session ID", peerAttrs(r)...)
 		return
 	}
 
@@ -344,6 +352,12 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		return nil, err
 	}
 
+	refusedCounter, err = m.Int64ObservableCounter("refused-websockets")
+	if err != nil {
+		closeFuncMetric(ctx)
+		return nil, err
+	}
+
 	_, err = m.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			q := atomic.LoadUint64(&nQUICConnections)
@@ -371,6 +385,11 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 			// decremented exactly once around the handler, whereas the legacy
 			// global nClients decrements in the conn's Close(). nClients is now
 			// only used for the log lines.
+			eachRefusal(func(reason string, count int64) {
+				o.ObserveInt64(refusedCounter, count,
+					metric.WithAttributes(attribute.String("reason", reason)))
+			})
+
 			eachCountryStats(func(cc string, clients, ingressBytes int64) {
 				attrs := metric.WithAttributes(attribute.String(attrDonorCountry, cc))
 				o.ObserveInt64(nClientsCounter, clients, attrs)
@@ -382,6 +401,7 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		nQUICConnectionsCounter,
 		nQUICStreamsCounter,
 		nIngressBytesCounter,
+		refusedCounter,
 	)
 	if err != nil {
 		closeFuncMetric(ctx)

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -19,27 +19,37 @@ import (
 // health check or many broken donors changes what we do about it, and neither the
 // count nor the source was observable.
 
-// Refusal reasons. Values are metric label content, so they are snake_case and
-// bounded: never derive one from request data, or the label becomes unbounded
-// cardinality controlled by whoever is connecting.
+// refusalReason is a distinct type rather than a bare string so a future caller
+// cannot pass request-derived data without an explicit, visible conversion.
+// These values become metric label content, and a label built from whatever a
+// client sends is unbounded cardinality controlled by the caller.
+type refusalReason string
+
 const (
-	refusedMissingSubprotocols = "missing_subprotocols"
-	refusedBadProtocolVersion  = "bad_protocol_version"
-	refusedMissingCSID         = "missing_consumer_session_id"
+	// refusedMissingSubprotocols: no Sec-Websocket-Protocol header at all.
+	refusedMissingSubprotocols refusalReason = "missing_subprotocols"
+	// refusedMalformedSubprotocols: the header was present but did not parse —
+	// wrong element count, or the magic cookie did not match. Kept separate from
+	// "missing" because the two implicate completely different callers: absent
+	// means something that is not a broflake client at all, malformed means
+	// something that tried and got the handshake wrong.
+	refusedMalformedSubprotocols refusalReason = "malformed_subprotocols"
+	refusedBadProtocolVersion    refusalReason = "bad_protocol_version"
+	refusedMissingCSID           refusalReason = "missing_consumer_session_id"
 )
 
 var (
 	refusalsMx sync.Mutex
-	// refusals is keyed by the constants above only. Entries are never removed;
-	// the set is fixed at three, and a reason that stops occurring should keep
-	// reporting its total rather than vanishing from the series.
-	refusals = map[string]*int64{}
+	// refusals is keyed by the constants above only. Entries are never removed:
+	// the set is small and fixed, and a reason that stops occurring should keep
+	// reporting its running total rather than vanishing from the series.
+	refusals = map[refusalReason]*int64{}
 )
 
 // recordRefusal counts one refused connection. Monotonic on purpose: this is a
 // tally, not a gauge, so consumers can rate() it. Contrast ingress-bytes, which
 // the otel callback drains each interval because it measures throughput.
-func recordRefusal(reason string) {
+func recordRefusal(reason refusalReason) {
 	refusalsMx.Lock()
 	c, ok := refusals[reason]
 	if !ok {
@@ -52,9 +62,9 @@ func recordRefusal(reason string) {
 
 // eachRefusal reports every reason seen so far. Snapshots under the lock so the
 // otel callback never holds refusalsMx while observing.
-func eachRefusal(f func(reason string, count int64)) {
+func eachRefusal(f func(reason refusalReason, count int64)) {
 	type row struct {
-		reason string
+		reason refusalReason
 		c      *int64
 	}
 	refusalsMx.Lock()

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -93,8 +94,37 @@ func eachRefusal(f func(reason refusalReason, count int64)) {
 // point at real clients failing the handshake.
 func peerAttrs(r *http.Request) []any {
 	return []any{
+		// RemoteAddr is synthesized by net/http from the accepted socket, not
+		// taken from the request, so it needs no bounding.
 		"remote_addr", r.RemoteAddr,
-		"forwarded_for", r.Header.Get("X-Forwarded-For"),
-		"user_agent", r.Header.Get("User-Agent"),
+		"forwarded_for", truncateHeader(r.Header.Get("X-Forwarded-For")),
+		"user_agent", truncateHeader(r.Header.Get("User-Agent")),
 	}
+}
+
+// maxLoggedHeaderLen bounds each client-controlled header value written to the
+// log. 256 bytes comfortably fits a real User-Agent and a long X-Forwarded-For
+// proxy chain, so honest values pass through untouched.
+const maxLoggedHeaderLen = 256
+
+// truncateHeader bounds a client-controlled header value before it reaches the
+// log.
+//
+// Both headers this is applied to are entirely attacker-chosen and effectively
+// unbounded in size. Writing them verbatim on a path that is currently refusing
+// ~10 connections per second turns a large header into sustained disk pressure on
+// the egress host — a client sending a 100 KB User-Agent at that rate writes
+// ~1 MB/s of DEBUG logs. This is the same hazard as letting an unbounded header
+// become a metric label, just spent on disk instead of cardinality.
+//
+// Truncation is byte-based for speed, then ToValidUTF8 drops any rune left
+// half-copied, so a multi-byte value cannot emit invalid UTF-8 into the log and
+// break ingestion downstream. The marker matters: a silently shortened value
+// would be indistinguishable from a genuinely short one, and the whole point of
+// logging these is to identify the caller.
+func truncateHeader(v string) string {
+	if len(v) <= maxLoggedHeaderLen {
+		return v
+	}
+	return strings.ToValidUTF8(v[:maxLoggedHeaderLen], "") + "…(truncated)"
 }

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -133,8 +133,12 @@ const truncationMarker = "…(truncated)"
 // would be indistinguishable from a genuinely short one, and the whole point of
 // logging these is to identify the caller.
 func truncateForLog(v string) string {
+	// Validate even when no truncation is needed. A short value can already be
+	// invalid UTF-8 (a lone 0xff, say), and this helper promises callers that
+	// nothing invalid reaches slog — a promise the early return was quietly
+	// exempting itself from.
 	if len(v) <= maxLoggedValueLen {
-		return v
+		return strings.ToValidUTF8(v, "")
 	}
 	keep := maxLoggedValueLen - len(truncationMarker)
 	return strings.ToValidUTF8(v[:keep], "") + truncationMarker

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -97,18 +97,28 @@ func peerAttrs(r *http.Request) []any {
 		// RemoteAddr is synthesized by net/http from the accepted socket, not
 		// taken from the request, so it needs no bounding.
 		"remote_addr", r.RemoteAddr,
-		"forwarded_for", truncateHeader(r.Header.Get("X-Forwarded-For")),
-		"user_agent", truncateHeader(r.Header.Get("User-Agent")),
+		"forwarded_for", truncateForLog(r.Header.Get("X-Forwarded-For")),
+		"user_agent", truncateForLog(r.Header.Get("User-Agent")),
 	}
 }
 
-// maxLoggedHeaderLen bounds each client-controlled header value written to the
-// log. 256 bytes comfortably fits a real User-Agent and a long X-Forwarded-For
-// proxy chain, so honest values pass through untouched.
-const maxLoggedHeaderLen = 256
+// maxLoggedValueLen is the hard ceiling on the total bytes any single
+// client-controlled value contributes to a log line, marker included. 256 bytes
+// comfortably fits a real User-Agent and a long X-Forwarded-For proxy chain, so
+// honest values pass through untouched.
+const maxLoggedValueLen = 256
 
-// truncateHeader bounds a client-controlled header value before it reaches the
-// log.
+// truncationMarker is appended to a shortened value. Its length is reserved out
+// of maxLoggedValueLen rather than added on top, so the documented ceiling is the
+// actual ceiling — a cap that its own marker can exceed is not a cap.
+const truncationMarker = "…(truncated)"
+
+// truncateForLog bounds a client-controlled value before it reaches the log.
+//
+// Applies to anything the peer chooses: the X-Forwarded-For and User-Agent
+// headers, and the protocol version lifted out of the subprotocol list. The
+// version was missed on the first pass, which is the whole reason this is named
+// for the sink rather than for headers.
 //
 // Both headers this is applied to are entirely attacker-chosen and effectively
 // unbounded in size. Writing them verbatim on a path that is currently refusing
@@ -122,9 +132,10 @@ const maxLoggedHeaderLen = 256
 // break ingestion downstream. The marker matters: a silently shortened value
 // would be indistinguishable from a genuinely short one, and the whole point of
 // logging these is to identify the caller.
-func truncateHeader(v string) string {
-	if len(v) <= maxLoggedHeaderLen {
+func truncateForLog(v string) string {
+	if len(v) <= maxLoggedValueLen {
 		return v
 	}
-	return strings.ToValidUTF8(v[:maxLoggedHeaderLen], "") + "…(truncated)"
+	keep := maxLoggedValueLen - len(truncationMarker)
+	return strings.ToValidUTF8(v[:keep], "") + truncationMarker
 }

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -1,0 +1,90 @@
+package egress
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// Refusals happen before handleWebsocket creates a session span, so until this
+// existed they produced no metric and no trace — only a DEBUG log on a host
+// nobody tails. That blindness was not hypothetical: the egress had been refusing
+// roughly 10 connections per second since at least 2026-07-26 (59,144 in a
+// 100-minute window), every one of them for the same reason, and it went unnoticed
+// because the only evidence was journalctl.
+//
+// Port 9001 is firewalled to localhost and Caddy reverse-proxies /ws to it, so
+// those refusals are not internet scan noise — they are clients that actually
+// reached the endpoint and were turned away. Whether that is one misdirected
+// health check or many broken donors changes what we do about it, and neither the
+// count nor the source was observable.
+
+// Refusal reasons. Values are metric label content, so they are snake_case and
+// bounded: never derive one from request data, or the label becomes unbounded
+// cardinality controlled by whoever is connecting.
+const (
+	refusedMissingSubprotocols = "missing_subprotocols"
+	refusedBadProtocolVersion  = "bad_protocol_version"
+	refusedMissingCSID         = "missing_consumer_session_id"
+)
+
+var (
+	refusalsMx sync.Mutex
+	// refusals is keyed by the constants above only. Entries are never removed;
+	// the set is fixed at three, and a reason that stops occurring should keep
+	// reporting its total rather than vanishing from the series.
+	refusals = map[string]*int64{}
+)
+
+// recordRefusal counts one refused connection. Monotonic on purpose: this is a
+// tally, not a gauge, so consumers can rate() it. Contrast ingress-bytes, which
+// the otel callback drains each interval because it measures throughput.
+func recordRefusal(reason string) {
+	refusalsMx.Lock()
+	c, ok := refusals[reason]
+	if !ok {
+		c = new(int64)
+		refusals[reason] = c
+	}
+	refusalsMx.Unlock()
+	atomic.AddInt64(c, 1)
+}
+
+// eachRefusal reports every reason seen so far. Snapshots under the lock so the
+// otel callback never holds refusalsMx while observing.
+func eachRefusal(f func(reason string, count int64)) {
+	type row struct {
+		reason string
+		c      *int64
+	}
+	refusalsMx.Lock()
+	rows := make([]row, 0, len(refusals))
+	for reason, c := range refusals {
+		rows = append(rows, row{reason, c})
+	}
+	refusalsMx.Unlock()
+
+	for _, r := range rows {
+		f(r.reason, atomic.LoadInt64(r.c))
+	}
+}
+
+// peerAttrs returns slog attributes identifying who was refused.
+//
+// RemoteAddr alone is useless here: Caddy terminates TLS on :443 and proxies to
+// localhost:9001, so every RemoteAddr is 127.0.0.1 with an ephemeral port. The
+// real client is in X-Forwarded-For, which Caddy sets. Both are logged because
+// their disagreement is itself information — an X-Forwarded-For present with a
+// non-loopback RemoteAddr would mean something is reaching 9001 without going
+// through Caddy.
+//
+// User-Agent is the field that actually discriminates the hypotheses: one
+// repeated UA points at a misdirected health check or monitor, many distinct ones
+// point at real clients failing the handshake.
+func peerAttrs(r *http.Request) []any {
+	return []any{
+		"remote_addr", r.RemoteAddr,
+		"forwarded_for", r.Header.Get("X-Forwarded-For"),
+		"user_agent", r.Header.Get("User-Agent"),
+	}
+}

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -199,23 +199,25 @@ func TestRecordRefusal_TakesTypedReason(t *testing.T) {
 // size. On a path refusing ~10 connections/second, writing them verbatim turns a
 // large header into sustained disk pressure, so they must be bounded — while
 // honest values pass through untouched, or the log stops identifying the caller.
-func TestTruncateHeader(t *testing.T) {
-	if got := truncateHeader(""); got != "" {
+func TestTruncateForLog(t *testing.T) {
+	if got := truncateForLog(""); got != "" {
 		t.Errorf("empty: got %q", got)
 	}
 	short := "Mozilla/5.0 (compatible; some-monitor/1.0)"
-	if got := truncateHeader(short); got != short {
+	if got := truncateForLog(short); got != short {
 		t.Errorf("short value was altered: got %q, want %q", got, short)
 	}
-	atLimit := strings.Repeat("a", maxLoggedHeaderLen)
-	if got := truncateHeader(atLimit); got != atLimit {
+	atLimit := strings.Repeat("a", maxLoggedValueLen)
+	if got := truncateForLog(atLimit); got != atLimit {
 		t.Error("a value exactly at the limit must pass through unchanged")
 	}
 
-	over := strings.Repeat("a", maxLoggedHeaderLen+500)
-	got := truncateHeader(over)
-	if len(got) >= len(over) {
-		t.Fatalf("oversized value not bounded: got %d bytes", len(got))
+	over := strings.Repeat("a", maxLoggedValueLen+500)
+	got := truncateForLog(over)
+	// The ceiling must include the marker. A cap its own marker can exceed is
+	// not a cap, and this is the contract the comment on maxLoggedValueLen makes.
+	if len(got) > maxLoggedValueLen {
+		t.Fatalf("result exceeds the documented ceiling: got %d bytes, want <= %d", len(got), maxLoggedValueLen)
 	}
 	if !strings.HasSuffix(got, "…(truncated)") {
 		t.Error("truncation must be marked, or a shortened value is indistinguishable from a short one")
@@ -223,8 +225,8 @@ func TestTruncateHeader(t *testing.T) {
 
 	// A multi-byte value truncated mid-rune must not emit invalid UTF-8, which
 	// would break log ingestion downstream.
-	multi := strings.Repeat("日", maxLoggedHeaderLen) // 3 bytes per rune
-	if got := truncateHeader(multi); !utf8.ValidString(got) {
+	multi := strings.Repeat("日", maxLoggedValueLen) // 3 bytes per rune
+	if got := truncateForLog(multi); !utf8.ValidString(got) {
 		t.Error("truncation produced invalid UTF-8")
 	}
 }

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -230,3 +230,24 @@ func TestTruncateForLog(t *testing.T) {
 		t.Error("truncation produced invalid UTF-8")
 	}
 }
+
+// A value short enough to skip truncation can still be invalid UTF-8, and the
+// helper promises callers that nothing invalid reaches slog.
+func TestTruncateForLog_NormalizesShortInvalidUTF8(t *testing.T) {
+	for name, in := range map[string]string{
+		"lone continuation byte": string([]byte{0xff}),
+		"truncated multibyte":    string([]byte{0xe6, 0x97}), // first 2 bytes of 日
+		"valid then invalid":     "ok" + string([]byte{0xfe}),
+	} {
+		got := truncateForLog(in)
+		if !utf8.ValidString(got) {
+			t.Errorf("%s: truncateForLog(%q) = %q, which is not valid UTF-8", name, in, got)
+		}
+	}
+	// Valid short values must still pass through byte-identical.
+	for _, ok := range []string{"", "curl/8.4.0", "日本語"} {
+		if got := truncateForLog(ok); got != ok {
+			t.Errorf("valid value altered: truncateForLog(%q) = %q", ok, got)
+		}
+	}
+}

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -9,14 +9,15 @@ import (
 func resetRefusals(t *testing.T) {
 	t.Helper()
 	refusalsMx.Lock()
-	refusals = map[string]*int64{}
+	refusals = map[refusalReason]*int64{}
 	refusalsMx.Unlock()
 }
 
-func collectRefusals(t *testing.T) map[string]int64 {
-	t.Helper()
-	out := map[string]int64{}
-	eachRefusal(func(reason string, count int64) { out[reason] = count })
+// Deliberately takes no *testing.T: it is called from the observer goroutine in
+// TestRecordRefusal_NoLostCountsUnderConcurrency, and nothing here needs t.
+func collectRefusals() map[refusalReason]int64 {
+	out := map[refusalReason]int64{}
+	eachRefusal(func(reason refusalReason, count int64) { out[reason] = count })
 	return out
 }
 
@@ -28,15 +29,15 @@ func TestRecordRefusal_IsMonotonicAcrossObservations(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		recordRefusal(refusedMissingSubprotocols)
 	}
-	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 3 {
+	if got := collectRefusals()[refusedMissingSubprotocols]; got != 3 {
 		t.Fatalf("after 3 refusals: got %d, want 3", got)
 	}
 	// A second observation must report the same total, not zero.
-	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 3 {
+	if got := collectRefusals()[refusedMissingSubprotocols]; got != 3 {
 		t.Fatalf("observing drained the tally: got %d, want 3", got)
 	}
 	recordRefusal(refusedMissingSubprotocols)
-	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 4 {
+	if got := collectRefusals()[refusedMissingSubprotocols]; got != 4 {
 		t.Fatalf("after a 4th refusal: got %d, want 4", got)
 	}
 }
@@ -48,8 +49,8 @@ func TestRecordRefusal_SeparatesReasons(t *testing.T) {
 	recordRefusal(refusedBadProtocolVersion)
 	recordRefusal(refusedMissingCSID)
 
-	got := collectRefusals(t)
-	for reason, want := range map[string]int64{
+	got := collectRefusals()
+	for reason, want := range map[refusalReason]int64{
 		refusedMissingSubprotocols: 1,
 		refusedBadProtocolVersion:  2,
 		refusedMissingCSID:         1,
@@ -81,7 +82,7 @@ func TestRecordRefusal_NoLostCountsUnderConcurrency(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				collectRefusals(t)
+				collectRefusals()
 			}
 		}
 	}()
@@ -100,7 +101,7 @@ func TestRecordRefusal_NoLostCountsUnderConcurrency(t *testing.T) {
 	close(stop)
 	obsWg.Wait()
 
-	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != writers*per {
+	if got := collectRefusals()[refusedMissingSubprotocols]; got != writers*per {
 		t.Fatalf("counted %d, want %d", got, writers*per)
 	}
 }
@@ -156,4 +157,38 @@ func TestPeerAttrs_HandlesMissingHeaders(t *testing.T) {
 	if _, present := kv["user_agent"]; !present {
 		t.Error("user_agent key must be present even when the header is absent")
 	}
+}
+
+// The split between "absent" and "malformed" is the whole point of the second
+// reason: they implicate different callers, and conflating them sent the original
+// investigation of ~10 refusals/second toward the wrong hypothesis. Pin that the
+// two constants are distinct and tallied separately, so a future refactor can't
+// quietly collapse them back into one.
+func TestRefusalReasons_AbsentAndMalformedAreDistinct(t *testing.T) {
+	if refusedMissingSubprotocols == refusedMalformedSubprotocols {
+		t.Fatal("absent and malformed must be distinct reasons")
+	}
+
+	resetRefusals(t)
+	recordRefusal(refusedMissingSubprotocols)
+	recordRefusal(refusedMalformedSubprotocols)
+	recordRefusal(refusedMalformedSubprotocols)
+
+	got := collectRefusals()
+	if got[refusedMissingSubprotocols] != 1 {
+		t.Errorf("%s = %d, want 1", refusedMissingSubprotocols, got[refusedMissingSubprotocols])
+	}
+	if got[refusedMalformedSubprotocols] != 2 {
+		t.Errorf("%s = %d, want 2", refusedMalformedSubprotocols, got[refusedMalformedSubprotocols])
+	}
+}
+
+// recordRefusal takes a refusalReason, not a string, so request-derived data
+// cannot reach a metric label without an explicit conversion that a reviewer
+// would see. This compiles only while that holds.
+func TestRecordRefusal_TakesTypedReason(t *testing.T) {
+	var f func(refusalReason) = recordRefusal
+	_ = f
+	// A bare string must not be assignable to the parameter type; if someone
+	// widens it back to string, the line above stops compiling.
 }

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -2,8 +2,10 @@ package egress
 
 import (
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 )
 
 func resetRefusals(t *testing.T) {
@@ -191,4 +193,38 @@ func TestRecordRefusal_TakesTypedReason(t *testing.T) {
 	_ = f
 	// A bare string must not be assignable to the parameter type; if someone
 	// widens it back to string, the line above stops compiling.
+}
+
+// Both headers peerAttrs logs are entirely client-controlled and unbounded in
+// size. On a path refusing ~10 connections/second, writing them verbatim turns a
+// large header into sustained disk pressure, so they must be bounded — while
+// honest values pass through untouched, or the log stops identifying the caller.
+func TestTruncateHeader(t *testing.T) {
+	if got := truncateHeader(""); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+	short := "Mozilla/5.0 (compatible; some-monitor/1.0)"
+	if got := truncateHeader(short); got != short {
+		t.Errorf("short value was altered: got %q, want %q", got, short)
+	}
+	atLimit := strings.Repeat("a", maxLoggedHeaderLen)
+	if got := truncateHeader(atLimit); got != atLimit {
+		t.Error("a value exactly at the limit must pass through unchanged")
+	}
+
+	over := strings.Repeat("a", maxLoggedHeaderLen+500)
+	got := truncateHeader(over)
+	if len(got) >= len(over) {
+		t.Fatalf("oversized value not bounded: got %d bytes", len(got))
+	}
+	if !strings.HasSuffix(got, "…(truncated)") {
+		t.Error("truncation must be marked, or a shortened value is indistinguishable from a short one")
+	}
+
+	// A multi-byte value truncated mid-rune must not emit invalid UTF-8, which
+	// would break log ingestion downstream.
+	multi := strings.Repeat("日", maxLoggedHeaderLen) // 3 bytes per rune
+	if got := truncateHeader(multi); !utf8.ValidString(got) {
+		t.Error("truncation produced invalid UTF-8")
+	}
 }

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -1,0 +1,159 @@
+package egress
+
+import (
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func resetRefusals(t *testing.T) {
+	t.Helper()
+	refusalsMx.Lock()
+	refusals = map[string]*int64{}
+	refusalsMx.Unlock()
+}
+
+func collectRefusals(t *testing.T) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	eachRefusal(func(reason string, count int64) { out[reason] = count })
+	return out
+}
+
+// The tally must be monotonic, unlike ingress-bytes which the otel callback
+// drains each interval. Observing it must not reset it, or every rate() over the
+// metric would be wrong.
+func TestRecordRefusal_IsMonotonicAcrossObservations(t *testing.T) {
+	resetRefusals(t)
+	for i := 0; i < 3; i++ {
+		recordRefusal(refusedMissingSubprotocols)
+	}
+	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 3 {
+		t.Fatalf("after 3 refusals: got %d, want 3", got)
+	}
+	// A second observation must report the same total, not zero.
+	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 3 {
+		t.Fatalf("observing drained the tally: got %d, want 3", got)
+	}
+	recordRefusal(refusedMissingSubprotocols)
+	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != 4 {
+		t.Fatalf("after a 4th refusal: got %d, want 4", got)
+	}
+}
+
+func TestRecordRefusal_SeparatesReasons(t *testing.T) {
+	resetRefusals(t)
+	recordRefusal(refusedMissingSubprotocols)
+	recordRefusal(refusedBadProtocolVersion)
+	recordRefusal(refusedBadProtocolVersion)
+	recordRefusal(refusedMissingCSID)
+
+	got := collectRefusals(t)
+	for reason, want := range map[string]int64{
+		refusedMissingSubprotocols: 1,
+		refusedBadProtocolVersion:  2,
+		refusedMissingCSID:         1,
+	} {
+		if got[reason] != want {
+			t.Errorf("%s = %d, want %d", reason, got[reason], want)
+		}
+	}
+	// Only reasons actually seen should appear; an unseen reason must not
+	// materialize a zero series.
+	if len(got) != 3 {
+		t.Errorf("reported %d reasons, want 3: %v", len(got), got)
+	}
+}
+
+// Refusals arrive concurrently from the HTTP handler while the otel callback
+// observes. No increment may be lost.
+func TestRecordRefusal_NoLostCountsUnderConcurrency(t *testing.T) {
+	resetRefusals(t)
+	const writers, per = 8, 500
+
+	stop := make(chan struct{})
+	var obsWg sync.WaitGroup
+	obsWg.Add(1)
+	go func() {
+		defer obsWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				collectRefusals(t)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < per; j++ {
+				recordRefusal(refusedMissingSubprotocols)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	obsWg.Wait()
+
+	if got := collectRefusals(t)[refusedMissingSubprotocols]; got != writers*per {
+		t.Fatalf("counted %d, want %d", got, writers*per)
+	}
+}
+
+// peerAttrs exists to discriminate "one misdirected monitor" from "many broken
+// clients", so it must surface the forwarded address and User-Agent — RemoteAddr
+// alone is always Caddy's loopback and tells us nothing.
+func TestPeerAttrs_SurfacesForwardedAddressAndUserAgent(t *testing.T) {
+	r := httptest.NewRequest("GET", "/ws", nil)
+	r.RemoteAddr = "127.0.0.1:54321"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7")
+	r.Header.Set("User-Agent", "some-monitor/1.0")
+
+	attrs := peerAttrs(r)
+	if len(attrs)%2 != 0 {
+		t.Fatalf("peerAttrs must return key/value pairs, got odd length %d", len(attrs))
+	}
+	kv := map[string]any{}
+	for i := 0; i < len(attrs); i += 2 {
+		k, ok := attrs[i].(string)
+		if !ok {
+			t.Fatalf("attr key %d is not a string: %#v", i, attrs[i])
+		}
+		kv[k] = attrs[i+1]
+	}
+	for k, want := range map[string]string{
+		"remote_addr":   "127.0.0.1:54321",
+		"forwarded_for": "203.0.113.7",
+		"user_agent":    "some-monitor/1.0",
+	} {
+		if kv[k] != want {
+			t.Errorf("%s = %v, want %q", k, kv[k], want)
+		}
+	}
+}
+
+// Absent headers must yield empty strings rather than panicking or omitting keys,
+// since a client that reaches 9001 without Caddy would have no X-Forwarded-For —
+// and that absence is itself the signal.
+func TestPeerAttrs_HandlesMissingHeaders(t *testing.T) {
+	r := httptest.NewRequest("GET", "/ws", nil)
+	r.RemoteAddr = "10.0.0.5:1234"
+	r.Header.Del("User-Agent")
+
+	kv := map[string]any{}
+	attrs := peerAttrs(r)
+	for i := 0; i < len(attrs); i += 2 {
+		kv[attrs[i].(string)] = attrs[i+1]
+	}
+	if kv["forwarded_for"] != "" {
+		t.Errorf("forwarded_for = %v, want empty", kv["forwarded_for"])
+	}
+	if _, present := kv["user_agent"]; !present {
+		t.Error("user_agent key must be present even when the header is absent")
+	}
+}


### PR DESCRIPTION
## Why

The egress has been refusing **~10 connections/second since at least 2026-07-26** — 59,144 in a single 100-minute window, **100% `missing subprotocols`** — and nobody knew. Refusals happen *before* `handleWebsocket` creates a session span, so the only evidence was a DEBUG line on a host nobody tails.

That's not idle log noise. Port 9001 is firewalled to localhost and Caddy reverse-proxies `/ws` to it (`cloudinit_egress.go:152-153`, `:172`), so these aren't internet scans — they're clients that **reached the endpoint and were turned away**. One misdirected health check is nothing; real donors failing the handshake is a silent outage. Neither the count nor the source was observable, so the question couldn't be answered.

Found while verifying the v2.3.4 deploy. Confirmed **not** caused by the magic-cookie validation added in #375 — the earliest occurrence is Jul 26 on the old binary, and the pre-restart rate was *higher*.

## What

**`refused-websockets` counter**, labelled by `reason` (`missing_subprotocols`, `bad_protocol_version`, `missing_consumer_session_id`).

- **Monotonic** `Int64ObservableCounter`, not an UpDownCounter — a tally to be `rate()`'d, unlike `ingress-bytes` which the callback drains each interval.
- Reason values are **fixed constants, never derived from request data**. A label built from whatever a client sends is unbounded cardinality controlled by the caller.

**Peer identification on each refusal** — `remote_addr`, `forwarded_for`, `user_agent`.

- `RemoteAddr` alone is useless: Caddy proxies from loopback, so every one reads `127.0.0.1`. The real client is in `X-Forwarded-For`.
- Both are logged because **their disagreement is information** — an `X-Forwarded-For` alongside a non-loopback `RemoteAddr` would mean something is reaching 9001 without Caddy.
- `User-Agent` is the field that actually discriminates: one repeated UA → a monitor; many distinct → broken clients.

Only the three **pre-span** refusals are instrumented. Failures after the span exists (accept failed, unresolvable peer, create-or-migrate) already surface as `teardown_reason` from #375.

## Verification

`go build`, `go vet`, `go test -race ./egress/... ./common/...` all pass. The two remaining vet findings are the pre-existing `lostcancel` pair on `origin/main`.

Tests cover monotonicity across repeated observation (a drained tally would make every `rate()` wrong), per-reason separation, no lost counts with 8 writers racing the observer, and `peerAttrs` with headers present and absent.

## After deploy

`refused-websockets` by `reason` in SigNoz gives the volume; the log's `user_agent` and `forwarded_for` give the culprit. Remember to filter or average across `via` — summing triples the figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry for refused WebSocket connections, categorized by refusal reason.
  * Added bounded peer and request metadata to debug logs to help diagnose refusals safely.

* **Bug Fixes**
  * Improved tracking accuracy for repeated and concurrent WebSocket refusals.
  * Distinguished missing, malformed, outdated, and missing-session-ID requests.

* **Tests**
  * Added comprehensive coverage for refusal metrics, request metadata, concurrency, and safe log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->