### PR TITLE
egress: name the legacy team clients, and tell them to upgrade

### DIFF
--- a/common/resource.go
+++ b/common/resource.go
@@ -17,6 +17,17 @@ const (
 )
 
 const (
+	// SubprotocolsHeader is spelled in Go's canonical MIME form, NOT the RFC 6455
+	// form, and the difference is load-bearing. RFC 6455 writes the header as
+	// "Sec-WebSocket-Protocol" (capital S in Socket); textproto.CanonicalMIMEHeaderKey
+	// capitalizes only the first letter after each hyphen, yielding
+	// "Sec-Websocket-Protocol".
+	//
+	// The egress indexes the header map directly with this constant
+	// (r.Header[common.SubprotocolsHeader]), and http.Header keys are stored
+	// canonicalized — so "correcting" this to the RFC spelling would make every lookup
+	// return nothing, and every connection would be refused as though the client had
+	// sent no subprotocols at all. Silently, and for all clients.
 	SubprotocolsHeader      = "Sec-Websocket-Protocol"
 	subprotocolsMagicCookie = "un80und3d"
 )

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -135,10 +135,12 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 		// A status only for the legacy client, because it is the only one of these
 		// where a specific remedy exists and a real operator is plausibly watching.
-		// These nine hosts have been retrying roughly once a second for months into
-		// what looks to them like success — websocket.Dial fails, the client backs off
-		// and tries again, and nothing says why. A status code is the only channel we
-		// have to that operator.
+		// These nine hosts have been retrying roughly once a second for months, and
+		// from the outside the client looks healthy the whole time: websocket.Dial
+		// returns an error, the client backs off and tries again, and that is
+		// indistinguishable from ordinary transient network trouble. Nothing says the
+		// handshake itself is obsolete. A status code is the only channel we have to
+		// whoever runs them.
 		//
 		// 426 rather than the 418 used above for a version-header mismatch: 426 is the
 		// registered status for "you must upgrade to talk to me", so it reads correctly

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -133,6 +133,23 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 			attrs = append(attrs, "subprotocol_values", truncateForLog(strings.Join(subprotocols, "|")))
 		}
 
+		// A status only for the legacy client, because it is the only one of these
+		// where a specific remedy exists and a real operator is plausibly watching.
+		// These nine hosts have been retrying roughly once a second for months into
+		// what looks to them like success — websocket.Dial fails, the client backs off
+		// and tries again, and nothing says why. A status code is the only channel we
+		// have to that operator.
+		//
+		// 426 rather than the 418 used above for a version-header mismatch: 426 is the
+		// registered status for "you must upgrade to talk to me", so it reads correctly
+		// in a log without knowing this codebase, and keeping the two distinct means a
+		// refusal's status alone says which check rejected it.
+		if reason == refusedLegacyTeamClient {
+			w.WriteHeader(http.StatusUpgradeRequired)
+			w.Write([]byte("426 upgrade required: this client predates the current " +
+				"handshake and cannot be served; please update unbounded\n"))
+		}
+
 		recordRefusal(reason)
 		slog.Debug(msg, attrs...)
 		return

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -48,9 +48,44 @@ const (
 	// the question that actually decides who to go talk to, from the metric alone,
 	// with no need to log anything a peer sent.
 	refusedForeignSubprotocols refusalReason = "foreign_subprotocols"
-	refusedBadProtocolVersion  refusalReason = "bad_protocol_version"
-	refusedMissingCSID         refusalReason = "missing_consumer_session_id"
+	// refusedLegacyTeamClient: a recognized *ex*-broflake client. It sends the team
+	// identifier that clients built before 2025-08-22 put in this header, which is
+	// where the cookie now goes. Split out from "foreign" because the cause is known
+	// and the remedy is specific — those operators need to upgrade — whereas
+	// "foreign" means we genuinely do not know who is calling.
+	//
+	// This accounted for every refusal on unbounded-us when it was added: ~9/s from
+	// 9 fixed hosts, unbroken since at least 2026-07-26 and in fact since the
+	// handshake changed under them nearly a year earlier.
+	refusedLegacyTeamClient   refusalReason = "legacy_team_client"
+	refusedBadProtocolVersion refusalReason = "bad_protocol_version"
+	refusedMissingCSID        refusalReason = "missing_consumer_session_id"
 )
+
+// legacyTeamIDPrefix is what pre-2025-08-22 clients put in Sec-Websocket-Protocol.
+//
+// Introduced in 0658b1f ("send teamId from consumer -> egress via websocket protocol
+// header", 2025-04-10) as common.TeamIdPrefix, and removed from common in 6561021
+// when the team mechanism moved to the QUIC layer. Redeclared here rather than
+// restored to common on purpose: nothing in this repo should *emit* it again, and a
+// private constant in the one place that still recognizes it says so.
+//
+// Those clients cannot be served, which is why this only labels them. They predate
+// both the consumer session ID (db39eb2, 2025-07-17) and QUIC connection migration
+// (7c86b73, 2025-08-06), and the csid exists *as* the migration key. Synthesizing one
+// to let them in would register connection state that nothing can ever migrate to,
+// and hold it through the migration window on every disconnect — spending resources
+// on sessions that cannot resume, to pretend a client speaks a protocol it does not.
+const legacyTeamIDPrefix = "unbounded-team:"
+
+// isLegacyTeamClient reports whether the peer is a recognized pre-handshake client.
+//
+// Prefix rather than equality: the identifier after the colon is the team, and while
+// every observed client sends the hardcoded "no_team" placeholder from 0658b1f, a
+// build that actually set one would be the same client with the same problem.
+func isLegacyTeamClient(parsed []string) bool {
+	return len(parsed) == 1 && strings.HasPrefix(parsed[0], legacyTeamIDPrefix)
+}
 
 var (
 	refusalsMx sync.Mutex
@@ -118,6 +153,14 @@ func classifySubprotocolRefusal(raw, parsed []string) (reason refusalReason, msg
 		// position here would classify that client as foreign and log its CSID, which
 		// is the one value deliberately withheld.
 		return refusedMalformedSubprotocols, "Refused WebSocket connection, malformed subprotocols", false
+	case isLegacyTeamClient(parsed):
+		// After the cookie check, not before. This is a subset of the foreign case and
+		// cannot overlap the cookie case today — a lone "unbounded-team:..." token is
+		// not the cookie, and a csid needs a second element — but the cookie check is
+		// the privacy guard, so it wins unconditionally rather than by coincidence.
+		// Ordering it first would make the guarantee depend on isLegacyTeamClient
+		// staying narrow, which is not a property to leave to a future edit.
+		return refusedLegacyTeamClient, "Refused WebSocket connection, legacy team client", true
 	default:
 		// Not our protocol. Recording the values is what identifies the caller, and it
 		// is safe precisely because the cookie is absent: a peer showing no sign of

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -63,6 +63,8 @@ const (
 )
 
 // legacyTeamIDPrefix is what pre-2025-08-22 clients put in Sec-Websocket-Protocol.
+// (Go's canonical casing, matching common.SubprotocolsHeader; RFC 6455 spells it
+// Sec-WebSocket-Protocol. See that constant for why the difference matters.)
 //
 // Introduced in 0658b1f ("send teamId from consumer -> egress via websocket protocol
 // header", 2025-04-10) as common.TeamIdPrefix, and removed from common in 6561021

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -357,3 +357,70 @@ func TestClassifySubprotocolRefusal_NeverLogsValuesWhenCookieMatched(t *testing.
 		}
 	}
 }
+
+// The legacy team client is the known cause of every refusal observed on
+// unbounded-us: pre-2025-08-22 builds put a team identifier in the header that now
+// carries the magic cookie. It gets its own label because the remedy is specific —
+// those operators must upgrade — while "foreign" means we do not know who is calling.
+func TestClassifySubprotocolRefusal_LegacyTeamClient(t *testing.T) {
+	// Exactly what production sends, from 0658b1f's hardcoded placeholder.
+	reason, msg, logValues := classifySubprotocolRefusal(
+		[]string{"unbounded-team:no_team"}, []string{"unbounded-team:no_team"})
+	if reason != refusedLegacyTeamClient {
+		t.Errorf("reason = %q, want %q", reason, refusedLegacyTeamClient)
+	}
+	if !logValues {
+		t.Error("values must be loggable: no cookie means no session ID to leak")
+	}
+	if msg == "" {
+		t.Error("empty message")
+	}
+
+	// A build that actually set a team is the same client with the same problem, so
+	// the match is on the prefix rather than the placeholder.
+	if r, _, _ := classifySubprotocolRefusal(
+		[]string{"unbounded-team:acme"}, []string{"unbounded-team:acme"}); r != refusedLegacyTeamClient {
+		t.Errorf("a real team id should still classify as legacy, got %q", r)
+	}
+}
+
+// The label must stay narrow: anything that merely mentions the prefix, or pairs it
+// with other tokens, is not the legacy client and should not be reported as one — the
+// point of the label is that it names a known cause.
+func TestIsLegacyTeamClient_StaysNarrow(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   []string
+		want bool
+	}{
+		"exact placeholder":  {[]string{"unbounded-team:no_team"}, true},
+		"real team":          {[]string{"unbounded-team:x"}, true},
+		"empty team":         {[]string{"unbounded-team:"}, true},
+		"nil":                {nil, false},
+		"prefix absent":      {[]string{"chat"}, false},
+		"prefix not leading": {[]string{"chat", "unbounded-team:x"}, false},
+		"extra token":        {[]string{"unbounded-team:x", "extra"}, false},
+		// Substring rather than prefix: not the legacy client.
+		"prefix embedded": {[]string{"x-unbounded-team:x"}, false},
+	} {
+		if got := isLegacyTeamClient(tc.in); got != tc.want {
+			t.Errorf("%s: isLegacyTeamClient(%q) = %v, want %v", name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// The cookie check must win over the legacy check. It cannot overlap today, but the
+// cookie check is the privacy guard and the guarantee should not rest on
+// isLegacyTeamClient happening to stay narrow.
+func TestClassifySubprotocolRefusal_CookieBeatsLegacy(t *testing.T) {
+	cookie := common.NewSubprotocolsResponse()[0]
+	realCSID := "9f8c1e2a-secret-session-id"
+
+	reason, _, logValues := classifySubprotocolRefusal(
+		[]string{"raw"}, []string{"unbounded-team:x", cookie, realCSID})
+	if reason != refusedMalformedSubprotocols {
+		t.Errorf("reason = %q, want %q", reason, refusedMalformedSubprotocols)
+	}
+	if logValues {
+		t.Error("a cookie-carrying list must never have its values logged, legacy prefix or not")
+	}
+}


### PR DESCRIPTION
Every refusal on unbounded-us is **one known cause**, so it gets a label saying so instead of sitting in the bucket that means "we don't know who this is."

## Who they are

Pre-2025-08-22 unbounded clients. They send the team identifier that `0658b1f` (2025-04-10) put in `Sec-Websocket-Protocol` — the header `c3b5fef` (2025-08-22) then repurposed for the magic cookie, csid and version. A "drive by" reuse of an occupied field with no version negotiation, so those clients have failed closed and silently ever since.

**Nearly a year**, not the ten days journal retention showed. Nine fixed hosts, ~1/s each, **5,331 refusals against 3 successful accepts** in the same 10-minute window.

## Can we actually use them? No — and the reason is specific

Not "a year of protocol drift." They predate two things the current egress requires:

| what | when | |
|---|---|---|
| the legacy client | 2025-04-10 | `0658b1f` |
| consumer session ID | 2025-07-17 | `db39eb2` |
| **QUIC connection migration** | 2025-08-06 | `7c86b73` |

The csid exists **as** the migration key. Synthesizing one to let them in would register connection state that nothing can ever migrate to, and hold it through the migration window on every disconnect — spending resources on sessions that can never resume, in order to pretend a client speaks a protocol it doesn't.

I also checked whether they might be sending csid/version as real HTTP headers, since before `c3b5fef` that's how both travelled (`X-BF-Version`, `X-BF-ConsumerSessionID`) and these are native Go clients that *can* set headers. They don't — the legacy dial is annotated:

```go
// 'HTTPClient, HTTPHeader and CompressionMode in DialOptions are no-op'
wsDialOpts := &websocket.DialOptions{
    Subprotocols: []string{fmt.Sprintf("%v%v", common.TeamIdPrefix, teamId)},
}
```

written for the wasm constraint, so it sets no headers at all. Nothing to recover.

## What this can do: stop the failure being silent

These hosts have retried for months into what looks locally like an ordinary dial failure — back off, try again, nothing saying why. They now get **426 Upgrade Required** with a body naming the problem. That's the only channel we have to whoever runs them, and the only realistic path to recovering nine volunteers who are currently paying for VPS capacity that contributes nothing.

**426 rather than the 418** this file already uses for a version-header mismatch: 426 is the registered status for "you must upgrade to talk to me", so it reads correctly in a log without knowing this codebase, and keeping the two distinct means a refusal's status alone identifies which check rejected it. It's also the only refusal that writes a status at all, because it's the only one where a specific remedy exists and someone is plausibly watching.

## Details worth review

- `legacyTeamIDPrefix` is redeclared **privately in `egress`** rather than restored to `common` (removed there in `6561021`): nothing here should ever *emit* it again, and a private constant in the one place that still recognizes it says that.
- Matched as a **prefix**, since a build that actually set a team is the same client with the same problem. Every observed client sends `0658b1f`'s hardcoded `no_team` placeholder — the team feature was never even finished, so they're being refused over a placeholder.
- The legacy check sits **after** the cookie check, not before. The two can't overlap today (a lone `unbounded-team:…` token isn't the cookie, and a csid needs a second element), but the cookie check is #387's privacy guard, so it wins unconditionally rather than by coincidence. Pinned by `TestClassifySubprotocolRefusal_CookieBeatsLegacy`, which puts a realistic csid next to the legacy prefix and asserts nothing is logged.

## Testing

`go test -race ./egress/... ./common/...` passes. `go vet` shows only the two pre-existing `wsCancel` findings. `gofmt` clean. `GOOS=js GOARCH=wasm go build ./cmd` still compiles.

New tests cover the exact production string, a real team id, the narrowness of the match (embedded prefix, extra token, non-leading), and the cookie-beats-legacy precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)