### PR TITLE
egress: separate "not our protocol" from "our protocol, wrong shape"

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -226,6 +226,24 @@ func ParseSubprotocolsRequest(s []string) (csid string, version string, ok bool)
 	return csid, version, ok
 }
 
+// HasSubprotocolsMagicCookie reports whether s opens with the magic cookie, i.e.
+// whether the peer is speaking this protocol at all — independent of whether it got
+// the rest of the handshake right.
+//
+// Exported so the egress can separate "our client, wrong shape" from "not our
+// protocol" when a handshake is refused. Conflating those two sent an investigation
+// of ~9 refusals/second down the wrong path for over a week: the refusals looked
+// like broken donors when the arity said something else entirely was calling.
+//
+// It also decides what is safe to log. A peer that fails this check cannot have
+// supplied a consumer session ID, because it is not following the format that has
+// one — so its values carry no identifier and can be recorded to identify the
+// caller. A peer that passes may well have a real session ID among its values, so
+// those stay unlogged.
+func HasSubprotocolsMagicCookie(s []string) bool {
+	return len(s) > 0 && s[0] == subprotocolsMagicCookie
+}
+
 // ParseSubprotocolsRequestWithCountry additionally returns the consumer country
 // when the peer supplied one; country is "" for the 3-element form.
 func ParseSubprotocolsRequestWithCountry(s []string) (csid, version, country string, ok bool) {

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -139,3 +139,53 @@ func TestParseSubprotocolsRequest_RejectsWrongArity(t *testing.T) {
 		}
 	}
 }
+
+// HasSubprotocolsMagicCookie answers "is this peer speaking our protocol at all",
+// independent of whether it got the rest right. The egress uses it to decide both
+// which refusal to report and what is safe to log, so both halves matter.
+func TestHasSubprotocolsMagicCookie(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   []string
+		want bool
+	}{
+		"nil":                     {nil, false},
+		"empty":                   {[]string{}, false},
+		"valid 3-element request": {NewSubprotocolsRequest("csid", "v2.3.5"), true},
+		"valid 4-element request": {NewSubprotocolsRequestWithCountry("csid", "v2.3.5", "CN"), true},
+		// The server's own response format. Exactly one element, which is the shape
+		// the live refusals have, so this case is load-bearing rather than academic.
+		"response form (cookie alone)": {NewSubprotocolsResponse(), true},
+		"foreign single token":         {[]string{"chat"}, false},
+		"foreign multi token":          {[]string{"graphql-ws", "mqtt"}, false},
+		// Order matters: the cookie has to lead. A list containing it elsewhere is
+		// not this protocol, and must not be treated as one.
+		"cookie not first": {[]string{"csid", NewSubprotocolsResponse()[0]}, false},
+		"empty first":      {[]string{"", NewSubprotocolsResponse()[0]}, false},
+		// Case-sensitive: the cookie is a byte-for-byte constant, not a token to
+		// normalize.
+		"wrong case": {[]string{"UN80UND3D", "csid", "v2.3.5"}, false},
+	} {
+		if got := HasSubprotocolsMagicCookie(tc.in); got != tc.want {
+			t.Errorf("%s: HasSubprotocolsMagicCookie(%q) = %v, want %v", name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// Anything the parser accepts must also be recognized as our protocol. If these
+// disagreed, a refusal could be labeled "foreign" for a peer that in fact speaks
+// this protocol correctly — which is the exact misattribution the label exists to
+// prevent.
+func TestHasSubprotocolsMagicCookie_AgreesWithParser(t *testing.T) {
+	for _, in := range [][]string{
+		NewSubprotocolsRequest("csid", "v2.3.5"),
+		NewSubprotocolsRequestWithCountry("csid", "v2.3.5", "CN"),
+		NewSubprotocolsRequestWithCountry("csid", "v2.3.5", ""),
+	} {
+		if _, _, _, ok := ParseSubprotocolsRequestWithCountry(in); !ok {
+			t.Fatalf("precondition: parser rejected %q", in)
+		}
+		if !HasSubprotocolsMagicCookie(in) {
+			t.Errorf("parser accepted %q but cookie check rejected it", in)
+		}
+	}
+}

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -114,23 +114,27 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	consumerSessionID, version, consumerCountry, ok := common.ParseSubprotocolsRequestWithCountry(subprotocols)
 	if !ok {
-		// ParseSubprotocolsRequestWithCountry returns !ok for an absent header,
-		// a wrong element count, or a magic-cookie mismatch. Reporting all three
-		// as "missing" would point an investigation at the wrong caller, so
-		// split on whether the client sent anything at all.
+		// ParseSubprotocolsRequestWithCountry returns !ok for three different
+		// situations with three different owners, so they are reported separately.
+		// Collapsing them is not a cosmetic loss: the egress refused ~9
+		// connections/second for ten days, and the single "missing subprotocols"
+		// label was consistent with every competing explanation, so it identified
+		// nobody.
 		//
-		// The element count is logged; the values are not. They are
-		// client-controlled and unbounded in size, and one of them is a session
-		// identifier.
-		// Test the RAW header, not the filtered list: "Sec-WebSocket-Protocol: ,"
-		// filters down to zero values, so keying off the filtered slice reported a
-		// client that clearly sent something as though it had sent nothing.
-		reason, msg := refusedMissingSubprotocols, "Refused WebSocket connection, missing subprotocols"
-		if len(rawSubprotocols) > 0 {
-			reason, msg = refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols"
+		// Test the RAW header for absence, not the filtered list:
+		// "Sec-WebSocket-Protocol: ," filters down to zero values, so keying off the
+		// filtered slice reported a client that clearly sent something as though it
+		// had sent nothing.
+		reason, msg, logValues := classifySubprotocolRefusal(rawSubprotocols, subprotocols)
+		attrs := append(peerAttrs(r), "subprotocol_count", len(subprotocols))
+		if logValues {
+			// Bounded even though the cookie mismatch means no session ID is present:
+			// these are still unbounded, peer-chosen bytes headed for disk.
+			attrs = append(attrs, "subprotocol_values", truncateForLog(strings.Join(subprotocols, "|")))
 		}
+
 		recordRefusal(reason)
-		slog.Debug(msg, append(peerAttrs(r), "subprotocol_count", len(subprotocols))...)
+		slog.Debug(msg, attrs...)
 		return
 	}
 

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/getlantern/broflake/common"
 )
 
 // Refusals happen before handleWebsocket creates a session span, so until this
@@ -29,14 +31,24 @@ type refusalReason string
 const (
 	// refusedMissingSubprotocols: no Sec-Websocket-Protocol header at all.
 	refusedMissingSubprotocols refusalReason = "missing_subprotocols"
-	// refusedMalformedSubprotocols: the header was present but did not parse —
-	// wrong element count, or the magic cookie did not match. Kept separate from
-	// "missing" because the two implicate completely different callers: absent
-	// means something that is not a broflake client at all, malformed means
-	// something that tried and got the handshake wrong.
+	// refusedMalformedSubprotocols: the magic cookie matched but the element count
+	// did not. This is *our* protocol with the wrong shape, so it implicates a
+	// broflake client — a version skew, or a caller that built the list by hand.
 	refusedMalformedSubprotocols refusalReason = "malformed_subprotocols"
-	refusedBadProtocolVersion    refusalReason = "bad_protocol_version"
-	refusedMissingCSID           refusalReason = "missing_consumer_session_id"
+	// refusedForeignSubprotocols: the header was present and the magic cookie did
+	// not match, so the peer is not speaking this protocol at all.
+	//
+	// Split out from "malformed" because the two point at completely different
+	// owners and the distinction is expensive to get wrong. For ten days the egress
+	// refused ~9 connections/second and reported them as "missing subprotocols",
+	// which reads as "not a broflake client"; the v2.3.5 deploy reclassified every
+	// one as malformed, which reads as "a broken donor". Neither was specific enough
+	// to act on, and both were consistent with the same evidence. This label answers
+	// the question that actually decides who to go talk to, from the metric alone,
+	// with no need to log anything a peer sent.
+	refusedForeignSubprotocols refusalReason = "foreign_subprotocols"
+	refusedBadProtocolVersion  refusalReason = "bad_protocol_version"
+	refusedMissingCSID         refusalReason = "missing_consumer_session_id"
 )
 
 var (
@@ -77,6 +89,32 @@ func eachRefusal(f func(reason refusalReason, count int64)) {
 
 	for _, r := range rows {
 		f(r.reason, atomic.LoadInt64(r.c))
+	}
+}
+
+// classifySubprotocolRefusal decides which of the three subprotocol refusals
+// applies, and whether the peer's values are safe to record.
+//
+// A function rather than inline branches in handleWebsocket so the safety property
+// below is testable directly. The property is easy to state and easy to break by
+// accident: values may be logged *only* when the magic cookie did not match.
+//
+// raw is the unsplit header lines and parsed is the comma-split, whitespace-trimmed
+// list. Absence is judged on raw because "Sec-WebSocket-Protocol: ," parses to zero
+// values while plainly having been sent.
+func classifySubprotocolRefusal(raw, parsed []string) (reason refusalReason, msg string, logValues bool) {
+	switch {
+	case len(raw) == 0:
+		return refusedMissingSubprotocols, "Refused WebSocket connection, missing subprotocols", false
+	case common.HasSubprotocolsMagicCookie(parsed):
+		// Our protocol, wrong shape. A peer that got the cookie right is plausibly a
+		// real client, so one of its values is plausibly a real consumer session ID.
+		return refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols", false
+	default:
+		// Not our protocol. Recording the values is what identifies the caller, and
+		// it is safe precisely because the cookie did not match: a peer not following
+		// the format cannot have supplied the session ID that format carries.
+		return refusedForeignSubprotocols, "Refused WebSocket connection, foreign subprotocols", true
 	}
 }
 

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/getlantern/broflake/common"
 )
 
 func resetRefusals(t *testing.T) {
@@ -248,6 +250,96 @@ func TestTruncateForLog_NormalizesShortInvalidUTF8(t *testing.T) {
 	for _, ok := range []string{"", "curl/8.4.0", "日本語"} {
 		if got := truncateForLog(ok); got != ok {
 			t.Errorf("valid value altered: truncateForLog(%q) = %q", ok, got)
+		}
+	}
+}
+
+// The three subprotocol refusals have three different owners, and collapsing them
+// is what made ~9 refusals/second unactionable for ten days: "missing" reads as
+// "not a broflake client", "malformed" reads as "a broken donor", and the evidence
+// was equally consistent with both.
+func TestClassifySubprotocolRefusal(t *testing.T) {
+	cookie := common.NewSubprotocolsResponse()[0] // the magic cookie, whatever it is
+
+	for name, tc := range map[string]struct {
+		raw        []string
+		parsed     []string
+		wantReason refusalReason
+		wantLog    bool
+	}{
+		"absent header": {
+			raw: nil, parsed: nil,
+			wantReason: refusedMissingSubprotocols, wantLog: false,
+		},
+		// Present but empty: the header was plainly sent, so it must not be reported
+		// as absent even though it parses to zero values.
+		"present but empty": {
+			raw: []string{","}, parsed: nil,
+			wantReason: refusedForeignSubprotocols, wantLog: true,
+		},
+		// Our protocol, wrong arity — the shape the live refusals actually have.
+		"cookie alone": {
+			raw: []string{cookie}, parsed: []string{cookie},
+			wantReason: refusedMalformedSubprotocols, wantLog: false,
+		},
+		"cookie plus one": {
+			raw: []string{cookie + ",csid"}, parsed: []string{cookie, "csid"},
+			wantReason: refusedMalformedSubprotocols, wantLog: false,
+		},
+		"cookie plus too many": {
+			raw:        []string{"x"},
+			parsed:     []string{cookie, "csid", "v2.3.5", "CN", "extra"},
+			wantReason: refusedMalformedSubprotocols, wantLog: false,
+		},
+		"foreign single token": {
+			raw: []string{"chat"}, parsed: []string{"chat"},
+			wantReason: refusedForeignSubprotocols, wantLog: true,
+		},
+		"foreign multi token": {
+			raw: []string{"graphql-ws,mqtt"}, parsed: []string{"graphql-ws", "mqtt"},
+			wantReason: refusedForeignSubprotocols, wantLog: true,
+		},
+		// Right tokens, wrong order: the cookie must lead, or it is not our protocol.
+		"cookie not first": {
+			raw: []string{"csid," + cookie}, parsed: []string{"csid", cookie},
+			wantReason: refusedForeignSubprotocols, wantLog: true,
+		},
+	} {
+		reason, msg, logValues := classifySubprotocolRefusal(tc.raw, tc.parsed)
+		if reason != tc.wantReason {
+			t.Errorf("%s: reason = %q, want %q", name, reason, tc.wantReason)
+		}
+		if logValues != tc.wantLog {
+			t.Errorf("%s: logValues = %v, want %v", name, logValues, tc.wantLog)
+		}
+		if msg == "" {
+			t.Errorf("%s: empty message", name)
+		}
+	}
+}
+
+// The safety property, stated as its own test because it is the reason the values
+// are logged at all: a peer that got the magic cookie right is plausibly a real
+// client, so one of its values is plausibly a real consumer session ID. Values may
+// be recorded only when the cookie did NOT match, which is precisely when the peer
+// cannot have supplied one.
+func TestClassifySubprotocolRefusal_NeverLogsValuesWhenCookieMatched(t *testing.T) {
+	cookie := common.NewSubprotocolsResponse()[0]
+	realCSID := "9f8c1e2a-secret-session-id"
+
+	// Every arity that fails to parse while still carrying the cookie.
+	for _, parsed := range [][]string{
+		{cookie},
+		{cookie, realCSID},
+		{cookie, realCSID, "v2.3.5", "CN", "surplus"},
+		{cookie, realCSID, "v2.3.5", "CN", "surplus", "more"},
+	} {
+		reason, _, logValues := classifySubprotocolRefusal([]string{"raw"}, parsed)
+		if logValues {
+			t.Errorf("would log values for a cookie-matching peer: %v", parsed)
+		}
+		if reason != refusedMalformedSubprotocols {
+			t.Errorf("parsed=%v reason = %q, want %q", parsed, reason, refusedMalformedSubprotocols)
 		}
 	}
 }


### PR DESCRIPTION
The ~9 refusals/second have now been misattributed **twice, in opposite directions, on identical evidence**:

| binary | label | what it reads as |
|---|---|---|
| pre-v2.3.5 | `missing subprotocols` | "not a broflake client at all" |
| v2.3.5 (#381) | `malformed subprotocols` | "a broken donor" |

Both were consistent with everything observable, and neither told anyone whose bug it is. The question that decides that is **did the magic cookie match** — cookie present means our protocol with the wrong shape (version skew, hand-built list); cookie absent means something else entirely is calling. Three reasons now instead of two, so the **metric alone** answers it with nothing a peer sent being recorded.

## What is known, none of which narrowed it further

- exactly **9 source IPs**, unchanged across an egress restart and since at least 2026-07-26, each retrying metronomically **~1/s**
- **5,331 refusals against 3 successful accepts** in the same 10 minutes
- all `Go-http-client/1.1` — so **not** the browser widget. `coder/websocket`'s wasm build is *"a wrapper around the browser WebSocket API"*, and browsers set their own `User-Agent` and don't let JS override it
- `subprotocol_count=1` uniformly, where the protocol requires 3 or 4
- 6 of 9 are datacenter VPS (Hetzner ×2, Contabo, `airnode.nl`, `trouble-free.net`, `landvps.online`); one AT&T residential, one university host (`ellen2.fims.uwo.ca`), one with no PTR
- none appear in `lantern-cloud`'s tracked config
- **nothing in this repo sends a 1-element request.** The only live dialer is `jit_egress_consumer.go:75`, which sends 3. `egress_consumer.go:51` dials with `nil` options, but is unreachable — there's a `panic("you discovered the missing egress consumer functionality")` above the call

The stable 9-host set at a fixed ~1/s rules out browser donors independently of the User-Agent: widget donors are humans opening and closing tabs, not six VPS boxes retrying on a metronome for ten days.

`NewSubprotocolsResponse()` returns exactly one element — the bare magic cookie. A peer echoing the server's own handshake format back as a *request* would produce precisely what is observed. That's a hypothesis, not a finding, and it is exactly what the new label settles: `foreign_subprotocols` means the one token is **not** the cookie; `malformed_subprotocols` means it **is**.

## Why logging the values is safe here

#381 deliberately withheld the subprotocol values because one of them is a consumer session ID. That reasoning still holds — and it is also precisely what makes the mismatch case different: **a peer that fails the cookie check is not following the format that carries a session ID**, so by construction there is no identifier among its values. When the cookie matches, they stay withheld.

Bounded either way via `truncateForLog` — they remain unbounded, peer-chosen bytes headed for disk on a path taking ~9 requests/second.

`classifySubprotocolRefusal` is a function rather than inline branches specifically so that property is testable, and `TestClassifySubprotocolRefusal_NeverLogsValuesWhenCookieMatched` pins it across every cookie-carrying arity — including ones with a realistic session ID present.

**I did not tcpdump `:9001`** to read the values instead. That's live user traffic on a circumvention proxy.

## Testing

`go test -race ./egress/... ./common/...` passes. `go vet` reports only the two pre-existing `wsCancel` findings (verified identical on `main`, just shifted line numbers). `gofmt` clean. `GOOS=js GOARCH=wasm go build ./cmd` still compiles.

New tests cover all three classifications including the ordering case (cookie must lead), present-but-empty, and the cookie-alone shape the live refusals actually have.

## To get the answer

Merge → `release-egress` opens a version bump PR → merging that publishes → deploy to the egress host. Then either `foreign_subprotocols` appears with `subprotocol_values` naming the caller, or `malformed_subprotocols` tells us it's our own software with a version skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)