### PR TITLE
docs: correct the UI deploy instructions, which now break production

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,32 @@ Development:
 1. Copy the example env: `cp .env.development.example .env.development`
 2. Start the dev server: `yarn dev:web` and open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-Production:
-1. Copy the example env: `cp .env.production.example .env.production`
-2. Build and deploy prod bundle to Github page: `yarn deploy`
+Production: **you don't deploy by hand.** Merging to `main` publishes both `widget.wasm`
+and the page bundle to the `gh-pages` branch (and from there to embed.lantern.io) via
+`.github/workflows/build-widget-wasm.yml`, gated on the js/wasm build and the Go unit
+tests. That covers unbounded.lantern.io and every third-party embedder at once, since
+they all load `https://embed.lantern.io/static/js/main.js` by absolute URL.
+
+> [!WARNING]
+> **Do not run `yarn deploy`.** Its `predeploy` runs `build:web`, which does *not*
+> run `cmd/build_web.sh` — so it publishes the committed `ui/public/widget.wasm`,
+> which is a prebuilt binary that goes stale as soon as any Go code changes. Running
+> it silently reverts the automatically published wasm to whatever that file holds
+> while the page JS moves forward, leaving the two halves mismatched. If you need a
+> one-off manual publish, build the wasm first (`cd cmd && ./build_web.sh`) so
+> `ui/public/widget.wasm` is current.
+
+Before pushing UI changes, build the way CI does:
+
+```bash
+CI=true yarn build:web
+```
+
+`react-scripts` turns ESLint **warnings into errors** when `CI` is set, and GitHub
+Actions sets it automatically — so a plain `yarn build:web` can print warnings,
+succeed locally, and still fail the publish. Note the failure is safe: the publish
+job verifies the build before it touches `gh-pages`, so a broken build stops rather
+than shipping.
 
 #### UI deep dive for devs
 
@@ -216,7 +239,9 @@ Production:
    1. Install a simple server e.g. `npm install -g serve` (or your lightweight http server of choice)
    2. Serve the build dir e.g. `cd build && serve -s -l 3000` and visit [http://localhost:3000](http://localhost:3000)
 
-7. To deploy to Github pages: `yarn deploy`
+7. To deploy to Github pages: nothing to do — merging to `main` publishes. See the
+   warning under [UI quickstart for devs](#ui-quickstart-for-devs) before reaching for
+   `yarn deploy`, which regresses the published `widget.wasm`.
 
 8. Coming soon to a repo near you: `yarn test`
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ than shipping.
    1. Install a simple server e.g. `npm install -g serve` (or your lightweight http server of choice)
    2. Serve the build dir e.g. `cd build && serve -s -l 3000` and visit [http://localhost:3000](http://localhost:3000)
 
-7. To deploy to Github pages: nothing to do — merging to `main` publishes. See the
+7. To deploy to GitHub Pages: nothing to do — merging to `main` publishes. See the
    warning under [UI quickstart for devs](#ui-quickstart-for-devs) before reaching for
    `yarn deploy`, which regresses the published `widget.wasm`.
 


### PR DESCRIPTION
The README told developers to publish with `yarn deploy` in two places. Since #388, that instruction is **actively harmful** rather than merely stale.

## Why it breaks things now

`predeploy` runs `build:web`, which does **not** run `cmd/build_web.sh`. So `yarn deploy` publishes the committed `ui/public/widget.wasm` — a prebuilt binary that goes stale the moment any Go code changes, and was four months behind as recently as yesterday.

Now that #388 publishes both artifacts automatically, following the README would silently revert the wasm while the page JS moved forward, leaving the two halves mismatched on embed.lantern.io. Measured:

```
ui/public/widget.wasm (committed, what yarn deploy ships)  42f5578a
currently published (fresh CI build)                       204bc788
```

Replaced with what actually happens — merging to `main` publishes both halves, reaching unbounded.lantern.io and every third-party embedder at once — plus the escape hatch for a genuine one-off manual publish (build the wasm first so `ui/public/` is current).

## Also documents the CI build trap

`react-scripts` turns ESLint **warnings into errors** when `CI` is set, and GitHub Actions sets it automatically. So `yarn build:web` can print warnings, succeed locally, and still fail the publish — which is exactly how #388's first publish run failed (#389 fixed the underlying ineffective `eslint-disable` directive).

```bash
CI=true yarn build:web   # the command that matches CI
```

I hit this myself and had even *seen* the warnings without recognising they were fatal, which seems like a good argument for it living in the README rather than in someone's memory.

It also notes that the failure mode is safe, since that's what people will want to know before merging: the publish job verifies the build before it touches `gh-pages`, so a bad build stops rather than shipping. That held up in practice — the failed run pushed nothing and the live artifacts were untouched.

## Verified

Both `yarn deploy` references updated (lines 198 and 244), and the cross-reference anchor matches the real heading (`#### UI quickstart for devs` → `#ui-quickstart-for-devs`).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to explain automatic publishing when changes are merged to `main`.
  * Removed outdated manual production deployment steps.
  * Added guidance for CI-compatible local builds and warnings against using `yarn deploy`.
  * Refined deep-dive deployment instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->