### PR TITLE
egress: ingest freeze reports from the page-side watchdog

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -58,6 +58,11 @@ var refusedCounter metric.Int64ObservableCounter
 // is fine for inspecting one session and useless for counting rare ones.
 var teardownCounter metric.Int64ObservableCounter
 
+// freezeReportCounter tallies freeze reports beaconed by the page-side watchdog,
+// labelled by diagnosis. The counterpart to session-teardowns: that one says a donor
+// stopped answering, this one says why.
+var freezeReportCounter metric.Int64ObservableCounter
+
 // tracer emits one span per WebSocket session. Sessions are the unit an
 // operator actually asks about ("did this consumer get served?"), and a span
 // per session carries the consumer session ID without the unbounded-cardinality
@@ -434,6 +439,12 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		return nil, err
 	}
 
+	freezeReportCounter, err = m.Int64ObservableCounter("freeze-reports")
+	if err != nil {
+		closeFuncMetric(ctx)
+		return nil, err
+	}
+
 	_, err = m.RegisterCallback(
 		func(ctx context.Context, o metric.Observer) error {
 			q := atomic.LoadUint64(&nQUICConnections)
@@ -471,6 +482,14 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 					metric.WithAttributes(attribute.String("reason", string(reason))))
 			})
 
+			// kind only. url, userAgent and longestTaskName are peer-chosen and
+			// unbounded; any of them here would be unbounded cardinality controlled
+			// by a stranger.
+			eachFreezeReport(func(kind freezeKind, count int64) {
+				o.ObserveInt64(freezeReportCounter, count,
+					metric.WithAttributes(attribute.String("kind", string(kind))))
+			})
+
 			eachCountryStats(func(cc string, clients, ingressBytes int64) {
 				attrs := metric.WithAttributes(attribute.String(attrDonorCountry, cc))
 				o.ObserveInt64(nClientsCounter, clients, attrs)
@@ -488,6 +507,7 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		// produces a metric that is registered, incremented, observed — and never
 		// exported. Silent, and indistinguishable from "the event never happened".
 		teardownCounter,
+		freezeReportCounter,
 	)
 	if err != nil {
 		closeFuncMetric(ctx)
@@ -525,6 +545,8 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 	// above already cover the only useful signals (concurrent ws/quic/streams,
 	// ingress bytes); per-request HTTP metrics on a single upgrade endpoint
 	// add no information.
+	mux.HandleFunc(freezeReportPath, l.handleFreezeReport)
+
 	mux.Handle("/ws", otelhttp.NewHandler(http.HandlerFunc(l.handleWebsocket), "/ws",
 		otelhttp.WithMeterProvider(metricnoop.NewMeterProvider())))
 

--- a/egress/freeze.go
+++ b/egress/freeze.go
@@ -1,0 +1,197 @@
+package egress
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Ingest for the page-side freeze watchdog (ui/src/utils/freezeWatchdog.ts).
+//
+// This is the second half of a pair. The egress can already count sessions that ended
+// with the donor no longer answering keepalive pings (session-teardowns,
+// keepalive_timeout), but that signal cannot distinguish the case anyone cares about
+// from the cases nobody does: a genuinely frozen page, a suspended laptop, and a tab
+// closed without a clean handshake all look identical from here. At ~45% of sessions it
+// is plainly dominated by the benign ones, so alerting on it would fire constantly and
+// identify nothing.
+//
+// The watchdog can tell them apart — main_thread_blocked, go_scheduler_wedged,
+// js_starved, page_died are four distinct diagnoses — and until now its reports had
+// nowhere to go: a console line, a window global, and a beacon with no endpoint. Every
+// freeze it correctly diagnosed died in the browser that diagnosed it.
+//
+// Three properties this endpoint has to hold, because it is unauthenticated and
+// reachable by any browser on any site that embeds the widget:
+//
+//   - Only `kind` becomes a metric label. url, userAgent and longestTaskName are all
+//     peer-chosen and unbounded; any of them as a label is unbounded cardinality
+//     controlled by a stranger. kind is validated against a fixed set of five.
+//   - The body is capped before it is read, not after. An unbounded POST to a Go
+//     handler is a memory-allocation primitive for whoever sends it.
+//   - The log is throttled and every peer-supplied field is truncated. This path can be
+//     driven as fast as a script can loop, and the refusal log already demonstrated
+//     what an unthrottled high-rate DEBUG line does to a journal.
+//
+// What it deliberately does not do is authenticate or rate-limit per IP. A determined
+// caller can inflate the counter, which is a data-integrity problem rather than a
+// resource one: the work per request is O(1), the body is bounded, the labels are
+// bounded, and the log is throttled. Worth knowing before trusting the absolute numbers
+// — treat them as "at least this many" and watch the shape rather than the total.
+
+// freezeReportPath is where the widget beacons to. Caddy must proxy it; the egress mux
+// serves nothing it is not routed.
+const freezeReportPath = "/freeze"
+
+// maxFreezeReportBytes caps the request body. A real report is a few hundred bytes; the
+// slack is for a long User-Agent and a long embedder URL. Enforced with
+// http.MaxBytesReader so an oversized body is refused during the read rather than
+// buffered first.
+const maxFreezeReportBytes = 8 << 10
+
+// freezeReportLogInterval throttles the log per freeze kind. Longer than the refusal
+// interval because these are supposed to be rare — if they are not, the counter says so
+// and the log does not need to.
+const freezeReportLogInterval = 5 * time.Minute
+
+var freezeReportLogs = newLogThrottle(freezeReportLogInterval)
+
+// freezeKind mirrors FreezeKind in freezeWatchdog.ts. Validated against this set rather
+// than trusted, because it is the one field that becomes a metric label.
+type freezeKind string
+
+const (
+	freezeMainThreadBlocked freezeKind = "main_thread_blocked"
+	freezeGoSchedulerWedged freezeKind = "go_scheduler_wedged"
+	freezeJSStarved         freezeKind = "js_starved"
+	freezePageDied          freezeKind = "page_died"
+	// freezeInvalid is recorded for anything that did not parse or carried an
+	// unrecognized kind. A distinct label rather than a silent drop: a widget release
+	// that changes the payload shape should show up as a visible category, not as
+	// reports quietly ceasing.
+	freezeInvalid freezeKind = "invalid"
+)
+
+func knownFreezeKind(k freezeKind) bool {
+	switch k {
+	case freezeMainThreadBlocked, freezeGoSchedulerWedged, freezeJSStarved, freezePageDied:
+		return true
+	}
+	return false
+}
+
+var freezeReports = newLabeledTally()
+
+func recordFreezeReport(kind freezeKind) {
+	freezeReports.add(string(kind))
+}
+
+func eachFreezeReport(f func(kind freezeKind, count int64)) {
+	freezeReports.each(func(label string, count int64) {
+		f(freezeKind(label), count)
+	})
+}
+
+// freezeReport is the subset of FreezeReport this endpoint reads. Unknown fields are
+// ignored rather than rejected, so a widget that adds one keeps working against an
+// older egress — the same forward-compatibility the subprotocol handshake lacked, which
+// is why a "drive by" field reuse silently broke every client built before it.
+type freezeReport struct {
+	Kind      freezeKind `json:"kind"`
+	Recovered bool       `json:"recovered"`
+	GapMs     int64      `json:"gapMs"`
+	// Pointers because null is meaningful and distinct from zero: a null goStaleMs
+	// means the wasm binary published no heartbeat, while 0 would claim it was current.
+	GoStaleMs       *int64  `json:"goStaleMs"`
+	ClockSkewMs     *int64  `json:"clockSkewMs"`
+	LongestTaskMs   *int64  `json:"longestTaskMs"`
+	LongestTaskName *string `json:"longestTaskName"`
+	Hidden          bool    `json:"hidden"`
+	Sharing         bool    `json:"sharing"`
+	// URL is the embedding site's address, which is the field that makes a report
+	// actionable: it says which page froze. It is also peer-chosen, so it is truncated
+	// and never becomes a label.
+	URL       string `json:"url"`
+	UserAgent string `json:"userAgent"`
+}
+
+// handleFreezeReport ingests one beacon.
+//
+// Always answers 204 with an empty body. navigator.sendBeacon ignores the response
+// entirely, so there is nothing to say and no reason to spend bytes saying it — and
+// returning 4xx for a malformed report would only teach a broken widget to retry.
+// Rejection is recorded as freezeInvalid instead.
+func (l proxyListener) handleFreezeReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Cap before reading. sendBeacon sends text/plain for a string body, so the
+	// content type is not checked — it is not a signal worth acting on and browsers
+	// vary.
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxFreezeReportBytes))
+	if err != nil {
+		recordFreezeReport(freezeInvalid)
+		l.logFreezeReport(freezeInvalid, nil, r, "oversized or unreadable freeze report")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	var report freezeReport
+	if err := json.Unmarshal(body, &report); err != nil || !knownFreezeKind(report.Kind) {
+		recordFreezeReport(freezeInvalid)
+		l.logFreezeReport(freezeInvalid, nil, r, "unparseable or unknown-kind freeze report")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	recordFreezeReport(report.Kind)
+	l.logFreezeReport(report.Kind, &report, r, "Freeze report from widget")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// logFreezeReport emits at most one line per kind per interval, with every peer-supplied
+// value bounded.
+func (l proxyListener) logFreezeReport(kind freezeKind, report *freezeReport, r *http.Request, msg string) {
+	shouldLog, suppressed := freezeReportLogs.allow(string(kind), time.Now())
+	if !shouldLog {
+		return
+	}
+
+	attrs := append(peerAttrs(r), "kind", string(kind))
+	if suppressed > 0 {
+		attrs = append(attrs, "suppressed_since_last", suppressed)
+	}
+	if report != nil {
+		attrs = append(attrs,
+			// The embedder URL, truncated. This is the field that says which page
+			// froze, and the reason the payload carries it at all.
+			"page_url", truncateForLog(report.URL),
+			"page_user_agent", truncateForLog(report.UserAgent),
+			// recovered separates a freeze the page survived from one it did not.
+			// Only page_died is unrecovered, and it is the severe case: a hiccup
+			// annoys a user, a death silently removes a donor from the network.
+			"recovered", report.Recovered,
+			"gap_ms", report.GapMs,
+			"hidden", report.Hidden,
+			"sharing", report.Sharing,
+		)
+		if report.GoStaleMs != nil {
+			attrs = append(attrs, "go_stale_ms", *report.GoStaleMs)
+		}
+		if report.LongestTaskMs != nil {
+			attrs = append(attrs, "longest_task_ms", *report.LongestTaskMs)
+		}
+		// The long-task attribution: the only field that says *what* froze rather
+		// than merely that something did.
+		if report.LongestTaskName != nil {
+			attrs = append(attrs, "longest_task", truncateForLog(*report.LongestTaskName))
+		}
+	}
+
+	slog.Debug(msg, attrs...)
+}

--- a/egress/freeze.go
+++ b/egress/freeze.go
@@ -133,7 +133,15 @@ func (l proxyListener) handleFreezeReport(w http.ResponseWriter, r *http.Request
 	// Cap before reading. sendBeacon sends text/plain for a string body, so the
 	// content type is not checked — it is not a signal worth acting on and browsers
 	// vary.
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxFreezeReportBytes))
+	//
+	// nil rather than w, deliberately. Given a real ResponseWriter, MaxBytesReader
+	// calls requestTooLarge() on exceed, which sets closeAfterReply and adds
+	// "Connection: close" — so an oversized report would get a different response than
+	// a normal one and drop the connection, for a request whose response nobody reads.
+	// It does not write a 413 (requestTooLarge only sets flags), so the 204 survives
+	// either way; passing nil just removes a side effect that buys nothing here. The
+	// read still fails on exceed, which is the part this needs.
+	body, err := io.ReadAll(http.MaxBytesReader(nil, r.Body, maxFreezeReportBytes))
 	if err != nil {
 		recordFreezeReport(freezeInvalid)
 		l.logFreezeReport(freezeInvalid, nil, r, "oversized or unreadable freeze report")

--- a/egress/freeze_test.go
+++ b/egress/freeze_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -199,5 +201,51 @@ func TestHandleFreezeReport_ToleratesUnknownFields(t *testing.T) {
 	postFreeze(t, body)
 	if got := collectFreezeReports()[freezePageDied]; got != 1 {
 		t.Errorf("a report with unknown fields was rejected: %v", collectFreezeReports())
+	}
+}
+
+// MaxBytesReader must be handed nil, not the ResponseWriter.
+//
+// Given a real one it calls requestTooLarge() on exceed, which sets closeAfterReply and
+// adds "Connection: close" — so an oversized report would get a different response than
+// a normal one and drop the connection, for a request whose response nobody reads.
+//
+// Asserted by reading the source, because the behavior is genuinely untestable from this
+// package. requestTooLarge() is an *unexported* method of net/http, so the interface
+// MaxBytesReader probes for can only be satisfied by a type in net/http; a same-named
+// method on a test type here does not satisfy it. My first attempt at this test did
+// exactly that and passed with either nil or w, proving nothing. Same approach as
+// TestMetricCallback_ObservesOnlyDeclaredInstruments: when the failure is a wrong
+// argument in one call, check the call.
+func TestHandleFreezeReport_MaxBytesReaderGetsNil(t *testing.T) {
+	src, err := os.ReadFile("freeze.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := regexp.MustCompile(`http\.MaxBytesReader\(\s*(\w+)`).FindAllStringSubmatch(string(src), -1)
+	if len(calls) == 0 {
+		t.Fatal("no MaxBytesReader call found; this test needs updating")
+	}
+	for _, c := range calls {
+		if c[1] != "nil" {
+			t.Errorf("MaxBytesReader called with %q, want nil — a real ResponseWriter lets an "+
+				"oversized body add Connection: close and drop the connection", c[1])
+		}
+	}
+}
+
+// The oversized path must still produce the documented empty 204 and be counted.
+func TestHandleFreezeReport_OversizedIsCountedAndQuiet(t *testing.T) {
+	resetFreezeReports(t)
+	huge := `{"kind":"page_died","url":"` + strings.Repeat("A", maxFreezeReportBytes*2) + `"}`
+	w := postFreeze(t, huge)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status %d, want 204", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty", w.Body.String())
+	}
+	if got := collectFreezeReports()[freezeInvalid]; got != 1 {
+		t.Errorf("counted %v, want one invalid", collectFreezeReports())
 	}
 }

--- a/egress/freeze_test.go
+++ b/egress/freeze_test.go
@@ -1,0 +1,203 @@
+package egress
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func resetFreezeReports(t *testing.T) {
+	t.Helper()
+	freezeReports = newLabeledTally()
+	freezeReportLogs = newLogThrottle(freezeReportLogInterval)
+}
+
+func collectFreezeReports() map[freezeKind]int64 {
+	out := map[freezeKind]int64{}
+	eachFreezeReport(func(kind freezeKind, count int64) { out[kind] = count })
+	return out
+}
+
+func postFreeze(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	// text/plain is what navigator.sendBeacon sends for a string body.
+	r := httptest.NewRequest(http.MethodPost, freezeReportPath, strings.NewReader(body))
+	r.Header.Set("Content-Type", "text/plain;charset=UTF-8")
+	r.RemoteAddr = "[::1]:40000"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7")
+	w := httptest.NewRecorder()
+	proxyListener{}.handleFreezeReport(w, r)
+	return w
+}
+
+func validReport(kind freezeKind) string {
+	b, _ := json.Marshal(freezeReport{
+		Kind: kind, Recovered: true, GapMs: 12000,
+		URL: "https://example.org/page", UserAgent: "Mozilla/5.0",
+	})
+	return string(b)
+}
+
+// Each of the four diagnoses must be counted under its own label — that distinction is
+// the entire value of the watchdog over the server-side keepalive signal, which cannot
+// tell a freeze from a sleeping laptop.
+func TestHandleFreezeReport_CountsEachKind(t *testing.T) {
+	resetFreezeReports(t)
+	for _, k := range []freezeKind{
+		freezeMainThreadBlocked, freezeGoSchedulerWedged, freezeJSStarved, freezePageDied,
+	} {
+		if got := postFreeze(t, validReport(k)).Code; got != http.StatusNoContent {
+			t.Errorf("%s: status %d, want 204", k, got)
+		}
+	}
+	got := collectFreezeReports()
+	for _, k := range []freezeKind{
+		freezeMainThreadBlocked, freezeGoSchedulerWedged, freezeJSStarved, freezePageDied,
+	} {
+		if got[k] != 1 {
+			t.Errorf("%s = %d, want 1", k, got[k])
+		}
+	}
+	if got[freezeInvalid] != 0 {
+		t.Errorf("valid reports produced %d invalid", got[freezeInvalid])
+	}
+}
+
+// A kind is the only field that becomes a metric label, so an unrecognized one must be
+// bucketed rather than trusted — otherwise a stranger chooses our label set.
+func TestHandleFreezeReport_RejectsUnknownKind(t *testing.T) {
+	resetFreezeReports(t)
+	for _, body := range []string{
+		`{"kind":"totally_made_up"}`,
+		`{"kind":""}`,
+		`{"kind":"MAIN_THREAD_BLOCKED"}`, // case-sensitive on purpose
+		`{"kind":"main_thread_blocked ";}`,
+		`not json at all`,
+		``,
+	} {
+		w := postFreeze(t, body)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("body %q: status %d, want 204 regardless", body, w.Code)
+		}
+	}
+	got := collectFreezeReports()
+	if got[freezeInvalid] != 6 {
+		t.Errorf("invalid = %d, want 6: %v", got[freezeInvalid], got)
+	}
+	if len(got) != 1 {
+		t.Errorf("unknown kinds leaked into the label set: %v", got)
+	}
+}
+
+// An unbounded POST to a Go handler is a memory-allocation primitive for whoever sends
+// it, so the body is capped during the read rather than buffered first.
+func TestHandleFreezeReport_CapsBodySize(t *testing.T) {
+	resetFreezeReports(t)
+
+	huge := `{"kind":"page_died","url":"` + strings.Repeat("A", maxFreezeReportBytes*2) + `"}`
+	if got := postFreeze(t, huge).Code; got != http.StatusNoContent {
+		t.Errorf("status %d, want 204", got)
+	}
+	if got := collectFreezeReports()[freezeInvalid]; got != 1 {
+		t.Errorf("oversized body recorded as %v, want one invalid", collectFreezeReports())
+	}
+
+	// Just under the cap still works, so the limit is not so tight that real reports
+	// with a long embedder URL and User-Agent are rejected.
+	resetFreezeReports(t)
+	ok := `{"kind":"page_died","url":"https://example.org/` + strings.Repeat("b", 2000) + `"}`
+	if len(ok) >= maxFreezeReportBytes {
+		t.Fatalf("test fixture is %d bytes, not under the %d cap", len(ok), maxFreezeReportBytes)
+	}
+	postFreeze(t, ok)
+	if got := collectFreezeReports()[freezePageDied]; got != 1 {
+		t.Errorf("a realistic long report was rejected: %v", collectFreezeReports())
+	}
+}
+
+// Only POST. A GET that counted would let any crawler inflate the numbers.
+func TestHandleFreezeReport_PostOnly(t *testing.T) {
+	resetFreezeReports(t)
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		r := httptest.NewRequest(method, freezeReportPath, nil)
+		w := httptest.NewRecorder()
+		proxyListener{}.handleFreezeReport(w, r)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: status %d, want 405", method, w.Code)
+		}
+		if w.Header().Get("Allow") != http.MethodPost {
+			t.Errorf("%s: Allow = %q, want POST", method, w.Header().Get("Allow"))
+		}
+	}
+	if len(collectFreezeReports()) != 0 {
+		t.Errorf("a non-POST was counted: %v", collectFreezeReports())
+	}
+}
+
+// This path can be driven as fast as a script can loop, and the refusal log already
+// demonstrated what an unthrottled high-rate DEBUG line does to a journal.
+func TestHandleFreezeReport_ThrottlesTheLog(t *testing.T) {
+	resetFreezeReports(t)
+	t0 := time.Now()
+
+	logged := 0
+	for i := 0; i < 500; i++ {
+		if shouldLog, _ := freezeReportLogs.allow(string(freezePageDied), t0); shouldLog {
+			logged++
+		}
+	}
+	if logged != 1 {
+		t.Errorf("logged %d of 500 within one interval, want 1", logged)
+	}
+
+	shouldLog, suppressed := freezeReportLogs.allow(string(freezePageDied), t0.Add(freezeReportLogInterval))
+	if !shouldLog {
+		t.Error("did not log after the interval elapsed")
+	}
+	if suppressed != 499 {
+		t.Errorf("suppressed = %d, want 499", suppressed)
+	}
+}
+
+// The counter must see every report even while the log sees one, or throttling would
+// trade one blind spot for another.
+func TestHandleFreezeReport_ThrottlingDoesNotAffectTheCounter(t *testing.T) {
+	resetFreezeReports(t)
+	const n = 200
+	for i := 0; i < n; i++ {
+		postFreeze(t, validReport(freezePageDied))
+	}
+	if got := collectFreezeReports()[freezePageDied]; got != n {
+		t.Errorf("counter = %d, want %d", got, n)
+	}
+}
+
+// The response body must stay empty. sendBeacon ignores it, so bytes spent here are
+// bytes spent for nobody — and a 4xx would teach a broken widget to retry.
+func TestHandleFreezeReport_AlwaysEmpty204(t *testing.T) {
+	resetFreezeReports(t)
+	for _, body := range []string{validReport(freezePageDied), `garbage`} {
+		w := postFreeze(t, body)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("status %d, want 204", w.Code)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("response body = %q, want empty", w.Body.String())
+		}
+	}
+}
+
+// Unknown fields must be ignored, not rejected, so a widget that adds one keeps working
+// against an older egress. The subprotocol handshake lacked exactly this and a field
+// reuse silently broke every client built before it.
+func TestHandleFreezeReport_ToleratesUnknownFields(t *testing.T) {
+	resetFreezeReports(t)
+	body := `{"kind":"page_died","url":"https://example.org","somethingNew":42,"nested":{"a":1}}`
+	postFreeze(t, body)
+	if got := collectFreezeReports()[freezePageDied]; got != 1 {
+		t.Errorf("a report with unknown fields was rejected: %v", collectFreezeReports())
+	}
+}

--- a/egress/logthrottle.go
+++ b/egress/logthrottle.go
@@ -1,0 +1,69 @@
+package egress
+
+import (
+	"sync"
+	"time"
+)
+
+// logThrottle bounds how often a given key may emit a log line, and counts what it
+// suppressed in between.
+//
+// Extracted from the refusal-specific version because freeze reports need exactly the
+// same thing, and a second copy is where the two drift apart. Same reasoning as
+// labeledTally: shared storage, typed wrappers at the call sites.
+//
+// The problem it solves is worth restating, since the shape recurs. A high-rate event
+// wants opposite things from a counter and from a log: the counter must see every
+// occurrence, and the log must not, or it drowns everything else. Refusal lines were
+// 96% of the egress journal — 5,326 of 5,551 entries over ten minutes — which is not
+// merely untidy: three separate greps for an unrelated startup line came back empty
+// because the signal was buried, and I concluded a deploy had not taken effect when it
+// had.
+type logThrottle struct {
+	interval time.Duration
+
+	mx    sync.Mutex
+	state map[string]*throttleState
+}
+
+type throttleState struct {
+	lastLogged time.Time
+	suppressed int64
+}
+
+func newLogThrottle(interval time.Duration) *logThrottle {
+	return &logThrottle{interval: interval, state: map[string]*throttleState{}}
+}
+
+// allow reports whether this key should be logged now, and how many occurrences went
+// unlogged since the last one that was.
+//
+// The first occurrence of a key always logs. A condition nobody has seen before is
+// exactly the one nobody is watching a dashboard for, so deferring it by up to an
+// interval is the wrong default — the throttle should quiet a known flood, not delay
+// news.
+//
+// now is a parameter rather than read inside so behavior is testable without sleeping.
+func (t *logThrottle) allow(key string, now time.Time) (shouldLog bool, suppressed int64) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	st, seen := t.state[key]
+	if !seen {
+		t.state[key] = &throttleState{lastLogged: now}
+		return true, 0
+	}
+	if now.Sub(st.lastLogged) < t.interval {
+		st.suppressed++
+		return false, 0
+	}
+
+	// Report the backlog on the line that breaks the silence, so one entry says how
+	// much it stands for. Without it a throttled line understates a flood by three
+	// orders of magnitude and reads like an isolated event — actively misleading
+	// rather than merely quiet.
+	suppressed = st.suppressed
+	st.suppressed = 0
+	st.lastLogged = now
+	return true, suppressed
+}

--- a/egress/refusals.go
+++ b/egress/refusals.go
@@ -3,7 +3,6 @@ package egress
 import (
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/getlantern/broflake/common"
@@ -107,65 +106,22 @@ func eachRefusal(f func(reason refusalReason, count int64)) {
 	})
 }
 
-// refusalLogInterval bounds how often any single refusal reason may emit a log
-// line. The metric is unaffected and stays exact — this only samples the log.
+// refusalLogInterval bounds how often any single refusal reason may emit a log line.
+// The metric is unaffected and stays exact — this only samples the log. See logThrottle
+// for why, and for the 96%-of-the-journal measurement that motivated it.
 //
-// Needed because the log and the counter want opposite things from a high-rate
-// event. Once v2.3.7 named the legacy team clients, the cause was known and the
-// per-refusal line stopped carrying new information, but it kept costing: at ~9
-// refusals/second those lines were 5,326 of 5,551 journal entries over ten minutes
-// on unbounded-us — 96% — which made journalctl useless for reading anything else.
-// Three separate greps for unrelated startup lines came back empty because the
-// signal was buried, which is how this was noticed.
-//
-// A minute is short enough that a changing peer set shows up promptly and long
-// enough to cut roughly 540 lines to one. Deliberately per-reason rather than
-// special-cased to the legacy clients: missing_subprotocols flooded exactly the same
-// way before v2.3.5 reclassified it, so the next high-rate reason should not need
-// this written again.
+// A minute is short enough that a changing peer set shows up promptly and long enough to
+// cut roughly 540 lines to one. Per-reason rather than special-cased to the legacy team
+// clients: missing_subprotocols flooded exactly the same way before v2.3.5 reclassified
+// it, so the next high-rate reason should not need this written again.
 const refusalLogInterval = time.Minute
 
-type refusalLogState struct {
-	lastLogged time.Time
-	suppressed int64
-}
+var refusalLogs = newLogThrottle(refusalLogInterval)
 
-var (
-	refusalLogMx sync.Mutex
-	refusalLogs  = map[refusalReason]*refusalLogState{}
-)
-
-// shouldLogRefusal reports whether this refusal should be logged, and how many of
-// the same reason went unlogged since the last one that was.
-//
-// The first occurrence of a reason always logs, so a condition that has never been
-// seen is visible immediately rather than up to an interval later — which matters
-// most for the reasons that are rare, since those are the ones nobody is watching a
-// dashboard for.
-//
-// now is a parameter rather than read inside so the behavior is testable without
-// sleeping.
+// shouldLogRefusal reports whether this refusal should be logged, and how many of the
+// same reason went unlogged since the last one that was.
 func shouldLogRefusal(reason refusalReason, now time.Time) (shouldLog bool, suppressed int64) {
-	refusalLogMx.Lock()
-	defer refusalLogMx.Unlock()
-
-	st, seen := refusalLogs[reason]
-	if !seen {
-		refusalLogs[reason] = &refusalLogState{lastLogged: now}
-		return true, 0
-	}
-	if now.Sub(st.lastLogged) < refusalLogInterval {
-		st.suppressed++
-		return false, 0
-	}
-
-	// Report the backlog on the line that breaks the silence, so a single log entry
-	// says how much it stands for. Without it a throttled line understates a flood by
-	// three orders of magnitude and reads like an isolated event.
-	suppressed = st.suppressed
-	st.suppressed = 0
-	st.lastLogged = now
-	return true, suppressed
+	return refusalLogs.allow(string(reason), now)
 }
 
 // classifySubprotocolRefusal decides which of the three subprotocol refusals

--- a/egress/refusals_test.go
+++ b/egress/refusals_test.go
@@ -430,9 +430,7 @@ func TestClassifySubprotocolRefusal_CookieBeatsLegacy(t *testing.T) {
 
 func resetRefusalLogs(t *testing.T) {
 	t.Helper()
-	refusalLogMx.Lock()
-	refusalLogs = map[refusalReason]*refusalLogState{}
-	refusalLogMx.Unlock()
+	refusalLogs = newLogThrottle(refusalLogInterval)
 }
 
 // The first occurrence of a reason must log immediately. A condition nobody has

--- a/ui/.env.development.example
+++ b/ui/.env.development.example
@@ -45,3 +45,9 @@ REACT_APP_NETSTATED_URL=https://netstated-d7bbec1ed55b.herokuapp.com/exec
 # CMS and Translations
 STRAPI_API_TOKEN=<STRAPI_API_TOKEN>
 STRAPI_API_URL=https://cms.lantern.io/api
+# where the freeze watchdog beacons crash/freeze reports (egress /freeze endpoint).
+# Leave empty to disable beaconing: reports then stay in the console and on
+# window.__unboundedWatchdog, which is where every freeze died before this existed.
+# NB this sends the *embedding site's* URL, since that is the field that says which page
+# froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
+REACT_APP_FREEZE_BEACON_URL=http://localhost:8000/freeze

--- a/ui/.env.production.example
+++ b/ui/.env.production.example
@@ -46,8 +46,14 @@ REACT_APP_NETSTATED_URL=https://netstated-d7bbec1ed55b.herokuapp.com/exec
 STRAPI_API_TOKEN=<STRAPI_API_TOKEN>
 STRAPI_API_URL=https://cms.lantern.io/api
 # where the freeze watchdog beacons crash/freeze reports (egress /freeze endpoint).
-# Leave empty to disable beaconing: reports then stay in the console and on
-# window.__unboundedWatchdog, which is where every freeze died before this existed.
-# NB this sends the *embedding site's* URL, since that is the field that says which page
+# Empty disables beaconing: reports stay in the console and on
+# window.__unboundedWatchdog, which is where every freeze died before /freeze existed.
+#
+# Deliberately empty until Caddy routes /freeze to the egress. The Caddyfile handles only
+# /ws and /healthz and 404s the rest, so setting this first would point every donor and
+# every embedding site at a 404 — silently, because sendBeacon ignores the response. Set
+# it to https://unbounded.iantem.io/freeze once the route is live.
+#
+# NB it sends the *embedding site's* URL, since that is the field that says which page
 # froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
-REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze
+REACT_APP_FREEZE_BEACON_URL=

--- a/ui/.env.production.example
+++ b/ui/.env.production.example
@@ -45,3 +45,9 @@ REACT_APP_NETSTATED_URL=https://netstated-d7bbec1ed55b.herokuapp.com/exec
 # CMS and Translations
 STRAPI_API_TOKEN=<STRAPI_API_TOKEN>
 STRAPI_API_URL=https://cms.lantern.io/api
+# where the freeze watchdog beacons crash/freeze reports (egress /freeze endpoint).
+# Leave empty to disable beaconing: reports then stay in the console and on
+# window.__unboundedWatchdog, which is where every freeze died before this existed.
+# NB this sends the *embedding site's* URL, since that is the field that says which page
+# froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
+REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze


### PR DESCRIPTION
Second and last prerequisite for the freeze detector — and the half that makes the first half mean anything.

## Why this is needed

`session-teardowns` (#399) already counts sessions that ended with the donor no longer answering keepalive pings. But that signal **cannot separate the case anyone cares about from the cases nobody does**: a frozen page, a suspended laptop, and a tab closed without a clean handshake are identical from the server. At ~45% of sessions it's dominated by the benign ones, so alerting on it would fire constantly and identify nothing.

The watchdog from #383 *can* tell them apart — `main_thread_blocked`, `go_scheduler_wedged`, `js_starved`, `page_died` are four distinct diagnoses. It just had nowhere to send them: a console line, a `window` global, and a beacon with no endpoint. **Every freeze it correctly diagnosed died in the browser that diagnosed it.**

`POST /freeze` on the egress, per your two decisions: endpoint on the egress, payload carries the embedding site's URL.

## Three properties, because this is unauthenticated

Reachable by any browser on any site that embeds the widget:

| property | why |
|---|---|
| only `kind` becomes a metric label, validated against a fixed set of five | `url`, `userAgent`, `longestTaskName` are peer-chosen and unbounded — any of them as a label is unbounded cardinality controlled by a stranger |
| body capped **during** the read (`http.MaxBytesReader`), not after | an unbounded POST to a Go handler is a memory-allocation primitive for whoever sends it |
| log throttled per kind, every peer field truncated | this path can be driven as fast as a script can loop, and the refusal log already showed what an unthrottled high-rate DEBUG line does to a journal |

Always answers an **empty 204**. `sendBeacon` ignores the response, so bytes spent there are spent for nobody — and a 4xx would only teach a broken widget to retry.

Malformed input is recorded as `kind=invalid` rather than dropped. A distinct label, not silence: a widget release that changes the payload shape should show up as a visible category instead of reports quietly ceasing.

Unknown JSON fields are **ignored, not rejected**, so a newer widget keeps working against an older egress. The subprotocol handshake lacked exactly that, and a drive-by field reuse silently broke every client built before it — the same mistake is cheap to avoid here.

`MaxBytesReader` is handed `nil` rather than the ResponseWriter. Given a real one it calls `requestTooLarge()` on exceed, which sets `closeAfterReply` and adds `Connection: close` — so an oversized report would get a *different* response and a dropped connection, for a request whose response nobody reads. (It does not write a 413; that only sets flags, so the 204 held either way.) The read still fails on exceed, which is the part the handler needs.

## On the URL

It's the point, and worth stating plainly: it's the field that says *which page froze*, and it's also the field that tells us *who embeds the widget*. That was a deliberate call and `freezeWatchdog.ts` already documents it for whoever reads the client side first.

## Reuse, and the #399 lesson applied

`logThrottle` is extracted from the refusal-specific version rather than copied — same reasoning as `labeledTally`: two copies are where they drift apart. Refusals now use it, with their tests passing unchanged.

`freezeReportCounter` **is** in the `RegisterCallback` instrument list, audited rather than assumed — seven observed, seven declared. #399 shipped a metric that was registered, incremented, observed and never exported because it was missing from exactly that list, and the structural test added there now covers this one too.

## Client side: the beacon ships DISABLED, on purpose

`REACT_APP_FREEZE_BEACON_URL` is **empty** in `.env.production.example`, with a comment naming the URL to set once the route below is live. Development points at `localhost:8000/freeze`.

This is the ordering that matters, and it changed during review. CI builds the page from `.env.production.example`, so merging with the URL set would have shipped a beacon pointing at a **404** to every donor and every embedding site — silently, because `sendBeacon` ignores the response. Nobody would have noticed until someone wondered why no reports were arriving.

So: endpoint and tests land first, route goes on the host, *then* the client starts sending. With the beacon disabled, reports still reach the console and `window.__unboundedWatchdog` — exactly where they were before this PR, so nothing regresses while the route is pending.

## Required before any report can arrive: the Caddy route

The egress mux serves nothing Caddy doesn't proxy, and the current Caddyfile handles only `/ws` and `/healthz`, 404ing everything else. That's host config, not repo:

```
handle /freeze {
  reverse_proxy localhost:9001
}
```

After that lands, set `REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze` and re-publish the widget page. Happy to do both, or leave them to you.

## Testing

Ten tests: each kind counted under its own label, unknown kinds bucketed as invalid without leaking into the label set, the body cap rejecting oversized while accepting a realistic long report, oversized bodies counted *and* quiet, POST-only with `Allow`, log throttling, the counter staying exact while the log is throttled, the empty-204 contract, unknown-field tolerance, and a source-level check that `MaxBytesReader` is passed `nil`.

That last one replaced a test that was worthless. It defined a `tooLargeRecorder` with a `requestTooLarge()` method and asserted the method was never called — but `requestTooLarge()` is an **unexported method of `net/http`**, so a same-named method in package `egress` cannot satisfy the interface `MaxBytesReader` probes for. It passed with `nil` *and* with `w`. The replacement checks the call site, and was verified to fail when the argument is changed back.

`go test -race ./...` passes, `gofmt` clean, `go vet` shows only the pre-existing `wsCancel` findings, `tsc --noEmit` clean.

## Deliberately not fixed here

CodeRabbit's point that these metrics should be registered once per process rather than per `NewListener` is **correct** and is left **unresolved** for a human call. It's now tracked as its own work item covering all seven instruments. Reworking metric lifecycle inside an ingest-endpoint change is the wrong bundling, and it raises a question this PR can't answer: what should `closeMetrics` mean when it's per-listener but registration isn't? Latent today — the binary builds one listener — but `NewListener` was made safe to call twice, which invites the configuration that breaks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
