### PR TITLE
clientcore: emit the consumer country, completing #375

### DIFF
--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -289,7 +289,7 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			connectionClosed := input[5].(chan struct{})
 			slog.Debug("Consumer state 2...")
 
-			offerJSON, err := json.Marshal(common.OfferMsg{SDP: sdp, Tag: options.Tag})
+			offerJSON, err := json.Marshal(common.OfferMsg{SDP: sdp, Tag: options.Tag, Country: options.ConsumerCountry})
 			if err != nil {
 				slog.Debug("Error marshaling JSON", "error", err)
 				return 1, []interface{}{peerConnection, connectionEstablished, connectionChange, connectionClosed}

--- a/clientcore/jit_egress_consumer.go
+++ b/clientcore/jit_egress_consumer.go
@@ -72,7 +72,16 @@ func NewJITEgressConsumer(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM
 			defer cancel()
 
 			dialOpts := &websocket.DialOptions{
-				Subprotocols: common.NewSubprotocolsRequest(consumerInfoMsg.SessionID, common.Version),
+				// The 4-element form when the consumer disclosed a country, the
+				// 3-element form when it did not — NewSubprotocolsRequestWithCountry
+				// decides, so this call site does not branch.
+				//
+				// Safe to emit now: an egress older than v2.3.5 requires exactly 3
+				// elements and would refuse 4, so #375 deliberately shipped the parser
+				// first and left this call site on the 3-element form. The fleet is a
+				// single host and it runs v2.3.7.
+				Subprotocols: common.NewSubprotocolsRequestWithCountry(
+					consumerInfoMsg.SessionID, common.Version, consumerInfoMsg.Country),
 			}
 			slog.
 				// Log only a short prefix of the CSID — enough to correlate

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -576,7 +576,7 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			// Announce the new connectivity situation for this slot
 			com.tx <- IPCMsg{
 				IpcType: ConsumerInfoIPC,
-				Data:    common.ConsumerInfo{Addr: remoteAddr, Tag: offer.Tag, SessionID: consumerSessionID},
+				Data:    common.ConsumerInfo{Addr: remoteAddr, Tag: offer.Tag, SessionID: consumerSessionID, Country: offer.Country},
 			}
 
 			// Inbound from datachannel (consumer → widget) and outbound

--- a/clientcore/settings.go
+++ b/clientcore/settings.go
@@ -26,6 +26,20 @@ type WebRTCOptions struct {
 	Patience          time.Duration
 	ErrorBackoff      time.Duration
 	ConsumerSessionID string
+	// ConsumerCountry is an optional ISO-3166-1 alpha-2 country the consumer
+	// discloses so the egress can attribute traffic to the region it is actually
+	// serving. Consumer-side only, like ConsumerSessionID above.
+	//
+	// Empty is a valid and complete choice: it emits the same 3-element subprotocol
+	// list as every release before this one, so a consumer that declines is
+	// byte-identical on the wire to one that predates the field.
+	//
+	// Note this travels consumer -> donor -> egress, so the donor can read it. That
+	// discloses nothing the donor does not already have: producer.go extracts the
+	// consumer's public address from the remote ICE candidates and the widget
+	// geolocates it for the UI globe. The marginal disclosure is to the *egress*,
+	// which otherwise cannot know.
+	ConsumerCountry string
 	// 'Net' is currently only respected by the WebRTC *consumer*, and it won't work for Wasm builds!
 	Net transport.Net
 	// CovertDTLS configures DTLS ClientHello fingerprint-resistance on the
@@ -43,6 +57,7 @@ func NewDefaultWebRTCOptions() *WebRTCOptions {
 		STUNBatch:         DefaultSTUNBatchFunc,
 		STUNBatchSize:     5,
 		Tag:               "",
+		ConsumerCountry:   "",
 		HTTPClient:        &http.Client{},
 		Patience:          500 * time.Millisecond,
 		ErrorBackoff:      5 * time.Second,

--- a/common/resource.go
+++ b/common/resource.go
@@ -73,8 +73,18 @@ type ConsumerInfo struct {
 	Addr      net.IP
 	Tag       string
 	SessionID string
+	// Country is the consumer's self-declared ISO-3166-1 alpha-2 country, or "" if
+	// it chose not to say. Copied from the OfferMsg by the producer and forwarded to
+	// the egress at WebSocket dial time, which is the only way the egress can learn
+	// it: the consumer sits behind the donor's data channel, so the egress only ever
+	// observes the *donor's* address.
+	Country string
 }
 
+// Nil deliberately ignores Country. A ConsumerInfo carrying nothing but a country
+// describes no consumer, and jit_egress_consumer keys "has a consumer claimed this
+// slot" on this method — treating a stray country as an occupied slot would wedge
+// the slot waiting for a session that does not exist.
 func (ci ConsumerInfo) Nil() bool {
 	return ci.Addr == nil && ci.Tag == "" && ci.SessionID == ""
 }
@@ -96,6 +106,16 @@ type GenesisMsg struct {
 type OfferMsg struct {
 	SDP webrtc.SessionDescription
 	Tag string
+	// Country is the consumer's self-declared ISO-3166-1 alpha-2 country, or "" to
+	// decline. Consumer-supplied rather than derived: the producer could geolocate
+	// the address it already extracts from the remote ICE candidates, but that makes
+	// the disclosure implicit and unrefusable, whereas a field the consumer fills in
+	// is a choice it can decline by leaving empty.
+	//
+	// Wire-compatible in both directions because this is JSON: an old consumer omits
+	// the field and a new producer reads "", while an old producer ignores a field a
+	// new consumer sends.
+	Country string
 }
 
 // NB: in the last segment of our signaling handshake, the consumer sends the producer an ICEMsg,
@@ -221,6 +241,12 @@ func NewSubprotocolsRequest(csid, version string) []string {
 // the donor is small — but it is not zero, and an empty country is always a
 // valid choice. Pass a country only when the consumer has consented to it.
 func NewSubprotocolsRequestWithCountry(csid, version, country string) []string {
+	// Normalize before emitting, with the same function the parser applies. Two
+	// reasons: a lowercase "cn" reaches the egress as "CN" rather than being
+	// discarded there, and anything that is not a country code at all collapses to ""
+	// and takes the 3-element path instead of putting a value on the wire that the
+	// receiver is guaranteed to throw away.
+	country = normalizeCountry(country)
 	if country == "" {
 		return NewSubprotocolsRequest(csid, version)
 	}

--- a/common/resource.go
+++ b/common/resource.go
@@ -347,6 +347,27 @@ func normalizeCountry(country string) string {
 			return ""
 		}
 	}
+
+	// Codes that mean "no country" are declined rather than passed through, because
+	// they collide with the receiver's own label for that: the egress records
+	// unresolvable traffic as the literal "unknown", so accepting ZZ would put two
+	// different labels on the same concept and split it across a dashboard. ZZ and AA
+	// are ISO-3166-1 user-assigned, i.e. defined by the standard as not designating a
+	// country, and ZZ conventionally means unknown.
+	//
+	// Deliberately not a full ISO-3166-1 alpha-2 allowlist, which is the obvious next
+	// step and the wrong one. It would need maintaining as assignments change, and it
+	// would reject codes our own geolocation emits — MaxMind uses XK for Kosovo, which
+	// is not an official ISO assignment, so an allowlist would discard real signal
+	// from the donor side while adding none. More fundamentally, this value is
+	// self-reported and unverifiable: a consumer in one country can claim another, so
+	// membership checking tidies the label space without making the data truer. The
+	// space is already bounded at 26*26, which is what actually matters for
+	// cardinality.
+	switch string(out) {
+	case "ZZ", "AA":
+		return ""
+	}
 	return string(out)
 }
 

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -1,6 +1,10 @@
 package common
 
 import (
+	"encoding/json"
+	"slices"
+
+	"github.com/pion/webrtc/v4"
 	"reflect"
 	"strings"
 	"testing"
@@ -192,5 +196,105 @@ func TestSubprotocolsContainMagicCookie_AgreesWithParser(t *testing.T) {
 		if !SubprotocolsContainMagicCookie(in) {
 			t.Errorf("parser accepted %q but cookie check rejected it", in)
 		}
+	}
+}
+
+// The emit side normalizes with the same function the parse side applies, so the
+// wire never carries a value the receiver is guaranteed to discard.
+func TestNewSubprotocolsRequestWithCountry_Normalizes(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in      string
+		wantLen int
+		wantCC  string
+	}{
+		"already canonical": {"CN", 4, "CN"},
+		"lowercase":         {"cn", 4, "CN"},
+		"mixed case":        {"Ir", 4, "IR"},
+		"empty declines":    {"", 3, ""},
+		"too long":          {"USA", 3, ""},
+		"too short":         {"U", 3, ""},
+		"not letters":       {"1!", 3, ""},
+		"whitespace":        {"  ", 3, ""},
+	} {
+		got := NewSubprotocolsRequestWithCountry("csid", "v2.3.7", tc.in)
+		if len(got) != tc.wantLen {
+			t.Errorf("%s: NewSubprotocolsRequestWithCountry(%q) produced %d elements, want %d (%v)",
+				name, tc.in, len(got), tc.wantLen, got)
+			continue
+		}
+		// Whatever we emit must round-trip through the parser to the same value.
+		_, _, cc, ok := ParseSubprotocolsRequestWithCountry(got)
+		if !ok {
+			t.Errorf("%s: own output failed to parse: %v", name, got)
+			continue
+		}
+		if cc != tc.wantCC {
+			t.Errorf("%s: round-tripped country = %q, want %q", name, cc, tc.wantCC)
+		}
+	}
+}
+
+// A consumer that declines must be byte-identical on the wire to one that predates
+// the field, or "declining" would itself be a distinguishing signal.
+func TestNewSubprotocolsRequestWithCountry_DeclineIsIndistinguishable(t *testing.T) {
+	plain := NewSubprotocolsRequest("csid", "v2.3.7")
+	for _, decline := range []string{"", "USA", "1!", " "} {
+		got := NewSubprotocolsRequestWithCountry("csid", "v2.3.7", decline)
+		if !slices.Equal(got, plain) {
+			t.Errorf("country %q produced %v, want the 3-element form %v", decline, got, plain)
+		}
+	}
+}
+
+// OfferMsg and ConsumerInfo gained a field, and the wire format is JSON, so both
+// directions of skew must be non-breaking: an old peer omits it, a new peer adds it.
+func TestOfferMsgCountry_WireCompatibleBothWays(t *testing.T) {
+	// Old consumer -> new producer: field absent, reads as "".
+	var fromOld OfferMsg
+	if err := json.Unmarshal([]byte(`{"SDP":{"type":"offer","sdp":"x"},"Tag":"t"}`), &fromOld); err != nil {
+		t.Fatalf("new producer cannot decode an old consumer's offer: %v", err)
+	}
+	if fromOld.Country != "" {
+		t.Errorf("absent Country decoded as %q, want empty", fromOld.Country)
+	}
+	if fromOld.Tag != "t" {
+		t.Errorf("Tag = %q, want t — adding a field must not disturb existing ones", fromOld.Tag)
+	}
+
+	// New consumer -> old producer: the extra field is ignored rather than fatal.
+	// oldOfferMsg is what OfferMsg looked like before Country existed.
+	type oldOfferMsg struct {
+		SDP webrtc.SessionDescription
+		Tag string
+	}
+	// A real SDP type: webrtc.SessionDescription has a custom unmarshaller that
+	// rejects the zero value as "unknown", so a bare OfferMsg{} would fail the round
+	// trip for reasons unrelated to the new field.
+	raw, err := json.Marshal(OfferMsg{
+		SDP:     webrtc.SessionDescription{Type: webrtc.SDPTypeOffer, SDP: "x"},
+		Tag:     "t",
+		Country: "CN",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var toOld oldOfferMsg
+	if err := json.Unmarshal(raw, &toOld); err != nil {
+		t.Fatalf("an old producer cannot decode a new consumer's offer: %v", err)
+	}
+	if toOld.Tag != "t" {
+		t.Errorf("old decode lost Tag: %q", toOld.Tag)
+	}
+}
+
+// Nil() must ignore Country. jit_egress_consumer keys "has a consumer claimed this
+// slot" on it, so a ConsumerInfo carrying only a country must still read as empty —
+// otherwise the slot would wedge waiting for a session that does not exist.
+func TestConsumerInfoNil_IgnoresCountry(t *testing.T) {
+	if !(ConsumerInfo{Country: "CN"}).Nil() {
+		t.Error("a ConsumerInfo with only a Country must be Nil()")
+	}
+	if (ConsumerInfo{SessionID: "csid", Country: "CN"}).Nil() {
+		t.Error("a ConsumerInfo with a SessionID must not be Nil()")
 	}
 }

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -298,3 +298,28 @@ func TestConsumerInfoNil_IgnoresCountry(t *testing.T) {
 		t.Error("a ConsumerInfo with a SessionID must not be Nil()")
 	}
 }
+
+// Codes meaning "no country" must decline rather than become a label. The egress
+// records unresolvable traffic as the literal "unknown", so accepting ZZ would split
+// one concept across two labels.
+func TestNormalizeCountry_DeclinesNonCountryCodes(t *testing.T) {
+	for _, in := range []string{"ZZ", "zz", "Zz", "AA", "aa"} {
+		if got := normalizeCountry(in); got != "" {
+			t.Errorf("normalizeCountry(%q) = %q, want \"\" — user-assigned codes are not countries", in, got)
+		}
+		// And the emitted form must be the 3-element one, indistinguishable from a
+		// consumer that declined outright.
+		if got := NewSubprotocolsRequestWithCountry("csid", "v2.3.7", in); len(got) != 3 {
+			t.Errorf("country %q produced %d elements, want 3: %v", in, len(got), got)
+		}
+	}
+
+	// Codes our own geolocation can emit must survive. MaxMind uses XK for Kosovo,
+	// which is not an official ISO assignment — an allowlist would discard it and lose
+	// real signal, which is why this is a denylist of non-countries instead.
+	for _, in := range []string{"XK", "CN", "IR", "RU", "US", "GB"} {
+		if got := normalizeCountry(in); got != in {
+			t.Errorf("normalizeCountry(%q) = %q, want it preserved", in, got)
+		}
+	}
+}


### PR DESCRIPTION
#375 taught the egress to *parse* a 4-element subprotocol carrying a consumer country, then deliberately left every client emitting the 3-element form — an egress older than v2.3.5 requires exactly 3 and would refuse 4, so the parser had to ship first. The result was an inert feature: the per-country counters bucketed everything to `unknown` because nothing ever sent a country.

**The gate is now clear.** The fleet is a single host — `unbounded-us-linode-nj.iantem.io` is the only `instance.id` reporting `concurrent-websockets` over 24h — and it runs v2.3.7.

## The path

The country rides the same path `Tag` already takes:

```
WebRTCOptions.ConsumerCountry     consumer-side option, like ConsumerSessionID
  → OfferMsg.Country              consumer.go:292, alongside Tag
  → ConsumerInfo.Country          producer.go:579, copied from the offer
  → NewSubprotocolsRequestWithCountry   jit_egress_consumer.go
```

Consumer-*supplied* rather than derived, though deriving was possible — the producer already extracts the consumer's public address from remote ICE candidates. Deriving would make the disclosure implicit and unrefusable; a field the consumer fills in is a choice it can decline by leaving empty.

## Why the subprotocol, given today's collision in that exact header

Worth justifying, since the `unbounded-team:` investigation was a collision in this same namespace:

- **Headers aren't available.** The WebSocket to the egress is opened by the *widget* — *"Widget peers consume connectivity from an egress server over WebSocket"* (`broflake.go:166`) — which is the wasm build, and the browser spec disallows arbitrary headers. That's why this mechanism exists at all.
- **A URL query param** is browser-legal but worse: it lands in Caddy's access logs and any intermediary's, where a handshake header doesn't.
- **In-band over QUIC** would hide the value from the donor, since QUIC is end-to-end consumer↔egress and the donor relays ciphertext. But the donor already extracts the consumer's address from ICE candidates and the widget geolocates it for the UI globe (`REACT_APP_GEO_LOOKUP_URL`), so the privacy gain is **zero** — while the cost is real: the value would arrive *after* the session span and per-country counters exist. Team info took that route twice (`890c58b` stream bytes, `73b2bed` datagrams) and was removed both times.
- **Freddie-side geolocation** is the only option needing no client change, so the only one covering clients that never upgrade. But freddie only relays the ICE payload; extracting consumer IPs there means parsing consumer PII in the signaling server, and the country would land in freddie's telemetry needing a csid join to reach egress bytes.

So: the subprotocol — and the load-bearing reason is **timing**, not privacy. It's available at handshake, before the session span and counters are created, so the label is right from the first packet.

## Normalizing at the emit site

Now applies the same `normalizeCountry` the parser uses. A lowercase `cn` arrives as `CN` instead of being discarded on receipt, and anything that isn't a country code collapses to `""` and takes the 3-element path rather than putting a value on the wire the receiver is guaranteed to throw away.

## Properties tested

- **Declining is indistinguishable from predating the field.** `""`, `"USA"`, `"1!"` and `" "` all emit the byte-identical 3-element list, so choosing not to disclose isn't itself a signal.
- **Wire compatibility both directions**, since `OfferMsg` is JSON: an old consumer omits `Country` and a new producer reads `""`; a new consumer's extra field decodes cleanly into the pre-`Country` struct shape.
- **`ConsumerInfo.Nil()` ignores `Country`.** `jit_egress_consumer` keys "has a consumer claimed this slot" on that method, so a stray country must not read as an occupied slot and wedge it waiting for a session that never arrives.
- Round-trip: everything emitted parses back to the same value.

## Testing

`go test -race ./egress/... ./common/... ./clientcore/...` passes. `go vet` shows only the three pre-existing clientcore findings — verified byte-identical against `main` by stashing. `gofmt` clean. `GOOS=js GOARCH=wasm go build ./cmd` builds.

## Note on the fleet assumption

The single-host finding is what makes this safe, and it's worth re-checking before merge if any egress has been provisioned since — an egress below v2.3.5 would refuse these handshakes outright. The provisioner (`lantern-cloud cmd/api/vps/cloudinit_egress.go`) takes the binary URL as a caller parameter, so there's no pinned version in the repo to read; SigNoz `instance.id` is the source of truth.

Depends on nothing, but note #393 (geo default) is what makes the *donor* side of this attribution work — together they fill in both halves of #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional consumer country support to WebRTC connection signaling and configuration.
  - Country codes are normalized and invalid values are safely omitted for compatibility.
  - Added a default GeoLite2 country database with automatic caching when no custom database is configured.

- **Bug Fixes**
  - Improved GeoIP database filename resolution for archived downloads.
  - Preserved compatibility with older connection peers and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->