### PR TITLE
ui: detect widget freezes from the page side

### DIFF
--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -299,6 +299,62 @@ test('ignores a liveness object missing required fields', () => {
 	wd.stop()
 })
 
+// goNowMs feeds only the diagnostic clockSkewMs, so losing it must not cost us the
+// primary staleness signal — and must not leak NaN into a report, where it would
+// look like a measurement rather than an absence.
+test('degrades a missing goNowMs without discarding the staleness signal', () => {
+	const {reports, onReport} = capture()
+	const stuckAt = now
+	const wd = new FreezeWatchdog({
+		liveness: () =>
+			({
+				goTicks: 5,
+				goLastTickMs: stuckAt,
+				goStartedMs: stuckAt - 60_000,
+				goIntervalMs: 1000,
+				// goNowMs deliberately absent
+			} as any),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	// The primary signal survives, so the classification is still correct...
+	expect(reports[0].kind).toBe('main_thread_blocked')
+	expect(reports[0].goStaleMs).toBeGreaterThan(FREEZE_MS)
+	// ...and the diagnostic one is absent rather than NaN.
+	expect(reports[0].clockSkewMs).toBeNull()
+	wd.stop()
+})
+
+// NaN and the infinities are numbers by typeof but poison every comparison exactly
+// like a missing field would, so typeof alone is not a sufficient guard.
+test('rejects non-finite numbers in a liveness snapshot', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: NaN,
+			goLastTickMs: Infinity,
+			goStartedMs: 0,
+			goIntervalMs: 1000,
+			goNowMs: NaN,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	// Treated as no snapshot at all, not as a stalled Go runtime.
+	expect(reports[0].kind).toBe('js_starved')
+	expect(reports[0].goStaleMs).toBeNull()
+	expect(reports[0].clockSkewMs).toBeNull()
+	wd.stop()
+})
+
 // A wedged Go runtime is a standing condition, not an event: it matches on every
 // single tick. Unthrottled that is one report every TICK_MS, which fills the
 // retained-report ring in under three minutes and evicts the 'page_died' record
@@ -407,9 +463,64 @@ describe('breadcrumb recovery', () => {
 		// The distinction that matters: a hiccup annoys a user, a death silently
 		// removes a donor from the network.
 		expect(reports[0].recovered).toBe(false)
-		expect(reports[0].sharing).toBe(false) // sharing reflects *this* page life
+		// The dead tab's own evidence, not this page life's. This is the entire
+		// reason the breadcrumb carries them: they are the only account of what that
+		// tab was doing when it stopped. Reading them from `this` instead yields null
+		// attribution and sharing=false at startup, which silently discards the
+		// explanation for the death being reported.
+		expect(reports[0].longestTaskMs).toBe(31_000)
+		expect(reports[0].longestTaskName).toBe('three-globe')
+		expect(reports[0].sharing).toBe(true)
 		// Reported once, then cleared, so reloading does not re-report it forever.
 		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
+	// A record truncated mid-write or left by an older version can carry any type,
+	// and a wrong type here reaches the console and the beacon body.
+	test('does not trust the types of recovered evidence fields', () => {
+		writeCrumb({
+			t: 'deadtab',
+			b: now - DEAD_TAB_MS - 60_000,
+			s: now - DEAD_TAB_MS - 600_000,
+			c: false,
+			h: false,
+			p: 'yes', // not a boolean
+			l: 'thirty seconds', // not a number
+			n: {evil: true}, // not a string
+		})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].longestTaskMs).toBeNull()
+		expect(reports[0].longestTaskName).toBeNull()
+		expect(reports[0].sharing).toBe(true) // coerced, since 'yes' is truthy
+		wd.stop()
+	})
+
+	// The attribution string round-trips through storage and lands in a console line
+	// and a beacon body, so it is bounded on the way back out.
+	test('bounds a recovered long-task name', () => {
+		writeCrumb({
+			t: 'deadtab',
+			b: now - DEAD_TAB_MS - 60_000,
+			s: now - DEAD_TAB_MS - 600_000,
+			c: false,
+			h: false,
+			p: false,
+			l: 9000,
+			n: 'x'.repeat(5000),
+		})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].longestTaskName!.length).toBeLessThanOrEqual(128)
 		wd.stop()
 	})
 

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -497,7 +497,9 @@ describe('breadcrumb recovery', () => {
 		expect(reports).toHaveLength(1)
 		expect(reports[0].longestTaskMs).toBeNull()
 		expect(reports[0].longestTaskName).toBeNull()
-		expect(reports[0].sharing).toBe(true) // coerced, since 'yes' is truthy
+		// Not coerced: 'yes' is truthy, and reporting sharing=true off a non-boolean
+		// would assert something about the dead tab that the record never said.
+		expect(reports[0].sharing).toBe(false)
 		wd.stop()
 	})
 
@@ -595,6 +597,93 @@ describe('breadcrumb recovery', () => {
 		window.dispatchEvent(new Event('pagehide'))
 
 		expect(JSON.parse(window.localStorage.getItem(own!)!).c).toBe(true)
+		wd.stop()
+	})
+
+	// A tick running after pagehide would rewrite the record with c:false and
+	// resurrect a cleanly-closed page as a casualty — turning every ordinary
+	// navigation into a reported crash.
+	test('does not let a later tick undo the clean flag', () => {
+		const wd = new FreezeWatchdog({})
+		wd.start()
+		const own = Object.keys(window.localStorage).find(k => k.startsWith('unbounded.watchdog.'))!
+
+		window.dispatchEvent(new Event('pagehide'))
+		fireTick(TICK_MS)
+		fireTick(TICK_MS)
+
+		expect(JSON.parse(window.localStorage.getItem(own)!).c).toBe(true)
+		wd.stop()
+	})
+
+	// A back/forward-cache restore makes the page a live donor again. Leaving it
+	// stopped would keep pagehide's clean flag in place forever, so a later kill
+	// would go unreported — trading a false positive for a false negative on the one
+	// case this path exists to catch.
+	test('resumes beating after a back/forward-cache restore', () => {
+		const wd = new FreezeWatchdog({})
+		wd.start()
+		const own = Object.keys(window.localStorage).find(k => k.startsWith('unbounded.watchdog.'))!
+
+		window.dispatchEvent(new Event('pagehide'))
+		expect(JSON.parse(window.localStorage.getItem(own)!).c).toBe(true)
+
+		// Frozen in the cache for ten minutes, then restored.
+		advance(10 * 60 * 1000)
+		window.dispatchEvent(new Event('pageshow'))
+
+		// Beating again, and no longer flagged as cleanly exited.
+		expect(JSON.parse(window.localStorage.getItem(own)!).c).toBe(false)
+		const beforeTick = JSON.parse(window.localStorage.getItem(own)!).b
+		fireTick(TICK_MS)
+		expect(JSON.parse(window.localStorage.getItem(own)!).b).toBeGreaterThan(beforeTick)
+		wd.stop()
+	})
+
+	// Ten minutes of wall clock passed while the page sat frozen in the cache, but
+	// nothing was wrong. An un-reset baseline would turn that whole interval into a
+	// fabricated freeze the instant the page came back.
+	test('does not report a freeze for time spent in the back/forward cache', () => {
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		window.dispatchEvent(new Event('pagehide'))
+		advance(10 * 60 * 1000)
+		window.dispatchEvent(new Event('pageshow'))
+
+		for (let i = 0; i < 5; i++) fireTick(TICK_MS)
+
+		expect(reports).toEqual([])
+		wd.stop()
+	})
+
+	// Of the two ways to be wrong about a malformed record, inventing a casualty is
+	// far cheaper than silently dropping one — so the clean-exit check is strict.
+	// The string "false" is truthy, and treating it as clean would suppress a real
+	// death report.
+	test('does not treat a truthy non-boolean clean flag as a clean exit', () => {
+		writeCrumb({
+			t: 'deadtab',
+			b: now - DEAD_TAB_MS - 60_000,
+			s: now - DEAD_TAB_MS - 600_000,
+			c: 'false',
+			h: 'false',
+			p: 'false',
+			l: null,
+			n: null,
+		})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].kind).toBe('page_died')
+		// And the same strictness applies to the report fields, so a non-boolean does
+		// not mislabel the report it is meant to explain.
+		expect(reports[0].hidden).toBe(false)
+		expect(reports[0].sharing).toBe(false)
 		wd.stop()
 	})
 

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -1,0 +1,543 @@
+import {FreezeReport, FreezeWatchdog} from './freezeWatchdog'
+
+// These mirror the constants in freezeWatchdog.ts. Duplicated rather than
+// exported: the thresholds are an implementation choice, and a test that imported
+// them would pass even if freezeMs were set to a value that never fires.
+const TICK_MS = 2000
+const FREEZE_MS = 8000
+const DEAD_TAB_MS = 5 * 60 * 1000
+
+// Advancing time is the whole point of these tests, so the clock is driven
+// explicitly rather than with jest's fake timers alone — the watchdog compares
+// Date.now() against its own last tick, and jest's timer mocks move the timer
+// queue without moving Date.now() unless told to.
+let now = 1_700_000_000_000
+
+const setNow = (t: number) => {
+	now = t
+}
+const advance = (ms: number) => {
+	now += ms
+}
+
+// fireTick runs the interval callback exactly once after moving the wall clock by
+// `gapMs`, simulating a tick that came due and fired late — which is what a
+// blocked event loop produces.
+//
+// Timer time advances by only TICK_MS regardless of gapMs, deliberately: browsers
+// do not replay intervals missed during a block, they fire once and resume.
+// Advancing timer time by the full gap would replay them and test behavior no
+// browser produces.
+const fireTick = (gapMs: number) => {
+	advance(gapMs)
+	jest.advanceTimersByTime(TICK_MS)
+}
+
+let visibility: DocumentVisibilityState = 'visible'
+
+beforeEach(() => {
+	jest.useFakeTimers()
+	jest.spyOn(Date, 'now').mockImplementation(() => now)
+	setNow(1_700_000_000_000)
+	visibility = 'visible'
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true,
+		get: () => visibility,
+	})
+	window.localStorage.clear()
+})
+
+afterEach(() => {
+	jest.useRealTimers()
+	jest.restoreAllMocks()
+	window.localStorage.clear()
+})
+
+const capture = () => {
+	const reports: FreezeReport[] = []
+	return {reports, onReport: (r: FreezeReport) => reports.push(r)}
+}
+
+// A healthy page must stay silent. This is the test that matters most in
+// practice: a watchdog that cries freeze during normal operation gets muted, and
+// then reports nothing when a real freeze happens.
+test('stays silent while ticks and Go heartbeat are both on time', () => {
+	const {reports, onReport} = capture()
+	let goTicks = 0
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: ++goTicks,
+			goLastTickMs: now,
+			goStartedMs: now - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	for (let i = 0; i < 20; i++) fireTick(TICK_MS)
+
+	expect(reports).toEqual([])
+	wd.stop()
+})
+
+// Both sides starve together when the shared thread is blocked, which is the
+// second freeze observed on 2026-08-03 — engine alive in netstate, page frozen.
+test('classifies a stalled Go heartbeat plus a starved timer as main_thread_blocked', () => {
+	const {reports, onReport} = capture()
+	const frozenAt = now
+	const wd = new FreezeWatchdog({
+		// Go's last tick stops advancing, as it must when the thread it shares is
+		// blocked.
+		liveness: () => ({
+			goTicks: 5,
+			goLastTickMs: frozenAt,
+			goStartedMs: frozenAt - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('main_thread_blocked')
+	expect(reports[0].gapMs).toBeGreaterThan(FREEZE_MS)
+	expect(reports[0].goStaleMs).toBeGreaterThan(FREEZE_MS)
+	// Every live detection is by definition survived — we had to run again to
+	// notice. Only a breadcrumb can report an unrecovered freeze.
+	expect(reports[0].recovered).toBe(true)
+	wd.stop()
+})
+
+// The crisp case, and the only reason the Go heartbeat exists: our timer is
+// perfectly on schedule, so the thread is fine and the Go scheduler is not. An
+// earlier version of this file gated Go staleness on our own gap, which made this
+// classification unreachable.
+test('classifies a stalled Go heartbeat with punctual ticks as go_scheduler_wedged', () => {
+	const {reports, onReport} = capture()
+	const frozenAt = now
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: 5,
+			goLastTickMs: frozenAt,
+			goStartedMs: frozenAt - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	// Punctual ticks throughout: no gap ever exceeds FREEZE_MS.
+	for (let i = 0; i < 8; i++) fireTick(TICK_MS)
+
+	expect(reports.length).toBeGreaterThan(0)
+	expect(reports[0].kind).toBe('go_scheduler_wedged')
+	expect(reports[0].gapMs).toBeLessThanOrEqual(TICK_MS)
+	wd.stop()
+})
+
+// When the thread frees up after a block, our timer callback can run before Go's
+// ticker goroutine is rescheduled, so Go's heartbeat still looks stale while
+// actually being fine. Reporting that would relabel every main-thread block as
+// also being a Go wedge moments later — collapsing exactly the two failure modes
+// this watchdog exists to separate.
+test('does not blame Go on the punctual tick right after a block', () => {
+	const {reports, onReport} = capture()
+	// Go's ticker cannot run while the thread is blocked, so its last tick stays
+	// pinned at stuckAt. Once the thread frees up it resumes and tracks the clock,
+	// which is what stuckAt = null models.
+	let stuckAt: number | null = now
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: 7,
+			goLastTickMs: stuckAt ?? now,
+			goStartedMs: now - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+	expect(reports.map(r => r.kind)).toEqual(['main_thread_blocked'])
+
+	// The thread recovers, but Go's heartbeat is momentarily still stale on our
+	// next tick: its goroutine has not been rescheduled yet. This single tick is
+	// the false positive being guarded against.
+	fireTick(TICK_MS)
+	// Now Go's ticker is running again.
+	stuckAt = null
+
+	for (let i = 0; i < 10; i++) fireTick(TICK_MS)
+
+	expect(reports.map(r => r.kind)).toEqual(['main_thread_blocked'])
+	wd.stop()
+})
+
+// Our timer was starved while Go kept ticking: not a full block, something
+// monopolized the task queue ahead of us.
+test('classifies a starved timer with a live Go heartbeat as js_starved', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({
+		// goLastTickMs tracks the current clock, i.e. Go never stopped.
+		liveness: () => ({
+			goTicks: 99,
+			goLastTickMs: now,
+			goStartedMs: now - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('js_starved')
+	wd.stop()
+})
+
+// Background tabs have their timers throttled to roughly one per minute, so a
+// hidden tab produces gaps far beyond FREEZE_MS while being perfectly healthy.
+// Reporting those would make the signal useless — most donor tabs sit in the
+// background, which is the entire point of the widget.
+test('does not report a gap produced while the tab was hidden', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({onReport})
+	wd.start()
+
+	visibility = 'hidden'
+	document.dispatchEvent(new Event('visibilitychange'))
+	fireTick(90_000)
+
+	expect(reports).toEqual([])
+	wd.stop()
+})
+
+// The gate has to survive a full hide/show cycle between two ticks. Checking
+// visibilityState at tick time alone would miss this: the tab is visible again by
+// the time we look, but the gap it produced was throttling, not a freeze.
+test('does not report a gap spanning a hide/show cycle', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({onReport})
+	wd.start()
+
+	visibility = 'hidden'
+	document.dispatchEvent(new Event('visibilitychange'))
+	advance(90_000)
+	visibility = 'visible'
+	document.dispatchEvent(new Event('visibilitychange'))
+	fireTick(TICK_MS)
+
+	expect(reports).toEqual([])
+
+	// ...and the very next real freeze is still caught, i.e. the gate suppresses
+	// one interval rather than latching off.
+	fireTick(FREEZE_MS + 4000)
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('js_starved')
+	wd.stop()
+})
+
+// The deployed widget.wasm predates the Go heartbeat, so liveness() being absent
+// is the live configuration, not a hypothetical. JS-side detection must still work.
+test('detects a freeze with no liveness() available', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({onReport})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('js_starved')
+	// Nulls rather than zeros: a missing heartbeat must not read as "Go is fine".
+	expect(reports[0].goStaleMs).toBeNull()
+	expect(reports[0].goTicks).toBeNull()
+	wd.stop()
+})
+
+// A wedged Go runtime can make the boundary call itself throw, and a watchdog
+// that dies on the failure it is watching for is worse than none.
+test('survives liveness() throwing', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({
+		liveness: () => {
+			throw new Error('wasm call failed')
+		},
+		onReport,
+	})
+	wd.start()
+
+	expect(() => fireTick(FREEZE_MS + 4000)).not.toThrow()
+	expect(reports).toHaveLength(1)
+	expect(reports[0].goStaleMs).toBeNull()
+	wd.stop()
+})
+
+// A malformed liveness object must not be treated as data. Reading a missing
+// field yields NaN, and NaN comparisons are all false — so a shape change in the
+// Go snapshot would silently disable detection rather than fail loudly.
+test('ignores a liveness object missing required fields', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({
+		liveness: () => ({goTicks: 1} as any),
+		onReport,
+	})
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].goStaleMs).toBeNull()
+	wd.stop()
+})
+
+// A wedged Go runtime is a standing condition, not an event: it matches on every
+// single tick. Unthrottled that is one report every TICK_MS, which fills the
+// retained-report ring in under three minutes and evicts the 'page_died' record
+// recovered at startup — the only evidence of a freeze nobody survived.
+test('throttles a standing condition instead of reporting it every tick', () => {
+	const {reports, onReport} = capture()
+	const frozenAt = now
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: 5,
+			goLastTickMs: frozenAt,
+			goStartedMs: frozenAt - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	// Five minutes of punctual ticks with Go wedged the whole time.
+	const ticks = 150
+	for (let i = 0; i < ticks; i++) fireTick(TICK_MS)
+
+	expect(reports.every(r => r.kind === 'go_scheduler_wedged')).toBe(true)
+	// One per suppression window, give or take a boundary — emphatically not one
+	// per tick.
+	expect(reports.length).toBeLessThanOrEqual(6)
+	expect(reports.length).toBeGreaterThanOrEqual(2)
+	expect(reports.length).toBeLessThan(ticks / 10)
+	wd.stop()
+})
+
+// Throttling is per-kind: a new failure surfacing while another is standing is
+// news, and muting it would hide a main-thread block behind an ongoing Go wedge.
+test('does not let a throttled kind suppress a different kind', () => {
+	const {reports, onReport} = capture()
+	// Already well past the threshold at start, so the verdict lands as soon as the
+	// punctual-tick evidence accumulates rather than waiting for staleness to grow.
+	const frozenAt = now - 20_000
+	const wd = new FreezeWatchdog({
+		liveness: () => ({
+			goTicks: 5,
+			goLastTickMs: frozenAt,
+			goStartedMs: frozenAt - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}),
+		onReport,
+	})
+	wd.start()
+
+	// Two punctual ticks to earn the Go verdict (see minPunctualTicks).
+	fireTick(TICK_MS)
+	fireTick(TICK_MS)
+	expect(reports.map(r => r.kind)).toEqual(['go_scheduler_wedged'])
+
+	// Now our timer starves too, well inside the suppression window.
+	fireTick(FREEZE_MS + 1000)
+	expect(reports.map(r => r.kind)).toEqual(['go_scheduler_wedged', 'main_thread_blocked'])
+	wd.stop()
+})
+
+// Distinct gaps separated by more than the suppression window are distinct
+// episodes, and collapsing them would hide that a page is freezing repeatedly.
+test('reports separate episodes separated by more than the suppression window', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({onReport})
+	wd.start()
+
+	fireTick(FREEZE_MS + 1000)
+	for (let i = 0; i < 40; i++) fireTick(TICK_MS) // 80s of calm
+	fireTick(FREEZE_MS + 1000)
+
+	expect(reports.map(r => r.kind)).toEqual(['js_starved', 'js_starved'])
+	wd.stop()
+})
+
+describe('breadcrumb recovery', () => {
+	const KEY = 'unbounded.watchdog.deadtab'
+
+	const writeCrumb = (crumb: Record<string, unknown>) =>
+		window.localStorage.setItem(KEY, JSON.stringify(crumb))
+
+	// The only detector for a freeze that never ended. A page that stays frozen
+	// cannot report anything, so the evidence has to be read back on the next load.
+	// This also catches renderer crashes and OS kills, which is how the iOS jetsam
+	// kills behind eng#3698 would present.
+	test('reports a tab that stopped beating without firing pagehide', () => {
+		writeCrumb({
+			t: 'deadtab',
+			b: now - DEAD_TAB_MS - 60_000,
+			s: now - DEAD_TAB_MS - 600_000,
+			c: false,
+			h: false,
+			p: true,
+			l: 31_000,
+			n: 'three-globe',
+		})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].kind).toBe('page_died')
+		// The distinction that matters: a hiccup annoys a user, a death silently
+		// removes a donor from the network.
+		expect(reports[0].recovered).toBe(false)
+		expect(reports[0].sharing).toBe(false) // sharing reflects *this* page life
+		// Reported once, then cleared, so reloading does not re-report it forever.
+		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
+	// pagehide is the clean-exit flag precisely so ordinary navigation is not
+	// mistaken for a death. If this leaked, every reload would report a freeze.
+	test('ignores a tab that exited cleanly', () => {
+		writeCrumb({t: 'deadtab', b: now - DEAD_TAB_MS - 60_000, s: now - 600_000, c: true, h: false, p: false, l: null, n: null})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toEqual([])
+		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
+	// A live tab in another window that has been backgrounded beats only about once
+	// a minute. Its record is stale but it is not dead, and reporting it would
+	// manufacture freezes out of healthy background donors.
+	test('leaves a recently-beating tab alone', () => {
+		writeCrumb({t: 'deadtab', b: now - 60_000, s: now - 600_000, c: false, h: true, p: true, l: null, n: null})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toEqual([])
+		// Still owned by that tab, so it must survive our sweep.
+		expect(window.localStorage.getItem(KEY)).not.toBeNull()
+		wd.stop()
+	})
+
+	// A record truncated by a quota failure mid-write, or left by an older version,
+	// is unusable — and must not throw on the startup path.
+	test('discards unparseable and malformed records without throwing', () => {
+		window.localStorage.setItem('unbounded.watchdog.garbage', '{not json')
+		window.localStorage.setItem('unbounded.watchdog.noBeat', JSON.stringify({t: 'x', c: false}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		expect(() => wd.start()).not.toThrow()
+
+		expect(reports).toEqual([])
+		expect(window.localStorage.getItem('unbounded.watchdog.garbage')).toBeNull()
+		expect(window.localStorage.getItem('unbounded.watchdog.noBeat')).toBeNull()
+		wd.stop()
+	})
+
+	// A week-old death is not news, and reporting it on every load would bury
+	// current problems.
+	test('expires records older than the retention window', () => {
+		writeCrumb({t: 'deadtab', b: now - 48 * 60 * 60 * 1000, s: now - 49 * 60 * 60 * 1000, c: false, h: false, p: false, l: null, n: null})
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toEqual([])
+		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
+	// pagehide flags the exit so the next load does not report this navigation as a
+	// death. This is the one write that must not be skipped.
+	test('marks its own record clean on pagehide', () => {
+		const wd = new FreezeWatchdog({})
+		wd.start()
+		const own = Object.keys(window.localStorage).find(k => k.startsWith('unbounded.watchdog.'))
+		expect(own).toBeDefined()
+
+		window.dispatchEvent(new Event('pagehide'))
+
+		expect(JSON.parse(window.localStorage.getItem(own!)!).c).toBe(true)
+		wd.stop()
+	})
+
+	// A watchdog that crashes the page it is watching would be worse than no
+	// watchdog. Safari private browsing throws on the property access itself, not
+	// just on setItem, so that is what is simulated here.
+	test('runs with localStorage unavailable', () => {
+		const real = Object.getOwnPropertyDescriptor(window, 'localStorage')
+		Object.defineProperty(window, 'localStorage', {
+			configurable: true,
+			get() {
+				throw new Error('SecurityError: localStorage is not available')
+			},
+		})
+
+		try {
+			const {reports, onReport} = capture()
+			const wd = new FreezeWatchdog({onReport})
+			expect(() => wd.start()).not.toThrow()
+			expect(() => fireTick(FREEZE_MS + 4000)).not.toThrow()
+
+			// Live detection still works; only crash recovery is lost.
+			expect(reports).toHaveLength(1)
+			wd.stop()
+		} finally {
+			if (real) Object.defineProperty(window, 'localStorage', real)
+		}
+	})
+})
+
+// Reports are retained in memory for console inspection, so a page that freezes
+// in a loop must not turn its own diagnostics into the leak.
+test('bounds retained reports', () => {
+	const wd = new FreezeWatchdog({})
+	jest.spyOn(console, 'warn').mockImplementation(() => {})
+	wd.start()
+
+	for (let i = 0; i < 40; i++) fireTick(FREEZE_MS + 4000)
+
+	expect(wd.reports.length).toBeLessThanOrEqual(20)
+	wd.stop()
+})
+
+// start() is called from WasmInterface.initialize, which React's dev server can
+// invoke more than once on hot reload — the same hazard the initializing flag
+// there guards against.
+test('start is idempotent', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({onReport})
+	wd.start()
+	wd.start()
+
+	fireTick(FREEZE_MS + 4000)
+
+	expect(reports).toHaveLength(1)
+	wd.stop()
+})

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -1,0 +1,579 @@
+// freezeWatchdog.ts is the page-side half of the freeze watchdog. The Go half
+// (clientcore/watchdog_wasm_impl.go) only publishes a heartbeat; all detection
+// lives here, because the failure this exists to catch is one Go cannot report.
+//
+// Both freezes observed on unbounded.lantern.io on 2026-08-03 were invisible in
+// telemetry, and they were not the same failure:
+//
+//   - the first took the netstate vertex and all four of its edges away, i.e. the
+//     engine stopped
+//   - the second left the vertex current and all four edges intact while the page
+//     was visually frozen, i.e. the engine was fine and the main thread was not
+//
+// Telling those apart is the whole job, and it is possible only from here: Go/wasm
+// and JS share one thread but fail independently, so comparing a JS timer against
+// Go's tick counter isolates which side stopped.
+//
+// The harder problem is that a page which freezes and stays frozen cannot report
+// anything — no timer, no beacon, no console. So detection alone is not enough.
+// Every tick also writes a breadcrumb to localStorage, and startup reads back
+// records left by tabs that stopped beating without ever saying goodbye. That is
+// the only path that catches a permanent freeze, a renderer crash, or an OS kill
+// (the iOS jetsam kills behind eng#3698 look exactly like this).
+//
+// Deliberately not OpenTelemetry: the otel Go SDK was found to abuse the call
+// stack in ways mobile Safari does not tolerate, so widget-side telemetry stays
+// primitive on both sides of the boundary.
+
+// tickMs is how often the watchdog samples. Frequent enough that an 8s freeze is
+// caught by a wide margin, cheap enough to be irrelevant: one Date.now(), one
+// liveness() call, one small localStorage write.
+const tickMs = 2000
+
+// freezeMs is the gap between watchdog ticks that counts as a freeze while the
+// tab is visible. Well above tickMs so ordinary scheduler jitter and GC pauses
+// never qualify, and above the ~1s stalls a heavy WebGL frame can cause — the
+// point is to catch what a user would call a freeze, not every long frame.
+const freezeMs = 8000
+
+// deadTabMs is how stale a breadcrumb must be before startup calls that tab dead.
+// Much larger than freezeMs on purpose: a *live* tab in another window that has
+// been backgrounded is throttled to roughly one timer per minute, so anything
+// near freezeMs would report healthy background tabs as casualties.
+const deadTabMs = 5 * 60 * 1000
+
+const storagePrefix = 'unbounded.watchdog.'
+// Bounds on the breadcrumb sweep. Records are normally deleted as they are read,
+// so these only matter when something goes wrong repeatedly and nobody reloads.
+const storageTtlMs = 24 * 60 * 60 * 1000
+const maxStoredTabs = 8
+
+// maxReports caps what we retain in memory for window.__unboundedWatchdog. A page
+// that freezes in a loop must not turn its own diagnostics into the leak.
+const maxReports = 20
+
+// repeatSuppressMs throttles repeats of a kind already reported.
+//
+// A wedged Go runtime is a *standing* condition, not an event: goLastTickMs stays
+// stale forever while our own ticks remain punctual, so every single tick matches
+// and would report. At tickMs that is one report every 2s, which fills maxReports
+// in well under three minutes and evicts the 'page_died' record recovered at
+// startup — the most valuable report we hold, and the only evidence of a freeze
+// nobody survived. Suppression is per-kind so a *different* failure appearing
+// during a standing one is still news and passes straight through.
+const repeatSuppressMs = 60_000
+
+// minPunctualTicks is how many consecutive on-time ticks must precede a
+// 'go_scheduler_wedged' verdict.
+//
+// Blaming Go requires positive evidence that the thread is healthy, and the tick
+// immediately after a block is not that evidence: when the thread frees up, our
+// timer callback can run before Go's ticker goroutine is rescheduled, so Go looks
+// stale while actually being fine. Without this guard every main-thread block is
+// followed by a spurious Go-wedge report — precisely the confusion between the two
+// failure modes that this watchdog exists to remove.
+//
+// Two ticks is 2 * tickMs of demonstrably healthy thread, several times Go's own
+// heartbeat interval, so a heartbeat still stale by then really is wedged.
+const minPunctualTicks = 2
+
+// FreezeKind is what stopped, not merely that something did. These map onto the
+// truth table in watchdog_wasm_impl.go, and they have different fixes — which is
+// exactly why the original "the widget froze" reports were not actionable.
+export type FreezeKind =
+	// Our timer was starved and Go's tick stalled with it. Both starve together
+	// when the shared thread is blocked, so this points at the page: a long task,
+	// a synchronous layout, a WebGL stall.
+	| 'main_thread_blocked'
+	// Our timer fired on schedule and Go's tick did not advance. The thread was
+	// fine, so the Go scheduler is wedged — a deadlock, or a goroutine looping
+	// without yielding.
+	| 'go_scheduler_wedged'
+	// Our timer was starved while Go kept ticking. Not a full block; something
+	// monopolized the task queue ahead of us.
+	| 'js_starved'
+	// Reconstructed at startup from a breadcrumb: a previous page life stopped
+	// beating and never fired pagehide. Unlike the three above, this one was never
+	// survived — see `recovered`.
+	| 'page_died'
+
+export interface FreezeReport {
+	kind: FreezeKind
+	detectedAt: number
+	// recovered distinguishes a freeze the page came back from — which is every
+	// live detection, since detecting it requires running again — from one it never
+	// came back from. Only 'page_died' is unrecovered, and it is the severe case:
+	// a hiccup annoys a user, a death silently removes a donor from the network.
+	recovered: boolean
+	// gapMs is the observed interval between watchdog ticks (for 'page_died', the
+	// staleness of the final breadcrumb). Compare against tickMs.
+	gapMs: number
+	// goStaleMs is how old Go's last tick was when we noticed. null when the wasm
+	// binary predates the Go heartbeat, or when the engine was never started.
+	goStaleMs: number | null
+	goTicks: number | null
+	// clockSkewMs is our Date.now() minus Go's, sampled around the same call. A
+	// large value means the liveness() call itself queued behind a blocked event
+	// loop — a freeze signal no counter delta reveals, since the counter is only
+	// read once the queue drains.
+	clockSkewMs: number | null
+	// The worst long task seen in this page life. This is the attribution signal:
+	// a 30-second long task *is* the freeze, and its container name is the suspect.
+	longestTaskMs: number | null
+	longestTaskName: string | null
+	// hidden records whether the tab was backgrounded, so a reader can discount a
+	// report that slipped past the visibility gate below.
+	hidden: boolean
+	// sharing separates a freeze while idle from one while actually proxying. The
+	// two implicate different code, and the observed freezes happened while live.
+	sharing: boolean
+	url: string
+	userAgent: string
+}
+
+// Breadcrumb is the localStorage record. Field names are short because this is
+// rewritten every tick.
+interface Breadcrumb {
+	t: string // tab id
+	b: number // last beat, epoch ms
+	s: number // page start, epoch ms
+	c: boolean // closed cleanly (pagehide fired)
+	h: boolean // hidden at last beat
+	p: boolean // sharing at last beat
+	l: number | null // longest task ms
+	n: string | null // longest task name
+}
+
+// Liveness mirrors the object returned by Go's liveness(). Field names are a
+// contract with watchdog_wasm_impl.go's snapshot(); renaming one there silently
+// disables Go-side detection here, which is why they are typed rather than read
+// loosely.
+interface Liveness {
+	goTicks: number
+	goLastTickMs: number
+	goStartedMs: number
+	goIntervalMs: number
+	goNowMs: number
+}
+
+// WatchdogContext supplies what only the caller knows. Passed in rather than
+// imported so this module stays free of app dependencies — wasmInterface imports
+// it, and importing back would be a cycle.
+export interface WatchdogContext {
+	// liveness returns Go's heartbeat, or undefined before the wasm client exists.
+	// Called through a getter every tick because the client is built asynchronously
+	// and may be rebuilt; capturing it once would read a stale object forever.
+	liveness?: () => Liveness | undefined
+	// sharing reports whether the widget is currently proxying.
+	sharing?: () => boolean
+	// onReport is called for each freeze. Defaults to console + beacon.
+	onReport?: (report: FreezeReport) => void
+}
+
+// safeStorage centralizes the fact that localStorage is not always usable: it
+// throws outright in Safari private browsing and when the quota is exhausted. A
+// watchdog that crashes the page it is watching would be worse than no watchdog,
+// so every access is guarded and failure is silent by design.
+const safeStorage = {
+	get(): Storage | null {
+		try {
+			return window.localStorage
+		} catch {
+			return null
+		}
+	},
+	read(key: string): string | null {
+		try {
+			return this.get()?.getItem(key) ?? null
+		} catch {
+			return null
+		}
+	},
+	write(key: string, value: string): void {
+		try {
+			this.get()?.setItem(key, value)
+		} catch {
+			// Quota or private mode. Live detection still works; only the
+			// crash-recovery path is lost.
+		}
+	},
+	remove(key: string): void {
+		try {
+			this.get()?.removeItem(key)
+		} catch {
+			// ignore
+		}
+	},
+	keys(): string[] {
+		try {
+			const s = this.get()
+			if (!s) return []
+			const out: string[] = []
+			for (let i = 0; i < s.length; i++) {
+				const k = s.key(i)
+				if (k && k.startsWith(storagePrefix)) out.push(k)
+			}
+			return out
+		} catch {
+			return []
+		}
+	},
+}
+
+const newTabId = (): string =>
+	// Not security-sensitive: this only has to avoid two tabs of the same page
+	// sharing a storage key.
+	`${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+
+export class FreezeWatchdog {
+	private readonly ctx: WatchdogContext
+	private readonly tabId = newTabId()
+	private readonly startedAt = Date.now()
+	private readonly storageKey: string
+
+	private timer: ReturnType<typeof setInterval> | undefined
+	private observer: PerformanceObserver | undefined
+	private lastTickAt = Date.now()
+	// hiddenSinceLastTick makes the visibility gate correct across a full
+	// hide/show cycle between two ticks. Checking visibilityState at tick time
+	// alone would miss it: the tab is visible again by then, but the gap it
+	// produced was throttling, not a freeze.
+	private hiddenSinceLastTick = false
+	private longestTaskMs: number | null = null
+	private longestTaskName: string | null = null
+	// Consecutive on-time ticks, i.e. how much evidence we have that the thread is
+	// currently healthy. See minPunctualTicks.
+	private punctualTicks = 0
+	// When each kind was last reported, so a standing condition is throttled
+	// without muting a newly-appearing one. See repeatSuppressMs.
+	private lastReportAt = new Map<FreezeKind, number>()
+
+	readonly reports: FreezeReport[] = []
+
+	constructor(ctx: WatchdogContext = {}) {
+		this.ctx = ctx
+		this.storageKey = storagePrefix + this.tabId
+	}
+
+	// start begins watching and reports anything left behind by a previous page
+	// life. Safe to call twice; the second call is ignored.
+	start(): void {
+		if (this.timer) return
+
+		// Sweep first, so a death is reported even if this page life is short.
+		this.recoverBreadcrumbs()
+
+		this.observeLongTasks()
+		document.addEventListener('visibilitychange', this.onVisibilityChange)
+		// pagehide rather than unload: unload does not fire reliably on mobile
+		// Safari, and treating a normal navigation as a death would drown the real
+		// signal in false positives.
+		window.addEventListener('pagehide', this.onPageHide)
+
+		this.lastTickAt = Date.now()
+		this.writeBreadcrumb(false)
+		this.timer = setInterval(this.tick, tickMs)
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer)
+			this.timer = undefined
+		}
+		this.observer?.disconnect()
+		this.observer = undefined
+		document.removeEventListener('visibilitychange', this.onVisibilityChange)
+		window.removeEventListener('pagehide', this.onPageHide)
+		// An explicit stop is a clean exit; leaving the record un-flagged would
+		// make the next load report this tab as dead.
+		safeStorage.remove(this.storageKey)
+	}
+
+	// snapshot exposes current state for manual inspection from the console. The
+	// most likely consumer is someone poking at a tab that just misbehaved.
+	snapshot() {
+		const live = this.readLiveness()
+		return {
+			tabId: this.tabId,
+			startedAt: this.startedAt,
+			lastTickAt: this.lastTickAt,
+			sinceLastTickMs: Date.now() - this.lastTickAt,
+			longestTaskMs: this.longestTaskMs,
+			longestTaskName: this.longestTaskName,
+			liveness: live ?? null,
+			longTasksSupported: this.observer !== undefined,
+			reports: this.reports,
+		}
+	}
+
+	private readLiveness(): Liveness | undefined {
+		try {
+			const live = this.ctx.liveness?.()
+			// Guard the shape rather than trusting it: this crosses the wasm
+			// boundary, and a binary predating the Go heartbeat returns undefined
+			// while a future one could change fields. Reading a missing field would
+			// yield NaN and quietly poison every comparison below.
+			if (!live || typeof live.goTicks !== 'number' || typeof live.goLastTickMs !== 'number') {
+				return undefined
+			}
+			return live
+		} catch {
+			// A wedged Go runtime can make the call itself throw.
+			return undefined
+		}
+	}
+
+	private sharing(): boolean {
+		try {
+			return this.ctx.sharing?.() ?? false
+		} catch {
+			return false
+		}
+	}
+
+	private onVisibilityChange = (): void => {
+		if (document.visibilityState !== 'visible') this.hiddenSinceLastTick = true
+	}
+
+	private onPageHide = (): void => {
+		// Mark the exit clean so the next load does not mistake this navigation for
+		// a death. This is the one write that must not be skipped.
+		this.writeBreadcrumb(true)
+	}
+
+	private tick = (): void => {
+		const now = Date.now()
+		const gapMs = now - this.lastTickAt
+		this.lastTickAt = now
+
+		const hidden = document.visibilityState !== 'visible'
+		// A tab that was hidden at any point since the last tick had its timers
+		// throttled, so its gap says nothing about freezing. Reset the baselines
+		// and wait for a clean interval rather than reporting throttling as a bug.
+		const trustworthy = !hidden && !this.hiddenSinceLastTick
+		this.hiddenSinceLastTick = false
+
+		const live = this.readLiveness()
+		// Go stamps goLastTickMs with Date.now() from inside wasm specifically so it
+		// can be compared against ours without clock-skew arithmetic. Staleness is
+		// measured on its own terms rather than against our gap: tying it to our gap
+		// would make 'go wedged' imply 'we were starved too', collapsing the two
+		// independent failures into one and losing the distinction entirely.
+		const goStaleMs = live ? now - live.goLastTickMs : null
+		const goStalled = goStaleMs !== null && goStaleMs > freezeMs
+
+		const jsStarved = gapMs > freezeMs
+
+		// A hidden interval tells us nothing about thread health either way, so it
+		// neither builds nor keeps the streak.
+		this.punctualTicks = trustworthy && !jsStarved ? this.punctualTicks + 1 : 0
+
+		// jsStarved is direct evidence from our own gap and needs no corroboration.
+		// A Go-only verdict does: see minPunctualTicks.
+		const actionable = jsStarved || (goStalled && this.punctualTicks >= minPunctualTicks)
+
+		if (trustworthy && actionable) {
+			this.report(this.classify(jsStarved, goStalled), {
+				gapMs,
+				goStaleMs,
+				goTicks: live?.goTicks ?? null,
+				clockSkewMs: live ? now - live.goNowMs : null,
+				hidden,
+				recovered: true,
+			})
+		}
+
+		this.writeBreadcrumb(false)
+	}
+
+	private classify(jsStarved: boolean, goStalled: boolean): FreezeKind {
+		if (jsStarved && goStalled) return 'main_thread_blocked'
+		if (goStalled) return 'go_scheduler_wedged'
+		return 'js_starved'
+	}
+
+	private report(
+		kind: FreezeKind,
+		fields: Pick<FreezeReport, 'gapMs' | 'goStaleMs' | 'goTicks' | 'clockSkewMs' | 'hidden' | 'recovered'>
+	): void {
+		const now = Date.now()
+		// 'page_died' is exempt: it is only ever produced by the startup sweep,
+		// which is already bounded, and each record represents a distinct casualty.
+		if (kind !== 'page_died') {
+			const last = this.lastReportAt.get(kind)
+			if (last !== undefined && now - last < repeatSuppressMs) return
+			this.lastReportAt.set(kind, now)
+		}
+
+		const report: FreezeReport = {
+			kind,
+			detectedAt: now,
+			longestTaskMs: this.longestTaskMs,
+			longestTaskName: this.longestTaskName,
+			sharing: this.sharing(),
+			url: window.location.href,
+			userAgent: navigator.userAgent,
+			...fields,
+		}
+
+		this.reports.push(report)
+		if (this.reports.length > maxReports) this.reports.shift()
+
+		if (this.ctx.onReport) {
+			this.ctx.onReport(report)
+			return
+		}
+		defaultReport(report)
+	}
+
+	// observeLongTasks records the worst long task of this page life, which is the
+	// only signal that says *what* froze rather than merely that something did.
+	//
+	// Feature-detected because Safari does not implement the longtask entry type,
+	// and mobile Safari is a target. The rest of the watchdog works without it;
+	// reports simply carry a null attribution.
+	private observeLongTasks(): void {
+		try {
+			if (typeof PerformanceObserver === 'undefined') return
+			const supported = (PerformanceObserver as any).supportedEntryTypes
+			if (Array.isArray(supported) && !supported.includes('longtask')) return
+
+			const observer = new PerformanceObserver(list => {
+				for (const entry of list.getEntries()) {
+					if (this.longestTaskMs === null || entry.duration > this.longestTaskMs) {
+						this.longestTaskMs = Math.round(entry.duration)
+						// Prefer the attribution container name — for a freeze inside a
+						// third-party widget that names the culprit, where the entry name
+						// is almost always the generic 'self'.
+						const attribution = (entry as any).attribution?.[0]
+						this.longestTaskName = attribution?.containerName || attribution?.name || entry.name
+					}
+				}
+			})
+			observer.observe({entryTypes: ['longtask']})
+			this.observer = observer
+		} catch {
+			// Unsupported or blocked; detection degrades rather than failing.
+		}
+	}
+
+	private writeBreadcrumb(closedCleanly: boolean): void {
+		const crumb: Breadcrumb = {
+			t: this.tabId,
+			b: Date.now(),
+			s: this.startedAt,
+			c: closedCleanly,
+			h: document.visibilityState !== 'visible',
+			p: this.sharing(),
+			l: this.longestTaskMs,
+			n: this.longestTaskName,
+		}
+		safeStorage.write(this.storageKey, JSON.stringify(crumb))
+	}
+
+	// recoverBreadcrumbs reports page lives that stopped beating without firing
+	// pagehide. This is the only detector for a freeze that never ended, and it
+	// also catches renderer crashes and OS kills — absence of the clean-exit flag
+	// is the signal, which is precisely why pagehide is the flag and not unload.
+	private recoverBreadcrumbs(): void {
+		const now = Date.now()
+		const crumbs: Breadcrumb[] = []
+
+		for (const key of safeStorage.keys()) {
+			if (key === this.storageKey) continue
+
+			const raw = safeStorage.read(key)
+			if (!raw) {
+				safeStorage.remove(key)
+				continue
+			}
+
+			let crumb: Breadcrumb | undefined
+			try {
+				crumb = JSON.parse(raw) as Breadcrumb
+			} catch {
+				// Truncated by a quota failure mid-write, or written by an older
+				// version. Unusable either way.
+				safeStorage.remove(key)
+				continue
+			}
+
+			if (!crumb || typeof crumb.b !== 'number') {
+				safeStorage.remove(key)
+				continue
+			}
+			// Expire before deciding: a week-old death is not news, and reporting it
+			// on every load would bury current problems.
+			if (now - crumb.b > storageTtlMs) {
+				safeStorage.remove(key)
+				continue
+			}
+			if (crumb.c) {
+				// Clean exit. Nothing to report, and nothing to keep.
+				safeStorage.remove(key)
+				continue
+			}
+			if (now - crumb.b <= deadTabMs) {
+				// Still beating recently, so this is a live tab in another window.
+				// Leave its record alone — it owns that key.
+				continue
+			}
+			crumbs.push(crumb)
+			safeStorage.remove(key)
+		}
+
+		// Newest first, then bounded: if many tabs died, the recent ones are the
+		// ones worth looking at.
+		crumbs.sort((a, b) => b.b - a.b)
+		for (const crumb of crumbs.slice(0, maxStoredTabs)) {
+			this.report('page_died', {
+				gapMs: now - crumb.b,
+				goStaleMs: null,
+				goTicks: null,
+				clockSkewMs: null,
+				hidden: !!crumb.h,
+				recovered: false,
+			})
+		}
+	}
+}
+
+// defaultReport is the sink used when the caller supplies none.
+//
+// console.warn is unconditional and deliberately first: it is the only sink that
+// works with no infrastructure, and someone staring at a misbehaving tab is the
+// most likely reader. The beacon is opt-in via REACT_APP_FREEZE_BEACON_URL —
+// there is no ingest endpoint for widget telemetry today, so wiring it now makes
+// turning it on a config change rather than a code change.
+export const defaultReport = (report: FreezeReport): void => {
+	const detail = report.recovered
+		? `recovered after ${report.gapMs}ms`
+		: `page never recovered (last beat ${report.gapMs}ms before this load)`
+	console.warn(`[unbounded watchdog] ${report.kind}: ${detail}`, report)
+
+	const url = process.env.REACT_APP_FREEZE_BEACON_URL
+	if (!url) return
+	try {
+		navigator.sendBeacon?.(url, JSON.stringify(report))
+	} catch {
+		// A failed beacon must never surface to the user; the console line above
+		// is the durable record.
+	}
+}
+
+let installed: FreezeWatchdog | undefined
+
+// installFreezeWatchdog starts the watchdog once per page and exposes it as
+// window.__unboundedWatchdog for console inspection.
+export const installFreezeWatchdog = (ctx: WatchdogContext = {}): FreezeWatchdog => {
+	if (installed) return installed
+	const watchdog = new FreezeWatchdog(ctx)
+	installed = watchdog
+	watchdog.start()
+	try {
+		;(window as any).__unboundedWatchdog = watchdog
+	} catch {
+		// ignore
+	}
+	return watchdog
+}

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -264,6 +264,9 @@ export class FreezeWatchdog {
 	private readonly storageKey: string
 
 	private timer: ReturnType<typeof setInterval> | undefined
+	// Whether start() has run. Distinct from `timer`, which is legitimately absent
+	// while the page sits in the back/forward cache.
+	private started = false
 	private observer: PerformanceObserver | undefined
 	private lastTickAt = Date.now()
 	// hiddenSinceLastTick makes the visibility gate correct across a full
@@ -290,7 +293,11 @@ export class FreezeWatchdog {
 	// start begins watching and reports anything left behind by a previous page
 	// life. Safe to call twice; the second call is ignored.
 	start(): void {
-		if (this.timer) return
+		// Guarded on `started` rather than on `timer`, because the timer is legitimately
+		// absent between pagehide and pageshow. Keying on the timer would let a second
+		// start() in that window re-run the breadcrumb sweep.
+		if (this.started) return
+		this.started = true
 
 		// Sweep first, so a death is reported even if this page life is short.
 		this.recoverBreadcrumbs()
@@ -301,24 +308,41 @@ export class FreezeWatchdog {
 		// Safari, and treating a normal navigation as a death would drown the real
 		// signal in false positives.
 		window.addEventListener('pagehide', this.onPageHide)
+		window.addEventListener('pageshow', this.onPageShow)
 
-		this.lastTickAt = Date.now()
-		this.writeBreadcrumb(false)
-		this.timer = setInterval(this.tick, tickMs)
+		this.armTimer()
 	}
 
 	stop(): void {
-		if (this.timer) {
-			clearInterval(this.timer)
-			this.timer = undefined
-		}
+		this.started = false
+		this.clearTimer()
 		this.observer?.disconnect()
 		this.observer = undefined
 		document.removeEventListener('visibilitychange', this.onVisibilityChange)
 		window.removeEventListener('pagehide', this.onPageHide)
+		window.removeEventListener('pageshow', this.onPageShow)
 		// An explicit stop is a clean exit; leaving the record un-flagged would
 		// make the next load report this tab as dead.
 		safeStorage.remove(this.storageKey)
+	}
+
+	// armTimer starts beating and resets the baselines the first tick will compare
+	// against. Resetting them is not optional: wall-clock time advances while a page
+	// sits frozen in the back/forward cache, and a stale lastTickAt turns that entire
+	// interval into a fabricated freeze the moment the page is restored.
+	private armTimer(): void {
+		this.lastTickAt = Date.now()
+		this.punctualTicks = 0
+		this.hiddenSinceLastTick = false
+		this.writeBreadcrumb(false)
+		this.timer = setInterval(this.tick, tickMs)
+	}
+
+	private clearTimer(): void {
+		if (this.timer) {
+			clearInterval(this.timer)
+			this.timer = undefined
+		}
 	}
 
 	// snapshot exposes current state for manual inspection from the console. The
@@ -386,6 +410,28 @@ export class FreezeWatchdog {
 		// Mark the exit clean so the next load does not mistake this navigation for
 		// a death. This is the one write that must not be skipped.
 		this.writeBreadcrumb(true)
+		// Then stop beating. A tick that runs after this point would rewrite the
+		// record with c:false and resurrect a cleanly-closed page as a casualty —
+		// the exact false positive that would make every ordinary navigation look
+		// like a crash.
+		//
+		// Not a one-way shutdown: pagehide is not necessarily terminal. The
+		// back/forward cache fires it, freezes the page, and may restore it later,
+		// which is what onPageShow re-arms for.
+		this.clearTimer()
+	}
+
+	// onPageShow resumes after a back/forward-cache restore.
+	//
+	// Re-arming is required, not merely tidy. A restored page is a live donor again,
+	// and leaving it stopped would mean it beats no more breadcrumbs — so if it is
+	// later killed, the record still carries pagehide's clean flag and the death goes
+	// unreported. That is the failure this whole path exists to catch, so a naive
+	// "stop the timer on pagehide" would trade one false positive for a false
+	// negative on the case that matters most.
+	private onPageShow = (): void => {
+		if (!this.started || this.timer) return
+		this.armTimer()
 	}
 
 	private tick = (): void => {
@@ -568,7 +614,13 @@ export class FreezeWatchdog {
 				safeStorage.remove(key)
 				continue
 			}
-			if (crumb.c) {
+			// Strictly === true, not truthy. A corrupt or hand-edited value like the
+			// string "false" is truthy, and treating it as a clean exit *suppresses* a
+			// real death report. Of the two ways to be wrong about a malformed record,
+			// inventing a casualty is far cheaper than silently dropping one: this
+			// whole path exists because deaths were invisible, and an anomalous record
+			// from a tab that never said goodbye is worth surfacing anyway.
+			if (crumb.c === true) {
 				// Clean exit. Nothing to report, and nothing to keep.
 				safeStorage.remove(key)
 				continue
@@ -593,7 +645,9 @@ export class FreezeWatchdog {
 				goStaleMs: null,
 				goTicks: null,
 				clockSkewMs: null,
-				hidden: !!crumb.h,
+				// === true rather than truthy, for the same reason as crumb.c above: a
+				// non-boolean would otherwise mislabel the report it is meant to explain.
+				hidden: crumb.h === true,
 				recovered: false,
 				// From the breadcrumb, not from this page life. The long task the dead
 				// tab recorded is the whole reason it was recorded — it is the only
@@ -604,7 +658,7 @@ export class FreezeWatchdog {
 				// carry anything. A wrong type here would reach console and the beacon.
 				longestTaskMs: typeof crumb.l === 'number' ? crumb.l : null,
 				longestTaskName: typeof crumb.n === 'string' ? crumb.n.slice(0, maxTaskNameLen) : null,
-				sharing: !!crumb.p,
+				sharing: crumb.p === true,
 			})
 		}
 	}

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -48,6 +48,13 @@ const storagePrefix = 'unbounded.watchdog.'
 const storageTtlMs = 24 * 60 * 60 * 1000
 const maxStoredTabs = 8
 
+// maxTaskNameLen bounds the long-task attribution string. It originates from the
+// DOM (a container's id or name) and survives a round trip through localStorage,
+// so by the time it is read back it is just bytes on the origin — and it ends up in
+// a console line and a beacon body. A real container name is a handful of
+// characters; this only truncates something that was never a name.
+const maxTaskNameLen = 128
+
 // maxReports caps what we retain in memory for window.__unboundedWatchdog. A page
 // that freezes in a loop must not turn its own diagnostics into the leak.
 const maxReports = 20
@@ -155,6 +162,31 @@ interface Liveness {
 	goIntervalMs: number
 	goNowMs: number
 }
+
+// ValidatedLiveness is what readLiveness returns, and the shape the rest of this
+// file is allowed to touch.
+//
+// Only goTicks and goLastTickMs carry the `number` guarantee, because only those
+// two are worth rejecting a whole snapshot over. Every other field is explicitly
+// nullable so no use site can do arithmetic on a missing one — the failure mode
+// being designed out is silent, not loud: reading an absent field yields NaN, every
+// NaN comparison is false, and the value lands in a report looking like data.
+//
+// Enforcing this at the boundary rather than at each use site is the point. The
+// first version validated only the two required fields and then read goNowMs
+// anyway, three lines below a comment claiming NaN had been designed out.
+type ValidatedLiveness = {
+	goTicks: number
+	goLastTickMs: number
+	goStartedMs: number | null
+	goIntervalMs: number | null
+	goNowMs: number | null
+}
+
+// asNumber narrows an unknown to a usable number, rejecting NaN and the
+// infinities: those are numbers by typeof but poison every comparison downstream
+// exactly like a missing field would.
+const asNumber = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null)
 
 // WatchdogContext supplies what only the caller knows. Passed in rather than
 // imported so this module stays free of app dependencies — wasmInterface imports
@@ -306,17 +338,32 @@ export class FreezeWatchdog {
 		}
 	}
 
-	private readLiveness(): Liveness | undefined {
+	private readLiveness(): ValidatedLiveness | undefined {
 		try {
-			const live = this.ctx.liveness?.()
-			// Guard the shape rather than trusting it: this crosses the wasm
-			// boundary, and a binary predating the Go heartbeat returns undefined
-			// while a future one could change fields. Reading a missing field would
-			// yield NaN and quietly poison every comparison below.
-			if (!live || typeof live.goTicks !== 'number' || typeof live.goLastTickMs !== 'number') {
-				return undefined
+			const live: Partial<Liveness> | undefined = this.ctx.liveness?.()
+			if (!live) return undefined
+
+			// Guard the shape rather than trusting it: this crosses the wasm boundary,
+			// a binary predating the Go heartbeat returns undefined, and a future one
+			// could change fields. Reading a missing field yields NaN, and because
+			// every NaN comparison is false the result is a silently disabled detector
+			// rather than a visible error.
+			const goTicks = asNumber(live.goTicks)
+			const goLastTickMs = asNumber(live.goLastTickMs)
+			// These two are what detection depends on, so a snapshot without them is
+			// no snapshot at all.
+			if (goTicks === null || goLastTickMs === null) return undefined
+
+			// The rest degrade individually. Rejecting the whole snapshot because a
+			// supplementary field was missing would throw away the primary staleness
+			// signal to protect a diagnostic one.
+			return {
+				goTicks,
+				goLastTickMs,
+				goStartedMs: asNumber(live.goStartedMs),
+				goIntervalMs: asNumber(live.goIntervalMs),
+				goNowMs: asNumber(live.goNowMs),
 			}
-			return live
 		} catch {
 			// A wedged Go runtime can make the call itself throw.
 			return undefined
@@ -377,9 +424,12 @@ export class FreezeWatchdog {
 				gapMs,
 				goStaleMs,
 				goTicks: live?.goTicks ?? null,
-				clockSkewMs: live ? now - live.goNowMs : null,
+				clockSkewMs: live?.goNowMs != null ? now - live.goNowMs : null,
 				hidden,
 				recovered: true,
+				longestTaskMs: this.longestTaskMs,
+				longestTaskName: this.longestTaskName,
+				sharing: this.sharing(),
 			})
 		}
 
@@ -392,9 +442,18 @@ export class FreezeWatchdog {
 		return 'js_starved'
 	}
 
+	// report takes every piece of evidence explicitly rather than reading any of it
+	// from instance state.
+	//
+	// That is deliberate and load-bearing: a 'page_died' report describes a
+	// *previous* page life, so its long-task attribution and sharing flag must come
+	// from that life's breadcrumb, not from this one. An earlier version filled them
+	// in from `this`, which at startup means null attribution and sharing=false —
+	// silently discarding the only evidence explaining the death it was reporting.
+	// Requiring them as arguments makes that mistake a compile error.
 	private report(
 		kind: FreezeKind,
-		fields: Pick<FreezeReport, 'gapMs' | 'goStaleMs' | 'goTicks' | 'clockSkewMs' | 'hidden' | 'recovered'>
+		fields: Omit<FreezeReport, 'kind' | 'detectedAt' | 'url' | 'userAgent'>
 	): void {
 		const now = Date.now()
 		// 'page_died' is exempt: it is only ever produced by the startup sweep,
@@ -408,9 +467,6 @@ export class FreezeWatchdog {
 		const report: FreezeReport = {
 			kind,
 			detectedAt: now,
-			longestTaskMs: this.longestTaskMs,
-			longestTaskName: this.longestTaskName,
-			sharing: this.sharing(),
 			url: window.location.href,
 			userAgent: navigator.userAgent,
 			...fields,
@@ -446,7 +502,11 @@ export class FreezeWatchdog {
 						// third-party widget that names the culprit, where the entry name
 						// is almost always the generic 'self'.
 						const attribution = (entry as any).attribution?.[0]
-						this.longestTaskName = attribution?.containerName || attribution?.name || entry.name
+						const name: unknown = attribution?.containerName || attribution?.name || entry.name
+						// Bounded on the way in as well as on the way out: this is written
+						// to localStorage every tick, so an unbounded value would be paid
+						// for repeatedly rather than once.
+						this.longestTaskName = typeof name === 'string' ? name.slice(0, maxTaskNameLen) : null
 					}
 				}
 			})
@@ -528,11 +588,23 @@ export class FreezeWatchdog {
 		for (const crumb of crumbs.slice(0, maxStoredTabs)) {
 			this.report('page_died', {
 				gapMs: now - crumb.b,
+				// The dead tab published no heartbeat we can read now. Nulls rather
+				// than zeros, so this never reads as "Go was fine".
 				goStaleMs: null,
 				goTicks: null,
 				clockSkewMs: null,
 				hidden: !!crumb.h,
 				recovered: false,
+				// From the breadcrumb, not from this page life. The long task the dead
+				// tab recorded is the whole reason it was recorded — it is the only
+				// account of what that tab was doing when it stopped.
+				//
+				// Types are checked rather than trusted: a record truncated by a quota
+				// failure mid-write, or written by an older version of this file, can
+				// carry anything. A wrong type here would reach console and the beacon.
+				longestTaskMs: typeof crumb.l === 'number' ? crumb.l : null,
+				longestTaskName: typeof crumb.n === 'string' ? crumb.n.slice(0, maxTaskNameLen) : null,
+				sharing: !!crumb.p,
 			})
 		}
 	}

--- a/ui/src/utils/wasmInterface.ts
+++ b/ui/src/utils/wasmInterface.ts
@@ -3,6 +3,7 @@ import {StateEmitter} from '../hooks/useStateEmitter'
 import MockWasmClient from '../mocks/mockWasmClient'
 import {MessageTypes, SIGNATURE, Targets, WASM_CLIENT_CONFIG} from '../constants'
 import {messageCheck} from './messages'
+import {installFreezeWatchdog} from './freezeWatchdog'
 
 type WebAssemblyInstance = InstanceType<typeof WebAssembly.Instance>
 
@@ -67,6 +68,11 @@ export interface WasmClient extends EventTarget {
 	stop(): void
 
 	debug(): void
+
+	// liveness returns the Go-side heartbeat (see clientcore/watchdog_wasm_impl.go).
+	// Optional because the wasm binary deployed to embed.lantern.io can predate it —
+	// it does today — and because MockWasmClient has no Go runtime to report on.
+	liveness?(): {goTicks: number; goLastTickMs: number; goStartedMs: number; goIntervalMs: number; goNowMs: number} | undefined
 }
 
 
@@ -125,6 +131,17 @@ export class WasmInterface {
 
 		this.initializing = true
 		this.target = target
+
+		// Start watching before instantiating, not after. Compiling a 12MB wasm
+		// module is the single heaviest thing this page does and a plausible freeze
+		// site, so a watchdog installed after it would be blind to exactly the
+		// window most likely to hang. The liveness getter tolerates the client not
+		// existing yet, which is the reason it is a getter and not a value.
+		installFreezeWatchdog({
+			liveness: () => this.wasmClient?.liveness?.(),
+			sharing: () => sharingEmitter.state,
+		})
+
 		if (mock) { // fake it till you make it
 			this.wasmClient = new MockWasmClient(this)
 			this.instance = {} as WebAssemblyInstance


### PR DESCRIPTION
Completes the freeze watchdog. #378 added the Go-side heartbeat; this is the half that actually detects anything.

## Why the detection has to live in JS

Both freezes on unbounded.lantern.io on 2026-08-03 were invisible in telemetry, and they were **not the same failure**:

| | netstate vertex | edges | meaning |
|---|---|---|---|
| first freeze | gone | gone | the engine stopped |
| second freeze | current | all 4 intact | engine fine, **main thread** not |

Those need different fixes, so the instrumentation has to tell them apart. Go/wasm and JS share one thread but fail independently, so comparing a JS timer against Go's tick counter isolates which side stopped:

| JS timer | Go ticks | verdict |
|---|---|---|
| on time | advancing | healthy |
| on time | frozen | `go_scheduler_wedged` — deadlock, or a goroutine not yielding |
| starved | frozen | `main_thread_blocked` — both starve when the shared thread blocks |
| starved | advancing | `js_starved` — something monopolized the task queue |
| never fires | — | undetectable from inside; see breadcrumbs below |

The fourth row is why the watchdog is in JS reading Go, rather than Go reporting on itself: if the thread is blocked, no Go code is running to report it either.

## Catching a freeze nobody survived

A page that freezes and stays frozen reports nothing — no timer, no beacon, no console. So every tick writes a breadcrumb to \`localStorage\`, and startup reads back records from tabs that stopped beating without ever firing \`pagehide\`. Absence of the clean-exit flag is the signal, which is why the flag is \`pagehide\` and not \`unload\` (\`unload\` is unreliable on mobile Safari, and treating a normal navigation as a death would drown the real signal).

This is the only path that catches a permanent freeze, and it also catches renderer crashes and OS kills — **the iOS jetsam kills behind getlantern/engineering#3698 present exactly this way**.

## The guard that matters most

A watchdog that cries wolf gets muted, and then reports nothing when it counts. Two false positives were live in my first draft:

**1. Blaming Go right after a thread block.** When the thread frees up, our timer callback can run *before* Go's ticker goroutine is rescheduled — so Go looks stale while being perfectly fine:

\`\`\`mermaid
sequenceDiagram
    autonumber
    participant T as JS timer<br/>freezeWatchdog.ts
    participant JS as event loop<br/>(shared thread)
    participant GO as Go ticker<br/>watchdog_wasm_impl.go

    Note over JS: something blocks the thread for 12s
    Note over GO: goLastTickMs pinned — cannot run ⚠️
    JS-->>T: tick fires late (gap 12s)
    T->>GO: freezeWatchdog.ts:361<br/>liveness() → stale by 12s
    Note over T: freezeWatchdog.ts:373<br/>gap starved + Go stale<br/>→ main_thread_blocked ✅

    Note over JS: thread frees up
    JS-->>T: next tick, punctual (gap 2s)
    T->>GO: liveness() → STILL stale
    Note over GO: goroutine not rescheduled yet ⚠️
    rect rgba(255, 200, 200, 0.3)
        Note over T: punctual tick + stale Go<br/>naively → go_scheduler_wedged 🐛<br/>relabels every block as a Go wedge
    end
    Note over T: freezeWatchdog.ts:373<br/>guard: needs 2 consecutive<br/>punctual ticks → suppressed ✅
    GO-->>T: heartbeat resumes
\`\`\`

Without the guard, *every* main-thread block is followed by a spurious \`go_scheduler_wedged\` — collapsing the exact two failure modes this feature exists to separate. A Go verdict now requires two consecutive on-time ticks as positive evidence the thread is healthy (\`freezeWatchdog.ts:78\`), which is 2×\`tickMs\` — several times Go's own heartbeat interval, so a heartbeat still stale by then really is wedged.

**2. Background tabs.** Throttled to roughly one timer per minute, so a hidden tab looks frozen. Gated on \`visibilityState\` *and* on whether the tab was hidden at any point **since the last tick** — checking only at tick time would miss a full hide/show cycle, whose gap is throttling, not a freeze. Most donor tabs sit in the background, so this is the difference between a usable signal and pure noise.

## Attribution

A \`longtask\` \`PerformanceObserver\` records the worst task of the page life. This is the only signal that says *what* froze rather than merely that something did — a 30-second long task **is** the freeze, and its container name is the suspect. \`three-globe\` is the standing candidate; the repo already carries \`ui/patches/three-globe+2.27.4.patch\`. Feature-detected, since Safari does not implement the entry type.

## Degrades instead of assuming

\`liveness()\` is optional, and **absent from the binary deployed to embed.lantern.io today** — built 2026-08-03 22:27 UTC, ~11.5h before #378 merged. Verified by grepping the live wasm:

\`\`\`
liveness                     ABSENT
goTicks                      ABSENT
goLastTickMs                 ABSENT
alwaysNegotiateDataChannels  PRESENT   <- so it is the recent rebuild, just pre-#378
\`\`\`

JS-side detection works without it. Also survives \`liveness()\` throwing, a malformed snapshot (a missing field would read as \`NaN\`, and every \`NaN\` comparison is false — so a shape change would silently disable detection rather than fail loudly), and \`localStorage\` being unavailable, which Safari private browsing does by throwing on the *property access* itself.

## Other decisions

- **Per-kind throttling.** A wedged Go runtime is a standing condition matching on every tick; unthrottled that fills the 20-entry report ring in under three minutes and evicts the \`page_died\` record recovered at startup — the most valuable report held. Per-kind so a *new* failure during a standing one still gets through.
- **Installed before wasm instantiation** (\`wasmInterface.ts:140\`), not after: compiling a 12MB module is the heaviest thing the page does and a plausible freeze site, so watching only afterward would be blind to the likeliest window.
- **Beacon is env-gated and off.** No ingest endpoint exists for widget telemetry (otel is deliberately avoided here — the Go SDK abuses the call stack in ways mobile Safari does not tolerate). \`console.warn\` and \`window.__unboundedWatchdog\` are the live sinks; enabling a beacon later is a config change, not a code change.

## Page lifecycle

`pagehide` marks the breadcrumb cleanly-exited **and stops the timer**. A tick firing after that write would rewrite the record with `c: false` and resurrect a cleanly-closed page as a casualty, turning ordinary navigation into a reported crash.

Stopping alone would be the worse bug, though. `pagehide` is **not terminal** — the back/forward cache fires it, freezes the page, and may restore it. A restored page is a live donor again, and one that stopped beating keeps the clean flag forever, so a later kill goes completely unreported. That is the one case the breadcrumb path exists for. So `pageshow` re-arms, and re-arming resets the tick baselines: ten minutes of wall clock passes while a page sits frozen in the cache, and a stale `lastTickAt` would turn that whole interval into a fabricated freeze the instant it came back.

## Untrusted inputs

Two boundaries, both treated as hostile rather than merely unreliable:

**The wasm boundary.** `readLiveness()` validates once and returns a type whose supplementary fields are explicitly `number | null`, so no use site can do arithmetic on a missing one. Only `goTicks` and `goLastTickMs` reject a whole snapshot — discarding one because a *diagnostic* field was absent would throw away the primary staleness signal to protect a secondary one. `NaN` and the infinities are rejected too: they pass `typeof x === 'number'` but poison comparisons exactly like a missing field, and because every `NaN` comparison is false the result is a silently disabled detector rather than a visible error.

**localStorage.** Recovered records are type-checked field by field, and the long-task name is bounded on the way in *and* out — it round-trips through storage and lands in a console line and a beacon body, so on read-back it is just bytes on the origin rather than a DOM-supplied name. The clean-exit flag compares `=== true` rather than truthily: `"false"` is truthy, and reading a corrupt record as a clean exit would **suppress** a real death report. Of the two ways to be wrong about a malformed record, inventing a casualty is far cheaper than silently dropping one.

## Evidence belongs to the page life it describes

`report()` takes every evidence field as an argument rather than reading any from instance state. A `page_died` report describes a *previous* page life, so its long-task attribution and sharing flag must come from that life's breadcrumb. Filling them from `this` yields null attribution and `sharing: false` at startup — writing the evidence, keeping it for 24h, reading it back, and discarding it at the last step. Passing them explicitly makes that a compile error.

## Testing

30 tests, all passing; `tsc --noEmit` clean; `yarn build:web` succeeds with no new lint warnings (remaining warnings are pre-existing in `goWasmExec.ts`). Every false positive and false negative described above is pinned by name so it cannot regress silently.

Note CI **does not run UI tests at all**, so these are local-only for now.

## Deploy caveat

This is page-side TypeScript, so it ships via the Vercel deploy of unbounded.lantern.io — **not** the `gh-pages`/embed.lantern.io wasm publish. Merging this does not by itself put it in front of users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
