### PR TITLE
egress: throttle refusal logs so the counter carries the rate

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -153,7 +153,14 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		}
 
 		recordRefusal(reason)
-		slog.Debug(msg, attrs...)
+		// The counter is the record; the log is a sample. See refusalLogInterval —
+		// these lines were 96% of the journal on unbounded-us.
+		if shouldLog, suppressed := shouldLogRefusal(reason, time.Now()); shouldLog {
+			if suppressed > 0 {
+				attrs = append(attrs, "suppressed_since_last", suppressed)
+			}
+			slog.Debug(msg, attrs...)
+		}
 		return
 	}
 
@@ -164,8 +171,13 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTeapot)
 		w.Write([]byte("418\n"))
 		recordRefusal(refusedBadProtocolVersion)
-		slog.Debug("Refused WebSocket connection, bad protocol version",
-			append(peerAttrs(r), "version", truncateForLog(version))...)
+		if shouldLog, suppressed := shouldLogRefusal(refusedBadProtocolVersion, time.Now()); shouldLog {
+			attrs := append(peerAttrs(r), "version", truncateForLog(version))
+			if suppressed > 0 {
+				attrs = append(attrs, "suppressed_since_last", suppressed)
+			}
+			slog.Debug("Refused WebSocket connection, bad protocol version", attrs...)
+		}
 		return
 	}
 
@@ -176,7 +188,13 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	if consumerSessionID == "" {
 		recordRefusal(refusedMissingCSID)
-		slog.Debug("Refused WebSocket connection, missing consumer session ID", peerAttrs(r)...)
+		if shouldLog, suppressed := shouldLogRefusal(refusedMissingCSID, time.Now()); shouldLog {
+			attrs := peerAttrs(r)
+			if suppressed > 0 {
+				attrs = append(attrs, "suppressed_since_last", suppressed)
+			}
+			slog.Debug("Refused WebSocket connection, missing consumer session ID", attrs...)
+		}
 		return
 	}
 

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/getlantern/broflake/common"
 )
@@ -128,6 +129,67 @@ func eachRefusal(f func(reason refusalReason, count int64)) {
 	for _, r := range rows {
 		f(r.reason, atomic.LoadInt64(r.c))
 	}
+}
+
+// refusalLogInterval bounds how often any single refusal reason may emit a log
+// line. The metric is unaffected and stays exact — this only samples the log.
+//
+// Needed because the log and the counter want opposite things from a high-rate
+// event. Once v2.3.7 named the legacy team clients, the cause was known and the
+// per-refusal line stopped carrying new information, but it kept costing: at ~9
+// refusals/second those lines were 5,326 of 5,551 journal entries over ten minutes
+// on unbounded-us — 96% — which made journalctl useless for reading anything else.
+// Three separate greps for unrelated startup lines came back empty because the
+// signal was buried, which is how this was noticed.
+//
+// A minute is short enough that a changing peer set shows up promptly and long
+// enough to cut roughly 540 lines to one. Deliberately per-reason rather than
+// special-cased to the legacy clients: missing_subprotocols flooded exactly the same
+// way before v2.3.5 reclassified it, so the next high-rate reason should not need
+// this written again.
+const refusalLogInterval = time.Minute
+
+type refusalLogState struct {
+	lastLogged time.Time
+	suppressed int64
+}
+
+var (
+	refusalLogMx sync.Mutex
+	refusalLogs  = map[refusalReason]*refusalLogState{}
+)
+
+// shouldLogRefusal reports whether this refusal should be logged, and how many of
+// the same reason went unlogged since the last one that was.
+//
+// The first occurrence of a reason always logs, so a condition that has never been
+// seen is visible immediately rather than up to an interval later — which matters
+// most for the reasons that are rare, since those are the ones nobody is watching a
+// dashboard for.
+//
+// now is a parameter rather than read inside so the behavior is testable without
+// sleeping.
+func shouldLogRefusal(reason refusalReason, now time.Time) (shouldLog bool, suppressed int64) {
+	refusalLogMx.Lock()
+	defer refusalLogMx.Unlock()
+
+	st, seen := refusalLogs[reason]
+	if !seen {
+		refusalLogs[reason] = &refusalLogState{lastLogged: now}
+		return true, 0
+	}
+	if now.Sub(st.lastLogged) < refusalLogInterval {
+		st.suppressed++
+		return false, 0
+	}
+
+	// Report the backlog on the line that breaks the silence, so a single log entry
+	// says how much it stands for. Without it a throttled line understates a flood by
+	// three orders of magnitude and reads like an isolated event.
+	suppressed = st.suppressed
+	st.suppressed = 0
+	st.lastLogged = now
+	return true, suppressed
 }
 
 // classifySubprotocolRefusal decides which of the three subprotocol refusals

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/getlantern/broflake/common"
@@ -422,5 +423,149 @@ func TestClassifySubprotocolRefusal_CookieBeatsLegacy(t *testing.T) {
 	}
 	if logValues {
 		t.Error("a cookie-carrying list must never have its values logged, legacy prefix or not")
+	}
+}
+
+func resetRefusalLogs(t *testing.T) {
+	t.Helper()
+	refusalLogMx.Lock()
+	refusalLogs = map[refusalReason]*refusalLogState{}
+	refusalLogMx.Unlock()
+}
+
+// The first occurrence of a reason must log immediately. A condition nobody has
+// seen before is exactly the one nobody is watching a dashboard for, so waiting an
+// interval to mention it is the wrong default.
+func TestShouldLogRefusal_FirstOccurrenceAlwaysLogs(t *testing.T) {
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	for _, reason := range []refusalReason{
+		refusedLegacyTeamClient, refusedForeignSubprotocols, refusedMissingCSID,
+	} {
+		shouldLog, suppressed := shouldLogRefusal(reason, t0)
+		if !shouldLog {
+			t.Errorf("%s: first occurrence did not log", reason)
+		}
+		if suppressed != 0 {
+			t.Errorf("%s: first occurrence reported %d suppressed, want 0", reason, suppressed)
+		}
+	}
+}
+
+// The point of the change: a flood collapses to one line per interval. At the
+// observed ~9/s this is the difference between 96% of the journal and a rounding
+// error.
+func TestShouldLogRefusal_ThrottlesAFlood(t *testing.T) {
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	logged := 0
+	// Five minutes of refusals at 9/s, stepping the clock rather than sleeping.
+	for i := 0; i < 5*60*9; i++ {
+		now := t0.Add(time.Duration(i) * (time.Second / 9))
+		if shouldLog, _ := shouldLogRefusal(refusedLegacyTeamClient, now); shouldLog {
+			logged++
+		}
+	}
+	// One immediately, then one per minute across five minutes.
+	if logged < 4 || logged > 7 {
+		t.Errorf("logged %d lines for 2700 refusals over 5 minutes, want ~5", logged)
+	}
+}
+
+// A throttled line must say how much it stands for, or it understates a flood by
+// three orders of magnitude and reads like an isolated event.
+func TestShouldLogRefusal_ReportsSuppressedCount(t *testing.T) {
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	shouldLogRefusal(refusedLegacyTeamClient, t0) // first, logs
+	const hidden = 500
+	for i := 0; i < hidden; i++ {
+		if shouldLog, _ := shouldLogRefusal(refusedLegacyTeamClient, t0.Add(time.Second)); shouldLog {
+			t.Fatal("logged inside the interval")
+		}
+	}
+
+	shouldLog, suppressed := shouldLogRefusal(refusedLegacyTeamClient, t0.Add(refusalLogInterval))
+	if !shouldLog {
+		t.Fatal("did not log after the interval elapsed")
+	}
+	if suppressed != hidden {
+		t.Errorf("suppressed = %d, want %d", suppressed, hidden)
+	}
+
+	// The backlog resets, so the next line does not double-count it.
+	for i := 0; i < 3; i++ {
+		shouldLogRefusal(refusedLegacyTeamClient, t0.Add(refusalLogInterval+time.Second))
+	}
+	_, suppressed = shouldLogRefusal(refusedLegacyTeamClient, t0.Add(2*refusalLogInterval))
+	if suppressed != 3 {
+		t.Errorf("second window reported %d suppressed, want 3 — backlog did not reset", suppressed)
+	}
+}
+
+// Throttling is per-reason. A flood of one reason must not silence a different one,
+// which is the whole reason this is keyed rather than global.
+func TestShouldLogRefusal_PerReason(t *testing.T) {
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	shouldLogRefusal(refusedLegacyTeamClient, t0)
+	for i := 0; i < 1000; i++ {
+		shouldLogRefusal(refusedLegacyTeamClient, t0.Add(time.Second))
+	}
+
+	// A different reason, seen for the first time mid-flood, still logs.
+	if shouldLog, _ := shouldLogRefusal(refusedBadProtocolVersion, t0.Add(time.Second)); !shouldLog {
+		t.Error("a flood of one reason silenced the first occurrence of another")
+	}
+}
+
+// The counter is the record and must stay exact regardless of what the log does.
+// Throttling the log while also dropping counts would trade one blind spot for
+// another.
+func TestShouldLogRefusal_DoesNotAffectTheCounter(t *testing.T) {
+	resetRefusals(t)
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	const n = 1000
+	for i := 0; i < n; i++ {
+		recordRefusal(refusedLegacyTeamClient)
+		shouldLogRefusal(refusedLegacyTeamClient, t0.Add(time.Second))
+	}
+	if got := collectRefusals()[refusedLegacyTeamClient]; got != n {
+		t.Errorf("counter = %d, want %d — throttling must not drop counts", got, n)
+	}
+}
+
+// Refusals arrive concurrently from the HTTP handler, so the throttle state is
+// shared mutable state on a hot path.
+func TestShouldLogRefusal_Concurrent(t *testing.T) {
+	resetRefusalLogs(t)
+	t0 := time.Now()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				shouldLogRefusal(refusedLegacyTeamClient, t0.Add(time.Second))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 4000 concurrent attempts: the first creates the entry and logs, the other 3999
+	// are suppressed and must all be counted. The probe is offset by the same second
+	// the goroutines used, since that is when the entry's window started — probing at
+	// t0+interval would land inside the window and suppress instead of reporting.
+	const want = 8*500 - 1
+	_, suppressed := shouldLogRefusal(refusedLegacyTeamClient, t0.Add(time.Second+refusalLogInterval))
+	if suppressed != want {
+		t.Errorf("suppressed = %d, want %d — a concurrent increment was lost", suppressed, want)
 	}
 }


### PR DESCRIPTION
Refusal lines were **5,326 of 5,551 journal entries** on unbounded-us over ten minutes — 96%.

At ~9/s from the nine legacy team clients they had also stopped carrying information: v2.3.7 named the cause, so every line says the same thing about the same nine hosts. Meanwhile they made `journalctl` useless for anything else — and not hypothetically. Three separate greps for the geo startup line came back empty because the signal was buried, and I briefly concluded the geo default hadn't taken effect. It had; I just couldn't see it.

Each refusal reason may now log at most once per minute. **The counter still increments on every refusal**, so the rate stays exact and only the log is sampled. Roughly 540 lines become one.

## Design choices

**The first occurrence of a reason always logs.** A condition nobody has seen before is exactly the one nobody is watching a dashboard for, so deferring it by up to an interval is the wrong default. The throttle should quiet a known flood, not delay news.

**The line that breaks the silence reports `suppressed_since_last`.** Without it a throttled line understates a flood by three orders of magnitude and reads like an isolated event — a worse failure than the noise it replaces. The backlog resets per window so consecutive lines don't double-count.

**Keyed per reason, not special-cased to the legacy clients.** `missing_subprotocols` flooded identically before v2.3.5 reclassified it, so a generic mechanism means the next high-rate reason doesn't need this written again. Verified a flood of one reason can't silence the first sighting of another.

**`now` is a parameter** rather than read inside, so behavior is testable without sleeping — 2,700 refusals across five simulated minutes run instantly.

## What this does not do

It doesn't reduce the refusal *rate*. Those nine hosts keep retrying ~1/s each regardless of the 426, and they can't be served (they predate the consumer session ID and QUIC migration — see #391). This makes the log usable again; the population itself needs those operators to upgrade.

## Testing

Six tests: first-occurrence, flood throttling, the suppressed count and its reset between windows, per-reason independence, that the counter is unaffected by throttling, and concurrency under `-race`.

The concurrency test caught its own arithmetic error first — the probe landed inside the window because the entry's clock starts at the first concurrent call, not at `t0` — so the fix was to the test, not the code. Worth mentioning since a green concurrency test that was silently probing the wrong instant would have been worthless.

`go test -race ./egress/... ./common/... ./clientcore/...` passes, `gofmt` clean, `go vet` shows only the pre-existing `wsCancel` findings, `GOOS=js GOARCH=wasm go build ./cmd` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate refusal log messages during repeated invalid connection attempts.
  * Log entries now report how many similar refusals were suppressed.
  * Refusal metrics continue to capture every event, even when logging is throttled.
  * Throttling is tracked independently for each refusal reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->