### PR TITLE
ui: repair the ineffective eslint-disable on the vendored wasm shim

### DIFF
--- a/ui/src/utils/goWasmExec.ts
+++ b/ui/src/utils/goWasmExec.ts
@@ -1,5 +1,14 @@
 // @ts-nocheck @todo add types
-// eslint-disable-file
+/* eslint-disable */
+// ^ was `// eslint-disable-file`, which is not a real ESLint directive and so did
+// nothing. The intent was always to exempt this file — it is vendored from Go's
+// wasm_exec.js (see the copyright below) and its style is upstream's business, not
+// ours. Fixing it in place rather than adding an .eslintignore keeps the exemption
+// visible to anyone re-vendoring the file.
+//
+// This was invisible until CI built the page: react-scripts turns ESLint warnings
+// into errors when CI=true, so four upstream style nits that had been merely noisy
+// locally failed the publish build outright.
 
 // Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style


### PR DESCRIPTION
#388's publish job failed on its first run. This unblocks it.

## Root cause

`ui/src/utils/goWasmExec.ts` is vendored from Go's `wasm_exec.js` ("Copyright 2018 The Go Authors"). Line 2 said:

```js
// eslint-disable-file
```

**That is not a real ESLint directive**, so it has always done nothing. The intent was unambiguous — the file also carries a working `@ts-nocheck` — but the lint half was silently inert for however long it has been there.

## Why it stayed invisible

`react-scripts` turns ESLint **warnings into errors** when `CI=true`, and GitHub Actions sets `CI=true` automatically. So locally:

```
$ yarn build:web
Compiled with warnings.     <- four upstream style nits, build succeeds
```

and in CI:

```
Treating warnings as errors because process.env.CI = true.
Failed to compile.
[eslint] src/utils/goWasmExec.ts
  Line 12:1:    'use strict' is unnecessary inside of modules
  Line 28:12:   Expected '!==' and instead saw '!='
  Line 131:10:  'setInt32' is assigned a value but never used
  Line 280:21:  Missing '()' invoking a constructor
```

I saw those four warnings while testing #388 and described them as pre-existing in `goWasmExec.ts`. That was true and beside the point: the question wasn't whether they were mine, it was whether they were fatal under CI — and I never ran the build the way CI runs it. Reproduced with `CI=true yarn build:web` before fixing.

## The fix

Replaced with the real `/* eslint-disable */`, plus a comment recording what the broken directive was and why the file is exempt.

Three things deliberately **not** done:

- **Not fixing the four nits.** The file is upstream's; editing it creates a diff to reconcile on every Go toolchain update.
- **Not using `.eslintignore`.** Fixing it in place keeps the exemption visible to whoever next re-vendors the file, rather than hiding it in a config they won't think to check.
- **Not disabling warnings-as-errors for the publish build.** That was the quicker fix and the worse one — it exists to stop real problems shipping, and the right scope for the exemption is one vendored file, not the whole UI.

## Nothing was published by the failed run

It died at the page build, *before* the publish step, so `gh-pages` still holds the previous good `widget.wasm` — verified: live `content-length` unchanged at 11,876,449, branch still at `b6fba18`. The fail-before-push ordering held up.

## Verification

```
$ CI=true yarn build:web
Compiled successfully.
```

And every check the workflow performs, run locally against the output:

| check | result |
|---|---|
| `CNAME` == `embed.lantern.io` | PASS |
| `static/js/main.js` ≥ 300KB | PASS (828,339) |
| `index.html`, `storage.html`, `popup.html`, `offscreen.html`, `asset-manifest.json` non-empty | PASS |
| `__unboundedWatchdog` present in bundle | PASS |

`tsc --noEmit` clean, 30 watchdog tests pass.

Merging this republishes both artifacts and is what finally puts #383's watchdog in front of donors and every third-party embedder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)