### PR TITLE
egress: don't leak a session ID from a misordered subprotocol list

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	// "errors"
 	"net"
+	"slices"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -226,22 +227,36 @@ func ParseSubprotocolsRequest(s []string) (csid string, version string, ok bool)
 	return csid, version, ok
 }
 
-// HasSubprotocolsMagicCookie reports whether s opens with the magic cookie, i.e.
-// whether the peer is speaking this protocol at all — independent of whether it got
-// the rest of the handshake right.
+// SubprotocolsContainMagicCookie reports whether the cookie appears anywhere in s,
+// i.e. whether the peer looks like it was trying to speak this protocol at all —
+// independent of whether it got position, arity, or anything else right.
 //
-// Exported so the egress can separate "our client, wrong shape" from "not our
-// protocol" when a handshake is refused. Conflating those two sent an investigation
-// of ~9 refusals/second down the wrong path for over a week: the refusals looked
-// like broken donors when the arity said something else entirely was calling.
+// Deliberately "anywhere" rather than "in the leading position", even though the
+// parser requires it to lead. The two questions are different and only one of them
+// is about parsing:
 //
-// It also decides what is safe to log. A peer that fails this check cannot have
-// supplied a consumer session ID, because it is not following the format that has
-// one — so its values carry no identifier and can be recorded to identify the
-// caller. A peer that passes may well have a real session ID among its values, so
-// those stay unlogged.
-func HasSubprotocolsMagicCookie(s []string) bool {
-	return len(s) > 0 && s[0] == subprotocolsMagicCookie
+//   - can this be parsed as our protocol?  -> the cookie must LEAD (see
+//     ParseSubprotocolsRequestWithCountry)
+//   - might these values contain a consumer session ID?  -> the cookie appearing
+//     ANYWHERE is enough to suspect so
+//
+// The second question is the one this answers, because it gates what reaches the
+// log. A first version checked the leading position for both and so claimed a
+// property it did not have: a client that built the list in the wrong order, say
+// [csid, cookie, version], fails a leading-position check while carrying a real
+// session ID — precisely the value withheld on purpose. Widening to "anywhere" is
+// what makes the claim below actually true.
+//
+// A peer that fails this check cannot have supplied a consumer session ID: it shows
+// no sign of following the format that carries one, so its values are safe to record
+// in order to identify the caller. A peer that passes may well have a real session
+// ID among its values, however garbled the rest, so those stay unlogged.
+//
+// The false-positive cost is negligible in the other direction: the cookie is a
+// nonce-like constant, so unrelated software containing it by coincidence is not a
+// realistic concern, and the consequence would only be declining to log values.
+func SubprotocolsContainMagicCookie(s []string) bool {
+	return slices.Contains(s, subprotocolsMagicCookie)
 }
 
 // ParseSubprotocolsRequestWithCountry additionally returns the consumer country

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -140,10 +140,10 @@ func TestParseSubprotocolsRequest_RejectsWrongArity(t *testing.T) {
 	}
 }
 
-// HasSubprotocolsMagicCookie answers "is this peer speaking our protocol at all",
+// SubprotocolsContainMagicCookie answers "is this peer speaking our protocol at all",
 // independent of whether it got the rest right. The egress uses it to decide both
 // which refusal to report and what is safe to log, so both halves matter.
-func TestHasSubprotocolsMagicCookie(t *testing.T) {
+func TestSubprotocolsContainMagicCookie(t *testing.T) {
 	for name, tc := range map[string]struct {
 		in   []string
 		want bool
@@ -157,16 +157,19 @@ func TestHasSubprotocolsMagicCookie(t *testing.T) {
 		"response form (cookie alone)": {NewSubprotocolsResponse(), true},
 		"foreign single token":         {[]string{"chat"}, false},
 		"foreign multi token":          {[]string{"graphql-ws", "mqtt"}, false},
-		// Order matters: the cookie has to lead. A list containing it elsewhere is
-		// not this protocol, and must not be treated as one.
-		"cookie not first": {[]string{"csid", NewSubprotocolsResponse()[0]}, false},
-		"empty first":      {[]string{"", NewSubprotocolsResponse()[0]}, false},
+		// Position deliberately does NOT matter here, unlike in the parser. This
+		// question is "might a session ID be in there", and a misordered list from a
+		// skewed client carries one just the same. Answering it positionally leaked
+		// exactly that value.
+		"cookie not first": {[]string{"csid", NewSubprotocolsResponse()[0]}, true},
+		"cookie last":      {[]string{"a", "b", NewSubprotocolsResponse()[0]}, true},
+		"empty first":      {[]string{"", NewSubprotocolsResponse()[0]}, true},
 		// Case-sensitive: the cookie is a byte-for-byte constant, not a token to
 		// normalize.
 		"wrong case": {[]string{"UN80UND3D", "csid", "v2.3.5"}, false},
 	} {
-		if got := HasSubprotocolsMagicCookie(tc.in); got != tc.want {
-			t.Errorf("%s: HasSubprotocolsMagicCookie(%q) = %v, want %v", name, tc.in, got, tc.want)
+		if got := SubprotocolsContainMagicCookie(tc.in); got != tc.want {
+			t.Errorf("%s: SubprotocolsContainMagicCookie(%q) = %v, want %v", name, tc.in, got, tc.want)
 		}
 	}
 }
@@ -174,8 +177,10 @@ func TestHasSubprotocolsMagicCookie(t *testing.T) {
 // Anything the parser accepts must also be recognized as our protocol. If these
 // disagreed, a refusal could be labeled "foreign" for a peer that in fact speaks
 // this protocol correctly — which is the exact misattribution the label exists to
-// prevent.
-func TestHasSubprotocolsMagicCookie_AgreesWithParser(t *testing.T) {
+// prevent. Note the converse does not hold, on purpose: this check is deliberately
+// broader than the parser, because "might contain a session ID" must not be a
+// narrower question than "parses".
+func TestSubprotocolsContainMagicCookie_AgreesWithParser(t *testing.T) {
 	for _, in := range [][]string{
 		NewSubprotocolsRequest("csid", "v2.3.5"),
 		NewSubprotocolsRequestWithCountry("csid", "v2.3.5", "CN"),
@@ -184,7 +189,7 @@ func TestHasSubprotocolsMagicCookie_AgreesWithParser(t *testing.T) {
 		if _, _, _, ok := ParseSubprotocolsRequestWithCountry(in); !ok {
 			t.Fatalf("precondition: parser rejected %q", in)
 		}
-		if !HasSubprotocolsMagicCookie(in) {
+		if !SubprotocolsContainMagicCookie(in) {
 			t.Errorf("parser accepted %q but cookie check rejected it", in)
 		}
 	}

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -31,12 +31,13 @@ type refusalReason string
 const (
 	// refusedMissingSubprotocols: no Sec-Websocket-Protocol header at all.
 	refusedMissingSubprotocols refusalReason = "missing_subprotocols"
-	// refusedMalformedSubprotocols: the magic cookie matched but the element count
-	// did not. This is *our* protocol with the wrong shape, so it implicates a
-	// broflake client — a version skew, or a caller that built the list by hand.
+	// refusedMalformedSubprotocols: the magic cookie appears somewhere in the list
+	// but the list does not parse — wrong arity, or the cookie not in the leading
+	// position. This is *our* protocol with the wrong shape, so it implicates a
+	// broflake client: a version skew, a hand-built list, or misordered tokens.
 	refusedMalformedSubprotocols refusalReason = "malformed_subprotocols"
-	// refusedForeignSubprotocols: the header was present and the magic cookie did
-	// not match, so the peer is not speaking this protocol at all.
+	// refusedForeignSubprotocols: the header was present and the magic cookie appears
+	// nowhere in it, so the peer shows no sign of speaking this protocol at all.
 	//
 	// Split out from "malformed" because the two point at completely different
 	// owners and the distinction is expensive to get wrong. For ten days the egress
@@ -96,8 +97,11 @@ func eachRefusal(f func(reason refusalReason, count int64)) {
 // applies, and whether the peer's values are safe to record.
 //
 // A function rather than inline branches in handleWebsocket so the safety property
-// below is testable directly. The property is easy to state and easy to break by
-// accident: values may be logged *only* when the magic cookie did not match.
+// below is testable directly. The property is easy to state and was in fact broken
+// on the first attempt: values may be logged *only* when the magic cookie appears
+// nowhere in the list. Checking the leading position instead — the same test the
+// parser uses — leaks a real consumer session ID from any client that merely
+// misordered its tokens.
 //
 // raw is the unsplit header lines and parsed is the comma-split, whitespace-trimmed
 // list. Absence is judged on raw because "Sec-WebSocket-Protocol: ," parses to zero
@@ -106,14 +110,18 @@ func classifySubprotocolRefusal(raw, parsed []string) (reason refusalReason, msg
 	switch {
 	case len(raw) == 0:
 		return refusedMissingSubprotocols, "Refused WebSocket connection, missing subprotocols", false
-	case common.HasSubprotocolsMagicCookie(parsed):
-		// Our protocol, wrong shape. A peer that got the cookie right is plausibly a
-		// real client, so one of its values is plausibly a real consumer session ID.
+	case common.SubprotocolsContainMagicCookie(parsed):
+		// Our protocol, wrong shape — a version skew, a hand-built list, or tokens in
+		// the wrong order. The cookie appearing *anywhere* is what qualifies, not the
+		// cookie leading: a misordered list is still our software getting it wrong,
+		// and it can still carry a real consumer session ID. Checking only the leading
+		// position here would classify that client as foreign and log its CSID, which
+		// is the one value deliberately withheld.
 		return refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols", false
 	default:
-		// Not our protocol. Recording the values is what identifies the caller, and
-		// it is safe precisely because the cookie did not match: a peer not following
-		// the format cannot have supplied the session ID that format carries.
+		// Not our protocol. Recording the values is what identifies the caller, and it
+		// is safe precisely because the cookie is absent: a peer showing no sign of
+		// following the format cannot have supplied the session ID that format carries.
 		return refusedForeignSubprotocols, "Refused WebSocket connection, foreign subprotocols", true
 	}
 }

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -299,10 +299,17 @@ func TestClassifySubprotocolRefusal(t *testing.T) {
 			raw: []string{"graphql-ws,mqtt"}, parsed: []string{"graphql-ws", "mqtt"},
 			wantReason: refusedForeignSubprotocols, wantLog: true,
 		},
-		// Right tokens, wrong order: the cookie must lead, or it is not our protocol.
+		// Wrong order. The parser requires the cookie to lead, so this does not parse
+		// — but it is still recognizably our software getting it wrong, and it can
+		// still carry a real CSID. So: malformed, and values withheld. Classifying it
+		// foreign (as a leading-position check does) would log that CSID.
 		"cookie not first": {
 			raw: []string{"csid," + cookie}, parsed: []string{"csid", cookie},
-			wantReason: refusedForeignSubprotocols, wantLog: true,
+			wantReason: refusedMalformedSubprotocols, wantLog: false,
+		},
+		"cookie last": {
+			raw: []string{"a,b," + cookie}, parsed: []string{"a", "b", cookie},
+			wantReason: refusedMalformedSubprotocols, wantLog: false,
 		},
 	} {
 		reason, msg, logValues := classifySubprotocolRefusal(tc.raw, tc.parsed)
@@ -327,12 +334,19 @@ func TestClassifySubprotocolRefusal_NeverLogsValuesWhenCookieMatched(t *testing.
 	cookie := common.NewSubprotocolsResponse()[0]
 	realCSID := "9f8c1e2a-secret-session-id"
 
-	// Every arity that fails to parse while still carrying the cookie.
+	// Every shape that fails to parse while still carrying the cookie somewhere —
+	// including the misordered ones, which a leading-position check misses. Those are
+	// the cases that leaked: the CSID sits right next to a cookie that is present but
+	// not first.
 	for _, parsed := range [][]string{
 		{cookie},
 		{cookie, realCSID},
 		{cookie, realCSID, "v2.3.5", "CN", "surplus"},
 		{cookie, realCSID, "v2.3.5", "CN", "surplus", "more"},
+		{realCSID, cookie},           // cookie second
+		{realCSID, cookie, "v2.3.5"}, // right tokens, wrong order
+		{"v2.3.5", realCSID, cookie}, // cookie last
+		{"", cookie, realCSID},       // empty leading token
 	} {
 		reason, _, logValues := classifySubprotocolRefusal([]string{"raw"}, parsed)
 		if logValues {


### PR DESCRIPTION
Integrates the review feedback on #385, which merged before it was addressed. Both comments were correct and they found a **real leak in the safety property #385 introduced**.

Worth merging before #386 (the v2.3.6 bump) so the leaky version never reaches production.

## The leak

#385 logs subprotocol values only when the magic cookie is absent, justified by: *a peer not following the format cannot have supplied the session ID that format carries.* The check implementing that tested only the **leading** position — the same test the parser uses — so the justification didn't hold:

```
Sec-WebSocket-Protocol: 9f8c1e2a-real-session-id, un80und3d, v2.3.5
                        ^ cookie present, just not first
```

A client that merely misordered its tokens fails a leading-position check, gets classified `foreign`, and has its real CSID written to disk — exactly the value #381 withheld on purpose.

## Root cause: one check answering two questions

| question | correct test |
|---|---|
| can this be parsed as our protocol? | the cookie must **lead** |
| might these values contain a session ID? | the cookie **anywhere** is enough |

Only the second gates logging, and it has to be the *broader* of the two. Collapsing them made the privacy guarantee exactly as narrow as the parser, which is the wrong bound. Now `SubprotocolsContainMagicCookie`, matching anywhere.

A misordered list is also reclassified `foreign` → `malformed`, which is independently more accurate: it's our software getting the shape wrong, which is what that label means. So the fix improves attribution as well as safety.

The false-positive direction is cheap: the cookie is a nonce-like constant, so unrelated software containing it isn't realistic, and the only cost would be declining to log values.

## How it survived being written

My own test encoded the leak as intended behavior:

```go
"cookie not first": {
    ..., wantReason: refusedForeignSubprotocols, wantLog: true,   // <- blessed the leak
},
```

That's the **second time in this stretch** a test asserted the bug it should have caught — the other being `page_died`'s `sharing` flag in #383. Both times the test was written from the implementation rather than from the property, so it locked in the defect and went green.

The replacement asserts the opposite and adds cookie-second, cookie-last, and empty-leading-token. The safety test now includes the misordered shapes, which is precisely where a positional check fails.

## Verified the tests have teeth

Reverted the implementation to leading-only and confirmed they fail on the leak, printing the value that would have been logged:

```
--- FAIL: TestClassifySubprotocolRefusal
    cookie not first: reason = "foreign_subprotocols", want "malformed_subprotocols"
    cookie not first: logValues = true, want false
--- FAIL: TestClassifySubprotocolRefusal_NeverLogsValuesWhenCookieMatched
    would log values for a cookie-matching peer: [9f8c1e2a-secret-session-id un80und3d]
    would log values for a cookie-matching peer: [v2.3.5 9f8c1e2a-secret-session-id un80und3d]
```

## Testing

`go test -race ./egress/... ./common/...` passes. `go vet` shows only the two pre-existing `wsCancel` findings. `gofmt` clean. `GOOS=js GOARCH=wasm go build ./cmd` still compiles.

Note this does not change what we learn about the 9 refusing hosts: they send a single token, so if it is the cookie they are `malformed` and if it is not they are `foreign` with the value logged — same as before. It only closes the case where a *different*, misordered client would have had its CSID logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol validation when security cookies appear in unexpected positions.
  * Prevented sensitive session identifiers from being exposed in logs for malformed protocol requests.
  * More accurately distinguishes malformed requests from unrelated protocol requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->