### PR TITLE
egress: count session teardowns as a metric, not only a span attribute

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -53,6 +53,11 @@ var nIngressBytesCounter metric.Int64ObservableUpDownCounter
 // rate()'d, unlike the concurrency gauges above.
 var refusedCounter metric.Int64ObservableCounter
 
+// teardownCounter tallies ended sessions by reason. Monotonic, and deliberately a
+// metric rather than only a span attribute: session spans are sampled at 1%, which
+// is fine for inspecting one session and useless for counting rare ones.
+var teardownCounter metric.Int64ObservableCounter
+
 // tracer emits one span per WebSocket session. Sessions are the unit an
 // operator actually asks about ("did this consumer get served?"), and a span
 // per session carries the consumer session ID without the unbounded-cardinality
@@ -220,17 +225,21 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	var sessionBytes int64
 	var sessionStreams int64
 	var keepaliveFailed atomic.Bool
-	teardownReason := "websocket_closed"
+	teardown := teardownWebSocketClosed
 	defer func() {
 		// A wedged peer is distinguishable from a disconnected one only by an
 		// unanswered keepalive, so let that outrank the generic close reason.
 		if keepaliveFailed.Load() {
-			teardownReason = "keepalive_timeout"
+			teardown = teardownKeepaliveTimeout
 		}
+		// Count it as well as recording it on the span. The span is sampled at 1%, so
+		// it answers "what happened in this session" but cannot answer "how often does
+		// this happen" — which is the question a detector asks.
+		recordTeardown(teardown)
 		span.SetAttributes(
 			attribute.Int64(attrIngressBytes, atomic.LoadInt64(&sessionBytes)),
 			attribute.Int64(attrQUICStreams, atomic.LoadInt64(&sessionStreams)),
-			attribute.String(attrTeardownReason, teardownReason),
+			attribute.String(attrTeardownReason, string(teardown)),
 		)
 		// A session that moved no bytes is the failure mode worth finding, so
 		// mark it on the span rather than leaving every session status Unset.
@@ -250,7 +259,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if err != nil {
-		teardownReason = "websocket_accept_failed"
+		teardown = teardownAcceptFailed
 		span.RecordError(err)
 		slog.Debug("Error accepting WebSocket connection", "error", err)
 		return
@@ -263,7 +272,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 		// and its goroutines. Pre-existing on main; closing it here since this
 		// branch is being touched anyway.
 		c.CloseNow()
-		teardownReason = "peer_addr_unresolvable"
+		teardown = teardownPeerAddrBad
 		span.RecordError(err)
 		slog.Debug("Error resolving TCPAddr", "error", err)
 		return
@@ -294,7 +303,7 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := l.connectionManager.createOrMigrate(consumerSessionID, &wspconn)
 	if err != nil {
-		teardownReason = "create_or_migrate_failed"
+		teardown = teardownMigrateFailed
 		span.RecordError(err)
 		slog.Debug("createOrMigrate error, closing!", "error", err)
 		return
@@ -415,6 +424,12 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		return nil, err
 	}
 
+	teardownCounter, err = m.Int64ObservableCounter("session-teardowns")
+	if err != nil {
+		closeFuncMetric(ctx)
+		return nil, err
+	}
+
 	_, err = m.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			q := atomic.LoadUint64(&nQUICConnections)
@@ -444,6 +459,11 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 			// only used for the log lines.
 			eachRefusal(func(reason refusalReason, count int64) {
 				o.ObserveInt64(refusedCounter, count,
+					metric.WithAttributes(attribute.String("reason", string(reason))))
+			})
+
+			eachTeardown(func(reason teardownReason, count int64) {
+				o.ObserveInt64(teardownCounter, count,
 					metric.WithAttributes(attribute.String("reason", string(reason))))
 			})
 

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -479,6 +479,11 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		nQUICStreamsCounter,
 		nIngressBytesCounter,
 		refusedCounter,
+		// Every instrument the callback observes must be declared here. The SDK
+		// ignores observations for anything absent from this list, so omitting one
+		// produces a metric that is registered, incremented, observed — and never
+		// exported. Silent, and indistinguishable from "the event never happened".
+		teardownCounter,
 	)
 	if err != nil {
 		closeFuncMetric(ctx)

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/broflake/common"
@@ -90,45 +89,22 @@ func isLegacyTeamClient(parsed []string) bool {
 	return len(parsed) == 1 && strings.HasPrefix(parsed[0], legacyTeamIDPrefix)
 }
 
-var (
-	refusalsMx sync.Mutex
-	// refusals is keyed by the constants above only. Entries are never removed:
-	// the set is small and fixed, and a reason that stops occurring should keep
-	// reporting its running total rather than vanishing from the series.
-	refusals = map[refusalReason]*int64{}
-)
+// refusals is keyed by the constants above only. See labeledTally for why entries
+// are never pruned.
+var refusals = newLabeledTally()
 
 // recordRefusal counts one refused connection. Monotonic on purpose: this is a
 // tally, not a gauge, so consumers can rate() it. Contrast ingress-bytes, which
 // the otel callback drains each interval because it measures throughput.
 func recordRefusal(reason refusalReason) {
-	refusalsMx.Lock()
-	c, ok := refusals[reason]
-	if !ok {
-		c = new(int64)
-		refusals[reason] = c
-	}
-	refusalsMx.Unlock()
-	atomic.AddInt64(c, 1)
+	refusals.add(string(reason))
 }
 
-// eachRefusal reports every reason seen so far. Snapshots under the lock so the
-// otel callback never holds refusalsMx while observing.
+// eachRefusal reports every reason seen so far.
 func eachRefusal(f func(reason refusalReason, count int64)) {
-	type row struct {
-		reason refusalReason
-		c      *int64
-	}
-	refusalsMx.Lock()
-	rows := make([]row, 0, len(refusals))
-	for reason, c := range refusals {
-		rows = append(rows, row{reason, c})
-	}
-	refusalsMx.Unlock()
-
-	for _, r := range rows {
-		f(r.reason, atomic.LoadInt64(r.c))
-	}
+	refusals.each(func(label string, count int64) {
+		f(refusalReason(label), count)
+	})
 }
 
 // refusalLogInterval bounds how often any single refusal reason may emit a log

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -86,6 +87,9 @@ func TestRecordRefusal_NoLostCountsUnderConcurrency(t *testing.T) {
 				return
 			default:
 				collectRefusals()
+				// Yield rather than spinning flat out; see the note in
+				// teardowns_test.go.
+				runtime.Gosched()
 			}
 		}
 	}()

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -13,9 +13,7 @@ import (
 
 func resetRefusals(t *testing.T) {
 	t.Helper()
-	refusalsMx.Lock()
-	refusals = map[refusalReason]*int64{}
-	refusalsMx.Unlock()
+	refusals = newLabeledTally()
 }
 
 // Deliberately takes no *testing.T: it is called from the observer goroutine in

--- a/egress/teardowns.go
+++ b/egress/teardowns.go
@@ -1,0 +1,110 @@
+package egress
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Session teardown reasons existed only as a span attribute, and session spans are
+// sampled at 1% (OTEL_TRACES_SAMPLER_ARG=0.01 in the egress unit). That makes them
+// unusable for counting: over 24 hours the whole fleet produced six sampled session
+// spans, and reading a ratio off six events is how "5 of 6 are keepalive_timeout"
+// became an 83% figure that a 7-day window corrected to ~45%.
+//
+// A detector for wedged donors has to count rare events, so it needs an unsampled
+// series. This mirrors refused-websockets: a monotonic tally per reason, observed by
+// the otel callback, unaffected by trace sampling.
+//
+// What it cannot do on its own is separate a frozen page from a sleeping laptop.
+// keepalive_timeout means "the donor stopped answering pings", which covers a real
+// freeze, a suspended machine, and a tab closed without a clean close. Distinguishing
+// them needs the page-side watchdog (ui/src/utils/freezeWatchdog.ts), whose reports
+// currently have nowhere to go. This is half of that pair, and the half that is
+// cheap.
+
+// teardownReason is why a WebSocket session ended. A distinct type rather than a bare
+// string for the same reason refusalReason is: these become metric label content, and
+// a label built from request-derived data is unbounded cardinality chosen by a peer.
+type teardownReason string
+
+const (
+	// teardownWebSocketClosed is the default: the session ended without any more
+	// specific cause being recorded. It is not necessarily clean — a donor that
+	// vanished without a close handshake also lands here — it only means nothing
+	// else claimed the teardown.
+	teardownWebSocketClosed teardownReason = "websocket_closed"
+	// teardownKeepaliveTimeout: the donor stopped answering keepalive pings. The
+	// closest server-side signature of a wedged or frozen donor, and the reason this
+	// metric exists. Outranks the default because an unanswered keepalive is the only
+	// thing that distinguishes a wedged peer from a merely disconnected one.
+	teardownKeepaliveTimeout teardownReason = "keepalive_timeout"
+	teardownAcceptFailed     teardownReason = "websocket_accept_failed"
+	teardownPeerAddrBad      teardownReason = "peer_addr_unresolvable"
+	teardownMigrateFailed    teardownReason = "create_or_migrate_failed"
+)
+
+// labeledTally is a monotonic count keyed by a small fixed label set.
+//
+// Extracted rather than copied: refusals already needed exactly this, teardowns are
+// the second, and a third near-identical mutex-plus-map would be the point at which
+// someone changes one and not the others. The typed wrappers around it keep the
+// call-site guarantee that a label cannot be built from request data by accident.
+type labeledTally struct {
+	mx sync.Mutex
+	// counts is never pruned. The label set is small and fixed, and a reason that
+	// stops occurring should keep reporting its running total rather than vanishing
+	// from the series — a series that disappears reads as "no data" rather than "no
+	// longer happening".
+	counts map[string]*int64
+}
+
+func newLabeledTally() *labeledTally {
+	return &labeledTally{counts: map[string]*int64{}}
+}
+
+// add increments the count for one label.
+func (t *labeledTally) add(label string) {
+	t.mx.Lock()
+	c, ok := t.counts[label]
+	if !ok {
+		c = new(int64)
+		t.counts[label] = c
+	}
+	t.mx.Unlock()
+	// Outside the lock: the map entry is stable once created, so only the pointer
+	// lookup needs synchronizing.
+	atomic.AddInt64(c, 1)
+}
+
+// each reports every label seen so far. Snapshots the pointers under the lock so an
+// otel callback never holds it while observing.
+func (t *labeledTally) each(f func(label string, count int64)) {
+	type row struct {
+		label string
+		c     *int64
+	}
+	t.mx.Lock()
+	rows := make([]row, 0, len(t.counts))
+	for label, c := range t.counts {
+		rows = append(rows, row{label, c})
+	}
+	t.mx.Unlock()
+
+	for _, r := range rows {
+		f(r.label, atomic.LoadInt64(r.c))
+	}
+}
+
+var teardowns = newLabeledTally()
+
+// recordTeardown counts one ended session. Monotonic, so consumers rate() it.
+func recordTeardown(reason teardownReason) {
+	teardowns.add(string(reason))
+}
+
+// eachTeardown reports every teardown reason seen so far.
+func eachTeardown(f func(reason teardownReason, count int64)) {
+	teardowns.each(func(label string, count int64) {
+		f(teardownReason(label), count)
+	})
+}

--- a/egress/teardowns_test.go
+++ b/egress/teardowns_test.go
@@ -1,0 +1,129 @@
+package egress
+
+import (
+	"sync"
+	"testing"
+)
+
+func resetTeardowns(t *testing.T) {
+	t.Helper()
+	teardowns = newLabeledTally()
+}
+
+func collectTeardowns() map[teardownReason]int64 {
+	out := map[teardownReason]int64{}
+	eachTeardown(func(reason teardownReason, count int64) { out[reason] = count })
+	return out
+}
+
+// The whole reason this metric exists: teardown reasons lived only on spans sampled
+// at 1%, so counting rare events off them was statistically blind. A tally must be
+// monotonic and must not be drained by observation, or every rate() would be wrong.
+func TestRecordTeardown_IsMonotonicAcrossObservations(t *testing.T) {
+	resetTeardowns(t)
+	for i := 0; i < 3; i++ {
+		recordTeardown(teardownKeepaliveTimeout)
+	}
+	if got := collectTeardowns()[teardownKeepaliveTimeout]; got != 3 {
+		t.Fatalf("after 3: got %d, want 3", got)
+	}
+	if got := collectTeardowns()[teardownKeepaliveTimeout]; got != 3 {
+		t.Fatalf("observing drained the tally: got %d, want 3", got)
+	}
+	recordTeardown(teardownKeepaliveTimeout)
+	if got := collectTeardowns()[teardownKeepaliveTimeout]; got != 4 {
+		t.Fatalf("after a 4th: got %d, want 4", got)
+	}
+}
+
+// keepalive_timeout is the reason a detector watches, so it must never be merged
+// with the generic default — that distinction is the entire signal.
+func TestRecordTeardown_SeparatesReasons(t *testing.T) {
+	resetTeardowns(t)
+	recordTeardown(teardownWebSocketClosed)
+	recordTeardown(teardownKeepaliveTimeout)
+	recordTeardown(teardownKeepaliveTimeout)
+	recordTeardown(teardownMigrateFailed)
+
+	got := collectTeardowns()
+	for reason, want := range map[teardownReason]int64{
+		teardownWebSocketClosed:  1,
+		teardownKeepaliveTimeout: 2,
+		teardownMigrateFailed:    1,
+	} {
+		if got[reason] != want {
+			t.Errorf("%s = %d, want %d", reason, got[reason], want)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("reported %d reasons, want 3: %v", len(got), got)
+	}
+}
+
+// recordTeardown takes a teardownReason, not a string, so request-derived data
+// cannot become a metric label without an explicit conversion a reviewer would see.
+// This compiles only while that holds.
+func TestRecordTeardown_TakesTypedReason(t *testing.T) {
+	var f func(teardownReason) = recordTeardown
+	_ = f
+}
+
+// Sessions end concurrently, and the otel callback observes while they do.
+func TestRecordTeardown_NoLostCountsUnderConcurrency(t *testing.T) {
+	resetTeardowns(t)
+	const writers, per = 8, 500
+
+	stop := make(chan struct{})
+	var obsWg sync.WaitGroup
+	obsWg.Add(1)
+	go func() {
+		defer obsWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				collectTeardowns()
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < per; j++ {
+				recordTeardown(teardownKeepaliveTimeout)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	obsWg.Wait()
+
+	if got := collectTeardowns()[teardownKeepaliveTimeout]; got != writers*per {
+		t.Fatalf("counted %d, want %d", got, writers*per)
+	}
+}
+
+// The tally is now shared by refusals and teardowns, so a bug in it would corrupt
+// both. Pins that the two do not see each other's counts.
+func TestLabeledTally_IsolatesInstances(t *testing.T) {
+	resetTeardowns(t)
+	resetRefusals(t)
+
+	recordTeardown(teardownKeepaliveTimeout)
+	recordRefusal(refusedLegacyTeamClient)
+
+	if got := collectTeardowns()[teardownKeepaliveTimeout]; got != 1 {
+		t.Errorf("teardown count = %d, want 1", got)
+	}
+	if got := collectRefusals()[refusedLegacyTeamClient]; got != 1 {
+		t.Errorf("refusal count = %d, want 1", got)
+	}
+	// A label used in one tally must not appear in the other.
+	if _, crossed := collectTeardowns()[teardownReason(refusedLegacyTeamClient)]; crossed {
+		t.Error("a refusal label leaked into the teardown tally")
+	}
+}

--- a/egress/teardowns_test.go
+++ b/egress/teardowns_test.go
@@ -1,6 +1,11 @@
 package egress
 
 import (
+	"bytes"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -84,6 +89,10 @@ func TestRecordTeardown_NoLostCountsUnderConcurrency(t *testing.T) {
 				return
 			default:
 				collectTeardowns()
+				// Yield rather than spinning flat out. A bare default branch pegs a
+				// core for the whole test, which under -race slows every other test
+				// sharing the machine.
+				runtime.Gosched()
 			}
 		}
 	}()
@@ -125,5 +134,53 @@ func TestLabeledTally_IsolatesInstances(t *testing.T) {
 	// A label used in one tally must not appear in the other.
 	if _, crossed := collectTeardowns()[teardownReason(refusedLegacyTeamClient)]; crossed {
 		t.Error("a refusal label leaked into the teardown tally")
+	}
+}
+
+// Every instrument the otel callback observes must also be declared in the
+// RegisterCallback instrument list. The SDK silently ignores observations for
+// anything absent from it, so an omission produces a metric that is registered,
+// incremented, observed — and never exported, which is indistinguishable from the
+// event never happening. teardownCounter shipped missing from that list in review.
+//
+// Asserted by reading the source rather than by standing up an SDK, because the
+// failure is a mismatch between two lists in one function and that is exactly what a
+// cheap structural check catches.
+func TestMetricCallback_ObservesOnlyDeclaredInstruments(t *testing.T) {
+	src, err := os.ReadFile("egresslib.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const marker = "_, err = m.RegisterCallback("
+	i := bytes.Index(src, []byte(marker))
+	if i < 0 {
+		t.Fatal("could not find the RegisterCallback call; this test needs updating")
+	}
+	block := string(src[i:])
+	end := strings.Index(block, "\n\tif err != nil {")
+	if end < 0 {
+		t.Fatal("could not find the end of the RegisterCallback call")
+	}
+	block = block[:end]
+
+	observed := map[string]bool{}
+	for _, m := range regexp.MustCompile(`o\.ObserveInt64\(\s*(\w+)`).FindAllStringSubmatch(block, -1) {
+		observed[m[1]] = true
+	}
+	if len(observed) == 0 {
+		t.Fatal("found no ObserveInt64 calls; this test needs updating")
+	}
+
+	declared := map[string]bool{}
+	for _, m := range regexp.MustCompile(`(?m)^\t\t(\w+Counter),?$`).FindAllStringSubmatch(block, -1) {
+		declared[m[1]] = true
+	}
+
+	for name := range observed {
+		if !declared[name] {
+			t.Errorf("%s is observed but not declared in the RegisterCallback instrument list — "+
+				"its observations will be silently dropped", name)
+		}
 	}
 }


### PR DESCRIPTION
First of two prerequisites for the freeze detector (task #3). Building the detector first would have meant inventing thresholds against a signal that can't support them.

## Why the span attribute isn't enough

Teardown reasons existed only on session spans, and those are sampled at **1%** (`OTEL_TRACES_SAMPLER_ARG=0.01` in the egress unit). That's fine for inspecting one session and useless for counting.

Concretely — and this is why I'm not building the detector yet:

| window | data | ratio I read |
|---|---|---|
| 24h | 6 spans: 5 `keepalive_timeout`, 1 `websocket_closed` | "83% of sessions end wedged" |
| 7d | 20 spans: 9 `keepalive_timeout`, 11 `websocket_closed` | ~45% |

The first figure was noise off six events, and I stated it before widening the window. No threshold should come from a sample that small, which is exactly what an unsampled counter fixes.

## What this adds

`session-teardowns`, a monotonic counter labelled by reason, observed by the existing otel callback exactly like `refused-websockets`.

Recorded **once**, inside the `defer` that already computes the reason for the span — so the metric and the span can never disagree about why a session ended. The `defer` is registered before every assignment (`websocket_accept_failed`, `peer_addr_unresolvable`, `create_or_migrate_failed`, and the `keepalive_timeout` override), so one call site covers all five reasons.

Refusals are deliberately **not** counted here: a refused connection never became a session, and it already has its own counter.

Teardown reasons become a type rather than bare strings assigned to a local, for the same reason `refusalReason` is one — these are metric label content, so the compiler should prevent request-derived data becoming a label.

## Shared tally

The mutex-and-map behind `refused-websockets` is extracted to `labeledTally` and shared. This was going to be the second verbatim copy, and the third is where someone fixes one and not the others. The typed wrappers stay, so call sites keep their guarantee; only the storage is shared. A test pins that the two tallies don't see each other's labels.

## What this deliberately does not fix

`keepalive_timeout` means "the donor stopped answering pings" — which covers a real freeze, a suspended laptop, and a tab closed without a clean close handshake. At ~45% it's plainly dominated by the benign cases, so **alerting on it alone would fire constantly and identify nothing.**

The signal that separates them is #383's page-side watchdog (`main_thread_blocked` / `go_scheduler_wedged` / `page_died`), whose reports currently have nowhere to go: console, a `window` global, and a beacon that ships disabled with no endpoint. That's the second prerequisite and the harder one — this PR is the cheap half.

## Testing

`go test -race ./...` passes (the whole tree, not just egress). `go vet` shows only the pre-existing `wsCancel` findings, `gofmt` clean, `GOOS=js GOARCH=wasm go build ./cmd` builds.

Five tests: monotonicity across observations, per-reason separation, the typed-parameter guarantee, no lost counts under 8 concurrent writers with a concurrent observer, and tally isolation between refusals and teardowns.

Note CI will run the Go jobs for this one because it touches `egress/**`… actually it won't — see the separate finding that `build-widget-wasm`'s paths exclude `egress/**` and its test job runs only `./clientcore/... ./common/...`, so **no egress test has ever run in CI**. Verified locally instead; that gap is worth closing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)