### PR TITLE
ci: run the whole test suite, so the egress is actually tested

### DIFF
--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -15,8 +15,8 @@ name: Build widget (wasm)
 # heartbeat by half a day and predated its own source by far longer. A release step
 # that only happens when a human remembers is a release step that does not happen.
 #
-# Publishing is gated on the wasm build AND the native unit tests, so "it reached
-# users" implies "it compiled for the target and its packages passed". That is a
+# Publishing is gated on the wasm build AND the full native test suite, so "it reached
+# users" implies "it compiled for the target and every package passed". That is a
 # real gate but not a complete one — there is no functional or browser test of the
 # widget, so a change that compiles and unit-tests clean can still ship a broken
 # widget to every donor. Worth closing before relying on this too heavily.
@@ -59,6 +59,8 @@ on:
       - 'cmd/**'
       - 'netstate/**'
       - 'ui/**'
+      - 'egress/**'
+      - 'freddie/**'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/build-widget-wasm.yml'
@@ -69,6 +71,8 @@ on:
       - 'cmd/**'
       - 'netstate/**'
       - 'ui/**'
+      - 'egress/**'
+      - 'freddie/**'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/build-widget-wasm.yml'
@@ -118,11 +122,25 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Native, not js/wasm: there is no wasm test runner here, and these packages
-      # are the ones the widget is built from. Running them is what lets the publish
-      # below claim more than "it compiled".
-      - name: Test packages the widget is built from
-        run: go test ./clientcore/... ./common/...
+      # Every package, not just the ones the widget is built from. The narrower list
+      # meant the egress was never tested here at all: its paths did not trigger this
+      # workflow, and even when another path did, the command excluded it. 42 tests
+      # across five egress files had never run in CI, and #385, #387, #395, #397 and
+      # #399 all merged on local verification alone.
+      #
+      # The whole suite runs in about six seconds with -race, so the narrower list was
+      # not buying anything.
+      #
+      # -race because it earns its runtime here. Three separate concurrency and
+      # ordering bugs this cycle were caught only by -race locally — a geo test suite
+      # that depended on a network download completing, and two lost-update paths in
+      # the refusal and teardown tallies. Without it CI would have been green on all
+      # three.
+      #
+      # Native rather than js/wasm: there is no wasm test runner, and the build job
+      # above already covers that target compiling.
+      - name: Test
+        run: go test -race ./...
 
   publish:
     name: publish widget + page to gh-pages


### PR DESCRIPTION
**No egress test has ever run in CI.** Two independent holes:

1. The `paths` filter omitted `egress/**` and `freddie/**`, so an egress-only PR triggered **no Go job at all**.
2. The test job ran `go test ./clientcore/... ./common/...`, which excluded the egress even when some other path *did* trigger the workflow.

Between them, **42 tests across five egress files** have never executed in CI — and #385, #387, #395, #397 and #399 all merged on local verification alone.

## The fix

Adds `egress/**` and `freddie/**` to both path lists, and runs `go test -race ./...`.

**`-race` because it earns its runtime here**, not as a general principle. Three separate concurrency and ordering bugs this cycle were caught only by running it locally:

- a geo test suite that silently depended on a 4MB network download finishing mid-run
- lost-update paths in the refusal tally
- and the same in the teardown tally

CI would have been green on all three.

The whole suite runs in **about six seconds** with `-race` on this repo, so the narrower package list wasn't buying anything.

Verified `go test -race ./...` is clean on `main` before broadening, so this doesn't land red.

## Note on naming

The workflow is still called "Build widget (wasm)", which now undersells it — it builds the widget *and* tests the repository. Left alone deliberately: renaming changes check names, which is worth doing on purpose rather than as a side effect of this change.

The publish gate still reads correctly, and slightly stronger than before: publishing requires the wasm build **and** the full suite, so "it reached users" implies "every package passed" rather than "the two packages the widget is built from passed".

## Suggested merge order

Worth merging **before** #400 (the donor geolocation fix), so that PR is the first to actually get its egress tests run by CI rather than only by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated validation to cover the complete native test suite.
  - Added race-condition checks across all native components.
  - Pull requests and pushes affecting additional application areas now receive automated checks.

- **Chores**
  - Publishing is now gated on successful completion of the full validation process, improving release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->