### PR TITLE
egress: correct four comments that describe behavior the code does not have

### DIFF
--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -2,12 +2,12 @@ package common
 
 import (
 	"encoding/json"
-	"slices"
-
-	"github.com/pion/webrtc/v4"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/pion/webrtc/v4"
 )
 
 // The 3-element form is what every release before the consumer-country field

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -398,7 +398,9 @@ func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (n
 		return errors.Join(errMetrics, errTracing)
 	}
 
-	// Geolocation is optional; without GEODB every series is labelled "unknown".
+	// Geolocation is on by default; GEODB only overrides which database is used.
+	// It is observability, never a gate on serving traffic — a failure here labels
+	// series "unknown" and changes nothing else.
 	initDonorGeo()
 
 	m := otel.Meter("github.com/getlantern/broflake/egress")

--- a/egress/freeze.go
+++ b/egress/freeze.go
@@ -119,10 +119,16 @@ type freezeReport struct {
 
 // handleFreezeReport ingests one beacon.
 //
-// Always answers 204 with an empty body. navigator.sendBeacon ignores the response
-// entirely, so there is nothing to say and no reason to spend bytes saying it — and
-// returning 4xx for a malformed report would only teach a broken widget to retry.
-// Rejection is recorded as freezeInvalid instead.
+// Every POST gets an empty 204, whether the report was valid, malformed, or
+// oversized. navigator.sendBeacon ignores the response entirely, so there is nothing
+// to say and no reason to spend bytes saying it — and returning 4xx for a malformed
+// report would only teach a broken widget to retry. Rejection is recorded as
+// freezeInvalid instead.
+//
+// A non-POST gets 405 with an Allow header, which is the one deliberate exception.
+// sendBeacon only ever POSTs, so a GET here is not a report at all — it is something
+// else probing the endpoint, and answering it accurately costs nothing and cannot
+// reach a widget.
 func (l proxyListener) handleFreezeReport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)

--- a/egress/freeze_test.go
+++ b/egress/freeze_test.go
@@ -179,7 +179,11 @@ func TestHandleFreezeReport_ThrottlingDoesNotAffectTheCounter(t *testing.T) {
 
 // The response body must stay empty. sendBeacon ignores it, so bytes spent here are
 // bytes spent for nobody — and a 4xx would teach a broken widget to retry.
-func TestHandleFreezeReport_AlwaysEmpty204(t *testing.T) {
+//
+// Named for POSTs specifically rather than "always", because this only ever POSTs and
+// non-POST answers 405 (TestHandleFreezeReport_PostOnly). A test named for a blanket
+// claim it does not actually exercise is how such a claim goes unchallenged.
+func TestHandleFreezeReport_EveryPostGetsEmpty204(t *testing.T) {
 	resetFreezeReports(t)
 	for _, body := range []string{validReport(freezePageDied), `garbage`} {
 		w := postFreeze(t, body)

--- a/egress/geo.go
+++ b/egress/geo.go
@@ -21,11 +21,15 @@ import (
 // to "no traffic".
 const unknownCountry = "unknown"
 
-// donorGeo resolves the country of a connecting donor. It defaults to
-// geo.NoLookup, whose CountryCode always returns "", so the egress runs
-// unchanged when GEODB is unset — every series is simply labelled
-// unknownCountry. Geolocation is observability, never a gate on serving
-// traffic.
+// donorGeo resolves the country of a connecting donor. Its zero value is
+// geo.NoLookup, whose CountryCode always returns "", so every series is labelled
+// unknownCountry until initDonorGeo replaces it — which it does on every start,
+// falling back to defaultGeoDBURL when GEODB is unset. An unset GEODB therefore
+// selects the default database rather than disabling geolocation; NoLookup
+// survives only when the URL yields no usable database name, and in tests that
+// install it deliberately.
+//
+// Geolocation is observability, never a gate on serving traffic.
 //
 // Held in an atomic pointer rather than a plain package variable. initDonorGeo's
 // sync.Once already makes the write happen once, before the first listener serves
@@ -119,7 +123,10 @@ func initDonorGeoLocked() {
 
 	nameInTarball, ok := dbNameFromURL(geoDb)
 	if !ok {
-		slog.Debug("Cannot derive a database name from GEODB, donor country will be unknown",
+		// "geo DB URL" rather than "GEODB": this URL is the default unless the env
+		// var overrides it, so naming the variable would send whoever reads this
+		// looking for a misconfiguration that may not exist.
+		slog.Debug("Cannot derive a database name from the geo DB URL, donor country will be unknown",
 			"geodb", geoDb, "donor_country", unknownCountry)
 		return
 	}


### PR DESCRIPTION
Four comments that assert something the adjacent code contradicts. No behavior changes.

## How these were missed

Copilot reports some findings in a collapsed **`Suppressed comments`** block inside the review body. Those create **no inline thread**, so they never appear in `pulls/{n}/comments`, never show as unresolved, and never block a "clean round".

My review loop keyed on unresolved threads and `requested_reviewers`. Both said #403 was clean while a real finding sat inside a `<details>` in the same review that said "generated no new comments".

Swept every PR from this batch:

| PR | suppressed findings | status |
|---|---|---|
| #381 | 2 reviews flagged, body empty | — |
| #383 | 4 | already fixed via inline twins (strict `crumb.c === true` etc.) |
| #384 | 3 | `actions/checkout@v5` vs `v4` consistency — declined, see below |
| #391 | 2 | one false positive, one text no longer in main |
| #393 | 5 | **2 real, fixed here**; rest already fixed |
| #394 | 1 | **real, fixed here** |
| #399 | 2 | one was the `teardownCounter` bug (caught inline, fixed then); one design point |
| #403 | 1 | **real, fixed here** |

18 total, mostly duplicates of inline comments already handled. Four were not.

## The four

**`handleFreezeReport` claimed "Always answers 204 with an empty body"** — directly above the branch returning **405** for non-POST. Now states the real contract and why the exception exists: `sendBeacon` only ever POSTs, so a GET is not a report at all and answering it accurately cannot reach a widget.

**`TestHandleFreezeReport_AlwaysEmpty204` made the identical overclaim** while only ever POSTing, so it could never have caught the discrepancy. Renamed to `_EveryPostGetsEmpty204`. A test named for a blanket claim it does not exercise is how that claim goes unchallenged.

**Two comments still described the pre-#393 world**, where an unset `GEODB` disabled geolocation:

- `egresslib.go`: "Geolocation is optional; without GEODB every series is labelled 'unknown'"
- `geo.go`: "the egress runs unchanged when GEODB is unset"

Since #393 an unset `GEODB` **selects the default database**. Both statements are now false, and not harmlessly so — `donor_country=unknown` was a real incident that took three PRs to resolve, and these comments send whoever investigates the next one toward setting an env var that is already defaulted.

**`"Cannot derive a database name from GEODB"`** had the same problem pointed at operators: the URL is usually the built-in default, so naming the env var implies a misconfiguration that may not exist.

Plus `common/resource_test.go`, where `reflect`, `strings` and `testing` sat in the third-party import group. `gofmt` sorts *within* groups, so it never flagged it.

## Declined

**`actions/checkout@v5` → `v4`** (#384, 3 comments). v5 is current and the workflow passes on it; pinning back to match older workflows would be consistency in the wrong direction. The right fix is moving the others forward, which is not this PR.

**`Sec-Websocket-Protocol` casing** (#391). Copilot wanted RFC 6455's `Sec-WebSocket-Protocol`. The comment deliberately uses Go's canonical casing and says so on the next line, because `textproto.CanonicalMIMEHeaderKey` produces the lowercase-s form and the code indexes the header map directly. Changing it would document a key that does not exist.

**`labeledTally` exposes `add(label string)`** (#399), letting package code bypass the typed wrappers. Fair, but a design change to a shared type, and it belongs with the metric-lifecycle rework already tracked.

## Test

`go test -race ./egress/ ./common/` passes, `gofmt` and `go vet` clean.

Verified the renamed test still fails on a broken handler rather than passing on its new name alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that geolocation is enabled by default and can be configured through `GEODB`.
  * Documented fallback behavior when no geolocation database is configured, including `"unknown"` metric labels when lookup fails.
  * Clarified freeze-report responses: POST requests return `204`, while other methods return `405 Method Not Allowed` with an `Allow: POST` header.
* **Tests**
  * Updated test descriptions to accurately reflect freeze-report request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->