### PR TITLE
ci: publish the widget page alongside widget.wasm

### DIFF
--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -214,8 +214,12 @@ jobs:
           # CNAME is the one file whose absence breaks DNS for embed.lantern.io
           # rather than merely breaking the page. It reaches the branch only because
           # it sits in ui/public/, which is easy to disturb without noticing.
-          if [ "$(cat "$b/CNAME")" != "embed.lantern.io" ]; then
-            echo "CNAME missing or wrong: $(cat "$b/CNAME" 2>&1)" >&2
+          # Read once, capturing either the contents or cat's error as the value, so
+          # the comparison below is the only guard. || true because a bare
+          # cname=$(cat missing) aborts under set -e before the friendlier message.
+          cname=$(cat "$b/CNAME" 2>&1 || true)
+          if [ "$cname" != "embed.lantern.io" ]; then
+            echo "CNAME missing or wrong: $cname" >&2
             exit 1
           fi
 

--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -21,11 +21,25 @@ name: Build widget (wasm)
 # widget, so a change that compiles and unit-tests clean can still ship a broken
 # widget to every donor. Worth closing before relying on this too heavily.
 #
-# Only widget.wasm is written. The gh-pages branch also serves index.html,
-# storage.html, popup.html and static/ for embedders, and `gh-pages -d build`
-# replaces the whole branch — so the page half stays a deliberate, separate deploy.
-# It could not move here anyway: ui/.env.production is gitignored, so a CI page
-# build would bake in undefined REACT_APP_* values.
+# Publishes BOTH halves of embed.lantern.io: widget.wasm and the page that loads it.
+#
+# It began as wasm-only, which turned out to be worse than useless for the thing it
+# was added for. unbounded.lantern.io is a separate Next.js site that pulls the
+# widget in via <script src="https://embed.lantern.io/static/js/main.js">, so the
+# page JS ships from this branch too. Automating only the binary left #383's freeze
+# watchdog with no path to production at all, and left a trap: `yarn deploy` (the
+# manual page deploy) pushes the committed ui/public/widget.wasm, which would have
+# silently reverted the automated binary to a months-old build.
+#
+# Both are published from one job so they cannot disagree, and widget.wasm is
+# written from the Go build *after* the page files are copied — so whatever stale
+# binary ui/public/ happens to hold is always overwritten rather than shipped.
+#
+# The page build config comes from ui/.env.production.example, which is tracked and
+# byte-identical to the gitignored ui/.env.production. Nothing in it is secret: every
+# REACT_APP_* value is compiled into a world-readable bundle by definition, and the
+# one token-shaped key (STRAPI_API_TOKEN) is read only by scripts/translate.js, not
+# by the build.
 #
 # Build only, no `go vet`: vetting under wasm tags currently reports four
 # pre-existing findings in clientcore (user.go lostcancel x2, unreachable code in
@@ -44,6 +58,7 @@ on:
       - 'common/**'
       - 'cmd/**'
       - 'netstate/**'
+      - 'ui/**'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/build-widget-wasm.yml'
@@ -53,6 +68,7 @@ on:
       - 'common/**'
       - 'cmd/**'
       - 'netstate/**'
+      - 'ui/**'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/build-widget-wasm.yml'
@@ -109,7 +125,7 @@ jobs:
         run: go test ./clientcore/... ./common/...
 
   publish:
-    name: publish widget.wasm to gh-pages
+    name: publish widget + page to gh-pages
     # Both gates must pass. A publish that only required compilation would put a
     # binary in front of every donor on the strength of the type checker alone.
     needs: [build-wasm, test]
@@ -167,6 +183,58 @@ jobs:
             exit 1
           fi
 
+      - uses: actions/setup-node@v4
+        with:
+          # Not the newest: react-scripts 5 is unmaintained and its webpack/openssl
+          # assumptions get less reliable the further ahead of it Node runs.
+          node-version: '20'
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
+
+      # ui/.env.production is gitignored, but ui/.env.production.example is tracked
+      # and byte-identical to it, so the tracked file is the source of truth here.
+      # Copying rather than duplicating the values into this workflow keeps one place
+      # to change them and no chance of CI and a local build drifting apart.
+      - name: Build the widget page
+        working-directory: ui
+        run: |
+          set -euo pipefail
+          cp .env.production.example .env.production
+          yarn install --frozen-lockfile
+          yarn build:web
+
+      # Same reasoning as the wasm check: a page build can "succeed" and still emit
+      # something that would break every embedder, and publishing it takes the widget
+      # down until the next merge.
+      - name: Verify the page build
+        run: |
+          set -euo pipefail
+          b=ui/build
+
+          # CNAME is the one file whose absence breaks DNS for embed.lantern.io
+          # rather than merely breaking the page. It reaches the branch only because
+          # it sits in ui/public/, which is easy to disturb without noticing.
+          if [ "$(cat "$b/CNAME")" != "embed.lantern.io" ]; then
+            echo "CNAME missing or wrong: $(cat "$b/CNAME" 2>&1)" >&2
+            exit 1
+          fi
+
+          # The entry point unbounded.lantern.io loads by absolute URL. Its name is
+          # pinned by ui/scripts/build.js (static/js/[name].js, no content hash), so
+          # the path is stable and worth asserting rather than globbing.
+          js=$b/static/js/main.js
+          size=$(stat -c%s "$js")
+          echo "main.js=$size bytes"
+          # A real bundle is ~800KB. Anything this far under is a broken build.
+          if [ "$size" -lt 300000 ]; then
+            echo "main.js implausibly small: $size bytes" >&2
+            exit 1
+          fi
+
+          for f in index.html storage.html popup.html offscreen.html asset-manifest.json; do
+            [ -s "$b/$f" ] || { echo "missing or empty: $f" >&2; exit 1; }
+          done
+
       # Separate worktree rather than a branch switch, so the built artifact in
       # RUNNER_TEMP is untouched and the checked-out source stays available.
       - name: Publish to gh-pages
@@ -191,20 +259,33 @@ jobs:
           # as a remote-tracking ref as --track -b, which would make the push below
           # depend on branch tracking config rather than the explicit refspec.
           git worktree add --detach /tmp/ghp origin/gh-pages
-          cp "$RUNNER_TEMP/widget.wasm" /tmp/ghp/widget.wasm
-          cd /tmp/ghp
 
-          # Byte-identical rebuilds are common — most merges here touch Go code that
-          # does not change the emitted module. Committing anyway would add a 12MB
-          # blob to history per merge and grow the repo without bound.
-          if git diff --quiet -- widget.wasm; then
-            echo "widget.wasm unchanged; nothing to publish"
+          # --delete so renamed or dropped assets do not accumulate forever; the
+          # branch should mirror the build, which is what `gh-pages -d build` did.
+          # ui/build/ holds exactly the branch's file set, CNAME included, so this
+          # does not strand anything the page needs.
+          rsync -a --delete --exclude '.git' ui/build/ /tmp/ghp/
+
+          # AFTER the page copy, deliberately. ui/build/widget.wasm is whatever
+          # ui/public/ happened to contain — a committed binary that has been months
+          # stale before — so the freshly built one always wins. This is what makes
+          # the two artifacts unable to disagree.
+          cp "$RUNNER_TEMP/widget.wasm" /tmp/ghp/widget.wasm
+
+          cd /tmp/ghp
+          git add -A
+
+          # Most merges do not change either artifact. Committing regardless would add
+          # a ~12MB blob per merge and grow the repo without bound.
+          if git diff --cached --quiet; then
+            echo "no change to widget.wasm or the page; nothing to publish"
             exit 0
           fi
 
-          git add widget.wasm
-          git commit -m "widget.wasm: build from $COMMIT_SHA"
+          echo "publishing:"
+          git diff --cached --stat | tail -20
+          git commit -m "widget: build from $COMMIT_SHA"
           # Push to the ref explicitly. The worktree is on a detached HEAD from
           # origin/gh-pages, so HEAD:gh-pages is what advances the branch.
           git push origin HEAD:gh-pages
-          echo "published widget.wasm from $COMMIT_SHA"
+          echo "published widget + page from $COMMIT_SHA"

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -24,6 +24,27 @@
 // Deliberately not OpenTelemetry: the otel Go SDK was found to abuse the call
 // stack in ways mobile Safari does not tolerate, so widget-side telemetry stays
 // primitive on both sides of the boundary.
+//
+// Runs on other people's sites. The widget is embedded by third parties with a
+// cross-origin script tag, not an iframe:
+//
+//	<script defer src="https://embed.lantern.io/static/js/main.js"></script>
+//
+// A cross-origin script executes in the *embedder's* origin, so everything below
+// happens on their page, not ours. Two consequences worth knowing before changing
+// any of it:
+//
+//   - localStorage, window.__unboundedWatchdog and console output all belong to the
+//     embedding site. Breadcrumbs therefore recover per-site, which is correct — a
+//     freeze on site X is evidence about site X — but it also means this writes keys
+//     into storage we do not own. Hence the narrow prefix, the 24h expiry, the cap
+//     on retained records, and deleting each record as it is read: the footprint on
+//     a host we are a guest on should stay small and self-cleaning.
+//   - FreezeReport carries `url`, which on an embedding site is that site's URL.
+//     Harmless while the only sinks are the local console and a window global, but
+//     enabling REACT_APP_FREEZE_BEACON_URL would start sending us the addresses of
+//     pages that embed the widget. That is a deliberate decision about third-party
+//     data, not a config toggle, which is part of why the beacon ships disabled.
 
 // tickMs is how often the watchdog samples. Frequent enough that an 8s freeze is
 // caught by a wide margin, cheap enough to be irrelevant: one Date.now(), one


### PR DESCRIPTION
Finishes what #384 started. Automating only the binary turned out to be worse than useless for the thing it was added for, and left a trap behind.

## The gap

`unbounded.lantern.io` is a separate Next.js site that pulls the widget in via:

```html
<script src="https://embed.lantern.io/static/js/main.js">
```

So the widget **JS ships from `gh-pages` too** — the same branch as the wasm. #384 wrote only `widget.wasm`, so **#383's freeze watchdog has no path to production at all**. Confirmed against what's live:

| artifact | state |
|---|---|
| `embed.lantern.io/widget.wasm` | today's build, `liveness()` **present** ✅ |
| `embed.lantern.io/static/js/main.js` | 821KB, `__unboundedWatchdog` occurrences: **0** ❌ |

The Go heartbeat is in front of users and nothing reads it.

`ui/**` was also missing from the `paths` filter — which is the direct reason #383 published nothing. It was a UI-only change, so it triggered no run at all. Added.

## The trap #384 created

`yarn deploy` is still the only way to ship page JS, and its `predeploy` runs `build:web`, which does **not** run `cmd/build_web.sh`. So it pushes the committed `ui/public/widget.wasm` — months stale — straight over the automated one. Anyone shipping the watchdog by hand would have silently reverted #384.

Reproduced in a dry run against the real branch:

```
on the branch (live, automated)   11,876,449
after the page copy               11,739,478   <- the regression
after the Go overwrite            12,399,554   <- the fix
```

Both artifacts now publish from **one job**, and `widget.wasm` is written from the Go build **after** the page files are copied. Whatever `ui/public/` holds is always overwritten rather than shipped, so the two cannot disagree.

## No secrets needed

Config comes from `ui/.env.production.example`, which is **tracked and byte-identical** to the gitignored `ui/.env.production` — verified by diff. One place to change it, no CI-vs-local drift.

Nothing in it is secret: every `REACT_APP_*` value is compiled into a world-readable bundle by definition, and the one token-shaped key (`STRAPI_API_TOKEN`) is read only by `scripts/translate.js`, never by `build:web`. So no repo secrets or variables required.

## Verification before publishing

Same principle as the existing wasm checks — a build can succeed and still emit something that breaks every embedder, and publishing it takes the widget down until the next merge.

- **`CNAME` must equal `embed.lantern.io`.** The one file whose absence breaks *DNS* rather than merely breaking the page, and it reaches the branch only by sitting in `ui/public/`.
- `static/js/main.js` must exist and exceed 300KB (a real bundle is ~800KB). Its name is pinned by `ui/scripts/build.js` (`static/js/[name].js`, no content hash), so the path is stable enough to assert rather than glob.
- `index.html`, `storage.html`, `popup.html`, `offscreen.html`, `asset-manifest.json` must be non-empty.

## Dry run

Simulated the whole publish against the real `gh-pages` (nothing pushed):

- the worktree's `.git` — a **file**, not a directory — survives `rsync --delete --exclude '.git'`
- `CNAME` preserved
- staged diff is exactly two files, `static/js/main.js` and `widget.wasm`, with no stale assets stranded and nothing needed deleted
- the freshly built `main.js` **does** contain `__unboundedWatchdog`, so this is what puts the watchdog live

`rsync --delete` so renamed assets don't accumulate, matching what `gh-pages -d build` did.

Node pinned to 20 rather than latest: `react-scripts` 5 is unmaintained and its webpack/openssl assumptions get less reliable the further ahead of it Node runs.

## Third-party embedders

The widget is embedded by third parties with a **cross-origin script tag**, not an iframe (per the README):

```html
<browsers-unbounded data-layout="banner" ... />
<script defer src="https://embed.lantern.io/static/js/main.js"></script>
```

That cuts two ways, and this PR is what makes both real for the first time.

**Distribution needs nothing from embedders.** They reference `main.js` by absolute URL, so publishing reaches every embedding site immediately — no action on their part. But it also means merging this pushes the watchdog to **every embedder at once**, not just unbounded.lantern.io.

**A cross-origin script executes in the embedder's origin**, so the watchdog's side effects land on *their* pages:

- `localStorage`, `window.__unboundedWatchdog` and console output all belong to the embedding site. Breadcrumbs recovering per-site is correct — a freeze on site X is evidence about site X — but it does mean writing keys into storage we don't own. That retroactively justifies the narrow prefix, 24h expiry, retained-record cap and delete-on-read already in `freezeWatchdog.ts`: the footprint on a host we're a guest on should stay small and self-cleaning.
- `FreezeReport.url` is the embedder's URL. Harmless while the only sinks are a local console and a window global, but enabling `REACT_APP_FREEZE_BEACON_URL` would start sending us the addresses of pages that embed the widget. That's a decision about third-party data, not a config toggle — part of why the beacon ships disabled, now documented where someone about to enable it will read it.

None of this changes the code's behavior; it's written into the file's header comment so the next person doesn't have to rediscover it.

## On merge

Merging republishes both halves, which is the point — it's what finally puts #383's watchdog in front of donors, on unbounded.lantern.io **and every third-party embedder**. Note this is a production deploy at merge time, same as #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
