### PR TITLE
ci: publish widget.wasm to gh-pages on merges to main

### DIFF
--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -7,9 +7,25 @@ name: Build widget (wasm)
 # landed in clientcore without wasm build tags and broke `GOOS=js GOARCH=wasm
 # go build ./cmd` on main, undetected.
 #
-# This job exists so that failure mode cannot recur silently. It only compiles;
-# it deliberately does not regenerate or commit widget.wasm, since publishing a
-# binary is a release decision, not a CI side effect.
+# The build job exists so that failure mode cannot recur silently.
+#
+# It now also publishes. Until 2026-08-05 widget.wasm reached embed.lantern.io only
+# via someone running `yarn deploy` by hand, and the consequence was a live widget
+# four months stale: the binary served on 2026-08-03 predated the Go liveness
+# heartbeat by half a day and predated its own source by far longer. A release step
+# that only happens when a human remembers is a release step that does not happen.
+#
+# Publishing is gated on the wasm build AND the native unit tests, so "it reached
+# users" implies "it compiled for the target and its packages passed". That is a
+# real gate but not a complete one — there is no functional or browser test of the
+# widget, so a change that compiles and unit-tests clean can still ship a broken
+# widget to every donor. Worth closing before relying on this too heavily.
+#
+# Only widget.wasm is written. The gh-pages branch also serves index.html,
+# storage.html, popup.html and static/ for embedders, and `gh-pages -d build`
+# replaces the whole branch — so the page half stays a deliberate, separate deploy.
+# It could not move here anyway: ui/.env.production is gitignored, so a CI page
+# build would bake in undefined REACT_APP_* values.
 #
 # Build only, no `go vet`: vetting under wasm tags currently reports four
 # pre-existing findings in clientcore (user.go lostcancel x2, unreachable code in
@@ -41,8 +57,15 @@ on:
       - 'go.sum'
       - '.github/workflows/build-widget-wasm.yml'
 
+# Read-only by default. Only the publish job widens this, and only for itself.
 permissions:
   contents: read
+
+# Serialize publishes so two merges cannot race on the gh-pages ref. Without this
+# the second push loses to a non-fast-forward and the newer wasm is the one dropped.
+concurrency:
+  group: publish-widget-wasm
+  cancel-in-progress: false
 
 jobs:
   build-wasm:
@@ -64,3 +87,101 @@ jobs:
         # compiles. -o /dev/null keeps the artifact out of the workspace so it
         # can't be mistaken for something publishable.
         run: go build -ldflags "-s -w" -o /dev/null ./cmd
+
+  test:
+    name: go test (native)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Native, not js/wasm: there is no wasm test runner here, and these packages
+      # are the ones the widget is built from. Running them is what lets the publish
+      # below claim more than "it compiled".
+      - name: Test packages the widget is built from
+        run: go test ./clientcore/... ./common/...
+
+  publish:
+    name: publish widget.wasm to gh-pages
+    # Both gates must pass. A publish that only required compilation would put a
+    # binary in front of every donor on the strength of the type checker alone.
+    needs: [build-wasm, test]
+    # Merges only. A PR must never be able to publish — it would let any fork's
+    # branch write to the branch users are served from.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the built wasm to gh-pages
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Real output path this time, unlike build-wasm above. Same flags as
+      # cmd/build_web.sh so what ships matches what a local build produces.
+      - name: Build widget.wasm
+        env:
+          GOOS: js
+          GOARCH: wasm
+        run: go build -ldflags "-s -w" -o "$RUNNER_TEMP/widget.wasm" ./cmd
+
+      # Sanity-check the artifact before it can replace a live one. A zero-byte or
+      # truncated file would still "build" if the toolchain failed strangely, and
+      # publishing one takes every donor offline until the next merge.
+      - name: Verify the artifact looks like a wasm module
+        run: |
+          set -euo pipefail
+          f="$RUNNER_TEMP/widget.wasm"
+          size=$(stat -c%s "$f")
+          echo "size=$size"
+          # The live binary is ~12MB. Anything under 1MB is not a broflake widget.
+          if [ "$size" -lt 1000000 ]; then
+            echo "artifact implausibly small: $size bytes" >&2
+            exit 1
+          fi
+          # Wasm magic number: 0x00 'a' 's' 'm'
+          magic=$(head -c 4 "$f" | od -An -tx1 | tr -d ' \n')
+          echo "magic=$magic"
+          if [ "$magic" != "0061736d" ]; then
+            echo "artifact is not a wasm module (magic $magic)" >&2
+            exit 1
+          fi
+
+      # Separate worktree rather than a branch switch, so the built artifact in
+      # RUNNER_TEMP is untouched and the checked-out source stays available.
+      - name: Publish to gh-pages
+        env:
+          # Only ever the resolved SHA of the pushed commit — never a ref name,
+          # branch, or message — so nothing attacker-controlled reaches the shell.
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch --depth=1 origin gh-pages
+          git worktree add /tmp/ghp origin/gh-pages
+          cp "$RUNNER_TEMP/widget.wasm" /tmp/ghp/widget.wasm
+          cd /tmp/ghp
+
+          # Byte-identical rebuilds are common — most merges here touch Go code that
+          # does not change the emitted module. Committing anyway would add a 12MB
+          # blob to history per merge and grow the repo without bound.
+          if git diff --quiet -- widget.wasm; then
+            echo "widget.wasm unchanged; nothing to publish"
+            exit 0
+          fi
+
+          git add widget.wasm
+          git commit -m "widget.wasm: build from $COMMIT_SHA"
+          # Push to the ref explicitly. The worktree is on a detached HEAD from
+          # origin/gh-pages, so HEAD:gh-pages is what advances the branch.
+          git push origin HEAD:gh-pages
+          echo "published widget.wasm from $COMMIT_SHA"

--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -61,18 +61,19 @@ on:
 permissions:
   contents: read
 
-# Serialize publishes so two merges cannot race on the gh-pages ref. Without this
-# the second push loses to a non-fast-forward and the newer wasm is the one dropped.
-concurrency:
-  group: publish-widget-wasm
-  cancel-in-progress: false
-
 jobs:
   build-wasm:
     name: go build js/wasm
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false because this job never pushes. checkout
+      # otherwise leaves the token in .git/config, and both this job and `test`
+      # below execute PR-authored code — a test or build directive added by a pull
+      # request could read it out. Read-only on fork PRs, but there is no reason
+      # for it to be readable at all here.
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -93,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -116,7 +119,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the built wasm to gh-pages
+    # Job-level, not workflow-level. Only this job touches a shared ref, and a
+    # workflow-level group with cancel-in-progress:false would queue every
+    # build+test run repo-wide behind every other one — so a PR pushed three times
+    # would sit waiting on its own earlier runs for no reason.
+    concurrency:
+      group: publish-widget-wasm
+      cancel-in-progress: false
     steps:
+      # Credentials are persisted here, unlike the jobs above: this is the one job
+      # that pushes, and `git push origin` needs the token checkout leaves in the
+      # local git config.
       - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
@@ -166,8 +179,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch --depth=1 origin gh-pages
-          git worktree add /tmp/ghp origin/gh-pages
+          # Name the destination ref explicitly. `git fetch origin gh-pages` alone
+          # lands in FETCH_HEAD, and the opportunistic remote-tracking update only
+          # fires for refs matching the configured remote.origin.fetch refspec —
+          # which actions/checkout narrows to the branch it checked out. So
+          # refs/remotes/origin/gh-pages would never exist and the worktree add
+          # below would fail with "invalid reference".
+          git fetch --depth=1 origin gh-pages:refs/remotes/origin/gh-pages
+          # --detach so HEAD is a bare commit rather than a new local gh-pages
+          # branch: `git worktree add <path> <name>` treats a name that exists only
+          # as a remote-tracking ref as --track -b, which would make the push below
+          # depend on branch tracking config rather than the explicit refspec.
+          git worktree add --detach /tmp/ghp origin/gh-pages
           cp "$RUNNER_TEMP/widget.wasm" /tmp/ghp/widget.wasm
           cd /tmp/ghp
 


### PR DESCRIPTION
Closes the gap found while checking whether unbounded.lantern.io picks up the latest wasm. It does not — and did not.

## The problem

`widget.wasm` reached `embed.lantern.io` only when someone ran `yarn deploy` by hand. The result was a live widget four months stale. I verified this by grepping the deployed module directly:

```
liveness                     ABSENT
goTicks                      ABSENT
goLastTickMs                 ABSENT
alwaysNegotiateDataChannels  PRESENT   <- the 2026-08-03 rebuild, but pre-#378
```

`last-modified: 2026-08-03 22:27 UTC`; #378 merged 2026-08-04 14:02 -0600, ~11.5h later. So the Go liveness heartbeat that #383's watchdog reads is not in front of any user, and neither was months of prior work. A release step that only happens when a human remembers is a release step that does not happen.

## What gates it

`publish` needs **both** `build-wasm` (js/wasm compiles) and `test` (native `go test ./clientcore/... ./common/...`). The test job is new — this workflow previously only compiled.

**Stating the limit plainly: that gate is real but incomplete.** There is no functional or browser test of the widget anywhere in this repo, so a change that compiles and unit-tests clean can still ship a broken widget to every donor. The honest description is "much better than a human remembering", not "CI verifies all functionality". Worth closing before leaning on this heavily.

## Safety

| Guard | Why |
|---|---|
| `if: push && ref == refs/heads/main` | a `pull_request` run must never write to the branch users are served from — otherwise any fork's branch can publish |
| `contents: write` scoped to the `publish` job | workflow default stays `contents: read` |
| size floor + wasm magic check (`0061736d`) | a truncated or empty file would still "build" if the toolchain failed oddly, and publishing one takes **every donor offline** until the next merge |
| `concurrency` group | two merges racing on the `gh-pages` ref would drop the newer wasm to a non-fast-forward |
| skip commit when byte-identical | most merges here don't change the emitted module; committing anyway adds a 12MB blob to history per merge |

Only `widget.wasm` is written. `gh-pages` also serves `index.html`, `storage.html`, `popup.html` and `static/` for embedders, and `yarn deploy` (`gh-pages -d build`) replaces the **whole branch** — so the page half stays a separate deliberate deploy. It couldn't move here anyway: `ui/.env.production` is gitignored (`ui/.gitignore:21`), so a CI page build would bake in `undefined` for every `REACT_APP_*`.

## Safety, after review

| Guard | Why |
|---|---|
| `if: push && ref == refs/heads/main` | a `pull_request` run must never write to the branch users are served from — otherwise any fork's branch can publish. **Verified**: CI on this PR shows `publish` correctly `skipping` while both gates pass |
| `contents: write` scoped to the `publish` job | workflow default stays `contents: read` |
| `persist-credentials: false` on `build-wasm` and `test` | both jobs execute PR-authored code (`go test` runs whatever tests a PR contains), so a token left in `.git/config` is readable by it. Read-only on fork PRs, but no reason to be readable at all in a job that never pushes. `publish` keeps its credentials — it is the one job that pushes |
| size floor + wasm magic check (`0061736d`) | a truncated or empty file would still "build" if the toolchain failed oddly, and publishing one takes **every donor offline** until the next merge |
| `concurrency` on the **`publish` job**, not the workflow | only `publish` touches a shared ref. At workflow level with `cancel-in-progress: false` it serialized every build+test run repo-wide, so a PR pushed three times queued behind its own earlier runs |
| skip commit when byte-identical | most merges here don't change the emitted module; committing anyway adds a 12MB blob to history per merge |

`cancel-in-progress: false` stays for `publish`: cancelling a queued publish would silently *drop* a widget build rather than defer it, which is the exact failure this PR exists to end.

## The gh-pages fetch bug

The PR originally flagged the `git push` from a shallow checkout as the one step I could not verify locally. Review caught a real bug one line earlier, and it would have failed the **first** publish run:

```
$ git clone --depth=1 --branch main --single-branch https://github.com/getlantern/unbounded.git
$ git config --get-all remote.origin.fetch
+refs/heads/main:refs/remotes/origin/main
$ git fetch --depth=1 origin gh-pages
 * branch            gh-pages   -> FETCH_HEAD
$ git worktree add --detach /tmp/ghp origin/gh-pages
fatal: invalid reference: origin/gh-pages
```

Git *does* opportunistically update remote-tracking refs on `git fetch <remote> <branch>`, but only for refs matching the configured `remote.origin.fetch` refspec — and `actions/checkout` narrows that to the single branch it checked out, so the opportunistic path can never cover `gh-pages`. Naming the destination explicitly fixes it.

Verified against the real branch: `origin/gh-pages` is created, the worktree lands on the live 12,390,243-byte `widget.wasm` (byte-for-byte the currently deployed artifact), HEAD is detached, and the unchanged-file no-op path exits without committing.

`--detach` is also now explicit: `git worktree add <path> <name>` treats a name existing only as a remote-tracking ref as `--track -b`, which would have created a local `gh-pages` branch and made the push depend on tracking config rather than the explicit `HEAD:gh-pages` refspec.

## How this composes with static.yml

`static.yml` has **no git write operations** — it is triggered *by* a push to `gh-pages` and only uploads (`path: '.'`) and deploys. So the publish job's push is what triggers the Pages deploy, and that chain is what makes the wasm go live. The two workflows compose correctly; their `concurrency` groups protect different things (`pages` serializes deployments, `publish-widget-wasm` serializes ref writes).

## One thing to know before merging

**Merging publishes immediately.** The workflow file is in its own `paths` filter, so the merge commit triggers a run that pushes the current `main` build of `widget.wasm` to `embed.lantern.io`, replacing the 2026-08-03 binary for all live donors. That is the point of the PR, but it happens at merge time.

Separately: `ui/public/widget.wasm` is a committed 11.7MB binary from 2026-05-01 that has now diverged from both `main` and the deployed artifact. It's what `yarn dev` serves locally. Not touched here, but it wants its own cleanup decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
