### PR TITLE
ui: enable the freeze beacon now that the egress route is live

### DIFF
--- a/ui/.env.production.example
+++ b/ui/.env.production.example
@@ -49,11 +49,6 @@ STRAPI_API_URL=https://cms.lantern.io/api
 # Empty disables beaconing: reports stay in the console and on
 # window.__unboundedWatchdog, which is where every freeze died before /freeze existed.
 #
-# Deliberately empty until Caddy routes /freeze to the egress. The Caddyfile handles only
-# /ws and /healthz and 404s the rest, so setting this first would point every donor and
-# every embedding site at a 404 — silently, because sendBeacon ignores the response. Set
-# it to https://unbounded.iantem.io/freeze once the route is live.
-#
 # NB it sends the *embedding site's* URL, since that is the field that says which page
 # froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
-REACT_APP_FREEZE_BEACON_URL=
+REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -1,4 +1,4 @@
-import {FreezeReport, FreezeWatchdog} from './freezeWatchdog'
+import {defaultReport, FreezeReport, FreezeWatchdog} from './freezeWatchdog'
 
 // These mirror the constants in freezeWatchdog.ts. Duplicated rather than
 // exported: the thresholds are an implementation choice, and a test that imported
@@ -740,4 +740,99 @@ test('start is idempotent', () => {
 
 	expect(reports).toHaveLength(1)
 	wd.stop()
+})
+
+// defaultReport is the sink used when no onReport is supplied, which is every
+// production install. Its beacon half had no coverage until the boolean below
+// started being read.
+describe('defaultReport beacon', () => {
+	const realBeacon = navigator.sendBeacon
+	const realUrl = process.env.REACT_APP_FREEZE_BEACON_URL
+	let warn: jest.SpyInstance
+
+	const report: FreezeReport = {
+		kind: 'js_starved',
+		detectedAt: now,
+		recovered: true,
+		gapMs: 9000,
+		goStaleMs: null,
+		goTicks: null,
+		clockSkewMs: null,
+		longestTaskMs: null,
+		longestTaskName: null,
+		hidden: false,
+		sharing: false,
+		url: 'https://example.test/',
+		userAgent: 'test',
+	}
+
+	const setBeacon = (fn: unknown) =>
+		Object.defineProperty(navigator, 'sendBeacon', {value: fn, configurable: true})
+
+	beforeEach(() => {
+		warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+		process.env.REACT_APP_FREEZE_BEACON_URL = 'https://egress.test/freeze'
+	})
+
+	afterEach(() => {
+		warn.mockRestore()
+		setBeacon(realBeacon)
+		if (realUrl === undefined) delete process.env.REACT_APP_FREEZE_BEACON_URL
+		else process.env.REACT_APP_FREEZE_BEACON_URL = realUrl
+	})
+
+	// The report line always goes to the console; the beacon is the second sink.
+	const beaconWarnings = () =>
+		warn.mock.calls.filter(c => String(c[0]).includes('beacon not queued'))
+
+	test('sends to the configured URL', () => {
+		const sent: unknown[] = []
+		setBeacon((url: string, body: string) => {
+			sent.push([url, body])
+			return true
+		})
+
+		defaultReport(report)
+
+		expect(sent).toHaveLength(1)
+		const [url, body] = sent[0] as [string, string]
+		expect(url).toBe('https://egress.test/freeze')
+		expect(JSON.parse(body).kind).toBe('js_starved')
+		expect(beaconWarnings()).toHaveLength(0)
+	})
+
+	// false means the browser declined to queue at all — the only delivery failure
+	// it will ever tell us about, so it must not be swallowed.
+	test('warns when the browser declines to queue', () => {
+		setBeacon(() => false)
+
+		defaultReport(report)
+
+		expect(beaconWarnings()).toHaveLength(1)
+	})
+
+	// Absent sendBeacon yields undefined through the optional call. That is "no
+	// beacon support", not "refused", and must not be reported as a drop — the
+	// same strict-comparison trap as the recovered breadcrumb flags.
+	test('stays quiet when sendBeacon is unavailable', () => {
+		setBeacon(undefined)
+
+		expect(() => defaultReport(report)).not.toThrow()
+		expect(beaconWarnings()).toHaveLength(0)
+	})
+
+	// Unset URL is the local-build case: still diagnosed, still logged, not sent.
+	test('does not beacon when no URL is configured', () => {
+		delete process.env.REACT_APP_FREEZE_BEACON_URL
+		let called = false
+		setBeacon(() => {
+			called = true
+			return true
+		})
+
+		defaultReport(report)
+
+		expect(called).toBe(false)
+		expect(beaconWarnings()).toHaveLength(0)
+	})
 })

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -697,8 +697,9 @@ export class FreezeWatchdog {
 //
 // console.warn is unconditional and deliberately first: it is the only sink that
 // works with no infrastructure, and someone staring at a misbehaving tab is the
-// most likely reader. It also stays the durable record when the beacon fails —
-// sendBeacon reports nothing back, so a dropped report is invisible from here.
+// most likely reader. It also stays the durable record when the beacon fails:
+// sendBeacon returns only whether the browser queued the payload, never whether it
+// arrived, so anything that goes wrong after queueing is invisible from here.
 //
 // The beacon is opt-in via REACT_APP_FREEZE_BEACON_URL, which production points at
 // the egress's POST /freeze. Unset — as in any local build — the watchdog still
@@ -713,7 +714,16 @@ export const defaultReport = (report: FreezeReport): void => {
 	const url = process.env.REACT_APP_FREEZE_BEACON_URL
 	if (!url) return
 	try {
-		navigator.sendBeacon?.(url, JSON.stringify(report))
+		// The one failure the browser will tell us about. sendBeacon returns false
+		// when it declines to queue at all — typically the payload exceeding its
+		// limit — and that is the only signal we get, since it reports nothing about
+		// what happens afterwards. Discarding it would make the single detectable
+		// drop as silent as the undetectable ones, which is the failure mode this
+		// whole path exists to avoid.
+		const queued = navigator.sendBeacon?.(url, JSON.stringify(report))
+		if (queued === false) {
+			console.warn('[unbounded watchdog] beacon not queued; report kept to console only')
+		}
 	} catch {
 		// A failed beacon must never surface to the user; the console line above
 		// is the durable record.

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -41,10 +41,18 @@
 //     on retained records, and deleting each record as it is read: the footprint on
 //     a host we are a guest on should stay small and self-cleaning.
 //   - FreezeReport carries `url`, which on an embedding site is that site's URL.
-//     Harmless while the only sinks are the local console and a window global, but
-//     enabling REACT_APP_FREEZE_BEACON_URL would start sending us the addresses of
-//     pages that embed the widget. That is a deliberate decision about third-party
-//     data, not a config toggle, which is part of why the beacon ships disabled.
+//     REACT_APP_FREEZE_BEACON_URL is now set in production, so we do receive the
+//     addresses of pages that embed the widget. That was a deliberate decision about
+//     third-party data rather than an incidental config change: the URL is the field
+//     that says *which page froze*, which is what makes a report actionable at all,
+//     and it is the same field that tells us who embeds the widget. Both follow from
+//     collecting it; neither is an accident.
+//
+//     What bounds it: the egress truncates the URL before logging, never promotes it
+//     to a metric label (only `kind` becomes one), and throttles the log. So the URL
+//     lands in a DEBUG line on the egress host, not in a queryable index of embedders.
+//     Anyone widening that — a url label, a longer retention — is making the
+//     third-party-data decision again, and should say so.
 
 // tickMs is how often the watchdog samples. Frequent enough that an 8s freeze is
 // caught by a wide margin, cheap enough to be irrelevant: one Date.now(), one
@@ -689,9 +697,13 @@ export class FreezeWatchdog {
 //
 // console.warn is unconditional and deliberately first: it is the only sink that
 // works with no infrastructure, and someone staring at a misbehaving tab is the
-// most likely reader. The beacon is opt-in via REACT_APP_FREEZE_BEACON_URL —
-// there is no ingest endpoint for widget telemetry today, so wiring it now makes
-// turning it on a config change rather than a code change.
+// most likely reader. It also stays the durable record when the beacon fails —
+// sendBeacon reports nothing back, so a dropped report is invisible from here.
+//
+// The beacon is opt-in via REACT_APP_FREEZE_BEACON_URL, which production points at
+// the egress's POST /freeze. Unset — as in any local build — the watchdog still
+// diagnoses freezes and still reports them to the console and the window global;
+// only the network hop is skipped.
 export const defaultReport = (report: FreezeReport): void => {
 	const detail = report.recovered
 		? `recovered after ${report.gapMs}ms`


### PR DESCRIPTION
One line: `REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze`. The last step of the freeze-reporting chain, and the one that had to go **last**.

## Why it shipped empty first

CI builds the production page from `.env.production.example`, and `sendBeacon` ignores its response. Setting this before the route existed would have pointed every donor and every embedding site at a **404** — no client error, no server log, no metric. The failure would have been invisible until someone wondered why the dashboard was empty.

That constraint is now satisfied.

## Deployed and verified before flipping it

**egress v2.3.10** is live on `unbounded.iantem.io` (checksum-verified against the published `.sha256`, previous binary kept for rollback), and Caddy routes `/freeze` to it.

| check | result |
|---|---|
| `POST localhost:9001/freeze` | **204** — the binary's handler |
| `POST https://unbounded.iantem.io/freeze` | **204** — through Caddy |
| `/healthz` | `egress:unbounded-us-linode-nj.iantem.io ok` |
| `/ws` | still routed, not 404 — the Caddyfile edit didn't disturb it |
| `freeze-reports` metric | exports to SigNoz, labelled by `kind` |

The report lands with every field intact:

```
msg="Freeze report from widget" kind=main_thread_blocked
  page_url=https://metric-check.invalid/ recovered=true gap_ms=12000
  hidden=false sharing=false longest_task_ms=11500 longest_task=deploy-verify
```

Log throttling also confirmed live: two same-kind reports produced one line, the second suppressed.

## Also confirmed in production while deploying

The v2.3.10 startup log shows the GEODB default from #393/#395 working — `Using GEODB to geolocate donors` against the built-in URL, `db validated`, 8,689,303 bytes. That was the three-PR `donor_country=unknown` chase, now visibly settled.

## Known noise in the counter

Three synthetic reports exist from deploy verification, and they are real rows: 2× `js_starved` with `url=https://deploy-check.invalid/`, 1× `main_thread_blocked` with `url=https://metric-check.invalid/`. Both `.invalid` hosts are reserved by RFC 2606 so they can't collide with a real embedder. Discount them from the first day's numbers.

## Deploy sequence

getlantern/lantern-cloud#3124 adds the same route to the egress cloud-init, so newly provisioned egresses get it. Cloud-init runs at first boot only, which is why this host was patched directly.

## Second commit: comments the first commit falsified

Found while reviewing this PR, not reported by a reviewer — Copilot passed it twice with no comments and CodeRabbit was rate-limited, and neither was ever going to flag a comment that the diff itself invalidates.

`freezeWatchdog.ts` carried two claims that the one-line change above makes false:

**The privacy note is the one that matters.** It said sending embedder URLs *"would"* happen if the beacon were enabled, and that shipping it disabled was part of that decision. We now collect them — so the comment understated what the widget does, on exactly the property where a reader most needs the code to be honest. It now says plainly that we receive the addresses of embedding sites, why that follows from wanting to know which page froze, and what bounds it: the egress truncates the URL, never promotes it to a metric label (only `kind` becomes one), and throttles the log — so it lands in a DEBUG line on one host, not a queryable index of embedders. Widening any of that is the same third-party-data decision again.

**`defaultReport` claimed "there is no ingest endpoint for widget telemetry today."** There is: `POST /freeze`, deployed in v2.3.10.

Also verified, since a wrong name here would fail exactly as silently as a wrong URL: the code reads `process.env.REACT_APP_FREEZE_BEACON_URL` (`freezeWatchdog.ts:701`) — the same name this PR sets — and `ui/**` is in the publish workflow's `paths` filter, so merging actually triggers the re-publish rather than leaving the value set but unshipped.

`tsc --noEmit` clean.

## Third commit: use the one failure signal sendBeacon gives us

Copilot (via a suppressed comment) correctly caught that "sendBeacon reports nothing back" is wrong — it returns a boolean for whether the payload was **queued**.

Acted on rather than just reworded. `false` means the browser declined to queue at all, typically an oversized payload, and it is the only delivery failure it will ever report. The code discarded it, making the single detectable drop as silent as the undetectable ones — in the path that exists precisely so freezes stop vanishing unreported. It now warns to the console.

Compared with `=== false`, not falsiness: an absent `sendBeacon` yields `undefined` through the optional call, and "unsupported" must not be reported as "refused". Same trap the breadcrumb flags hit (`!!crumb.c` → `crumb.c === true`).

`defaultReport` had **no test coverage**, despite being the sink every production install uses. Four tests added; the declined-queue case verified to fail without the change (`1 failed, 33 passed`). 34/34 pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3
