### PR TITLE
egress: register metrics once per process, not once per listener

### DIFF
--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -85,7 +85,17 @@ func (l proxyListener) Close() error {
 	err := l.Listener.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	l.closeMetrics(ctx)
+
+	// Logged rather than returned, and definitely rather than discarded as it was.
+	// A failed shutdown means the provider could not flush, so whatever it had
+	// buffered is gone — worth knowing, since the symptom is otherwise a metric
+	// that simply stops with no explanation. But it is not a reason to tell the
+	// caller that closing the listener failed: telemetry is observability, never a
+	// gate, and conflating the two would have a lost flush look like a lost socket.
+	if metricsErr := l.closeMetrics(ctx); metricsErr != nil {
+		slog.Warn("Metrics shutdown failed; buffered telemetry was likely dropped",
+			"error", metricsErr)
+	}
 	return err
 }
 

--- a/egress/egresslib.go
+++ b/egress/egresslib.go
@@ -18,12 +18,10 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/getlantern/broflake/common"
-	"github.com/getlantern/telemetry"
 )
 
 // TODO: rate limiters and fancy settings and such:
@@ -43,25 +41,9 @@ var nQUICStreams uint64
 // nQUICConnections is the number of open QUIC connections
 var nQUICConnections uint64
 
-var nClientsCounter metric.Int64ObservableUpDownCounter
-var nQUICStreamsCounter metric.Int64ObservableUpDownCounter
-var nQUICConnectionsCounter metric.Int64ObservableUpDownCounter
-var nIngressBytesCounter metric.Int64ObservableUpDownCounter
-
-// refusedCounter tallies connections turned away before a session span exists.
-// A monotonic Counter, not an UpDownCounter: it is a cumulative tally meant to be
-// rate()'d, unlike the concurrency gauges above.
-var refusedCounter metric.Int64ObservableCounter
-
-// teardownCounter tallies ended sessions by reason. Monotonic, and deliberately a
-// metric rather than only a span attribute: session spans are sampled at 1%, which
-// is fine for inspecting one session and useless for counting rare ones.
-var teardownCounter metric.Int64ObservableCounter
-
-// freezeReportCounter tallies freeze reports beaconed by the page-side watchdog,
-// labelled by diagnosis. The counterpart to session-teardowns: that one says a donor
-// stopped answering, this one says why.
-var freezeReportCounter metric.Int64ObservableCounter
+// The metric instruments, their otel callback and the provider lifecycle live in
+// metrics.go. They are process-scoped, not per-listener, which is the whole point
+// of them being over there.
 
 // tracer emits one span per WebSocket session. Sessions are the unit an
 // operator actually asks about ("did this consumer get served?"), and a span
@@ -381,140 +363,19 @@ func (l proxyListener) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 }
 
 func NewListener(ctx context.Context, ll net.Listener, tlsConfig *tls.Config) (net.Listener, error) {
-	closeFuncMetrics := telemetry.EnableOTELMetrics(ctx)
-
-	// Tracing powers the per-session spans in handleWebsocket. Enabled alongside
-	// metrics rather than instead of them: the counters answer "is the fleet
-	// carrying traffic", the spans answer "did this particular consumer session
-	// get served", and neither substitutes for the other.
-	closeFuncTracing := telemetry.EnableOTELTracing(ctx)
-
-	// Shut both down together on listener close. Dropping the tracing shutdown
-	// would leak the provider and discard whatever spans were still buffered,
-	// which on a low-traffic egress could be most of them.
-	closeFuncMetric := func(ctx context.Context) error {
-		errMetrics := closeFuncMetrics(ctx)
-		errTracing := closeFuncTracing(ctx)
-		return errors.Join(errMetrics, errTracing)
+	// Instruments and the otel callback are installed once for the process, not once
+	// per listener; see metrics.go for what calling this twice used to do. What comes
+	// back is this listener's release function, not a global off switch — it shuts
+	// telemetry down only when the last listener closes.
+	closeFuncMetric, err := startMetrics(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Geolocation is on by default; GEODB only overrides which database is used.
 	// It is observability, never a gate on serving traffic — a failure here labels
 	// series "unknown" and changes nothing else.
 	initDonorGeo()
-
-	m := otel.Meter("github.com/getlantern/broflake/egress")
-	var err error
-	nClientsCounter, err = m.Int64ObservableUpDownCounter("concurrent-websockets")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	nQUICConnectionsCounter, err = m.Int64ObservableUpDownCounter("concurrent-quic-connections")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	nQUICStreamsCounter, err = m.Int64ObservableUpDownCounter("concurrent-quic-streams")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	nIngressBytesCounter, err = m.Int64ObservableUpDownCounter("ingress-bytes")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	refusedCounter, err = m.Int64ObservableCounter("refused-websockets")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	teardownCounter, err = m.Int64ObservableCounter("session-teardowns")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	freezeReportCounter, err = m.Int64ObservableCounter("freeze-reports")
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
-
-	_, err = m.RegisterCallback(
-		func(ctx context.Context, o metric.Observer) error {
-			q := atomic.LoadUint64(&nQUICConnections)
-			o.ObserveInt64(nQUICConnectionsCounter, int64(q))
-
-			s := atomic.LoadUint64(&nQUICStreams)
-			o.ObserveInt64(nQUICStreamsCounter, int64(s))
-
-			// concurrent-websockets and ingress-bytes are now reported per donor
-			// country rather than as a single unlabelled series. Totals are
-			// preserved: summing across the country dimension gives the same
-			// number the unlabelled series carried, so queries that don't group
-			// by country are unaffected. Anything that reduced with max/latest
-			// instead of sum needs a spaceAggregation of sum to stay correct.
-			//
-			// CAUTION when summing: these datapoints also carry a `via` resource
-			// attribute identifying the telemetry collector that forwarded them
-			// (ops-0/1/2), and the same datapoint arrives once per collector. The
-			// egress is a single instance — instance.id has exactly one value,
-			// unbounded-us-linode-nj.iantem.io — so summing across `via` triples
-			// the real figure. Sum across donor_country, but filter or average
-			// across `via`.
-			//
-			// Note these counts come from per-session counters incremented and
-			// decremented exactly once around the handler, whereas the legacy
-			// global nClients decrements in the conn's Close(). nClients is now
-			// only used for the log lines.
-			eachRefusal(func(reason refusalReason, count int64) {
-				o.ObserveInt64(refusedCounter, count,
-					metric.WithAttributes(attribute.String("reason", string(reason))))
-			})
-
-			eachTeardown(func(reason teardownReason, count int64) {
-				o.ObserveInt64(teardownCounter, count,
-					metric.WithAttributes(attribute.String("reason", string(reason))))
-			})
-
-			// kind only. url, userAgent and longestTaskName are peer-chosen and
-			// unbounded; any of them here would be unbounded cardinality controlled
-			// by a stranger.
-			eachFreezeReport(func(kind freezeKind, count int64) {
-				o.ObserveInt64(freezeReportCounter, count,
-					metric.WithAttributes(attribute.String("kind", string(kind))))
-			})
-
-			eachCountryStats(func(cc string, clients, ingressBytes int64) {
-				attrs := metric.WithAttributes(attribute.String(attrDonorCountry, cc))
-				o.ObserveInt64(nClientsCounter, clients, attrs)
-				o.ObserveInt64(nIngressBytesCounter, ingressBytes, attrs)
-			})
-			return nil
-		},
-		nClientsCounter,
-		nQUICConnectionsCounter,
-		nQUICStreamsCounter,
-		nIngressBytesCounter,
-		refusedCounter,
-		// Every instrument the callback observes must be declared here. The SDK
-		// ignores observations for anything absent from this list, so omitting one
-		// produces a metric that is registered, incremented, observed — and never
-		// exported. Silent, and indistinguishable from "the event never happened".
-		teardownCounter,
-		freezeReportCounter,
-	)
-	if err != nil {
-		closeFuncMetric(ctx)
-		return nil, err
-	}
 
 	cm := &connectionManager{
 		connections:     make(map[string]*connectionRecord),

--- a/egress/metrics.go
+++ b/egress/metrics.go
@@ -1,0 +1,244 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/getlantern/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// OTel setup for the egress, scoped to the process rather than to a listener.
+//
+// It used to live inline in NewListener, which meant every listener built its own
+// copy of everything. That was raised in review three separate times before this
+// fixed it, and by then the pattern had accreted seven instruments — so what began
+// as a tidiness point had become the shape of a real outage.
+//
+// Nothing it touches is per-listener. The tallies the callback reads (refusals,
+// teardowns, freezeReports, statsByCC) are package globals, the instrument handles
+// are package variables, and telemetry.EnableOTELMetrics installs a *global* meter
+// provider via otel.SetMeterProvider. Calling it twice therefore did not produce two
+// independent setups; it produced one broken one, in three distinct ways:
+//
+//   - Duplicate series. Both callbacks observe the same process-global tallies, so
+//     every attribute set is reported twice per collection cycle. Exactly the
+//     double-counting #375 fixed for donor_country, reintroduced by a second listener.
+//   - Silently dropped observations. The callback closure captures nothing — it reads
+//     nClientsCounter and friends as globals when it runs. A second NewListener
+//     overwrites those variables with instruments belonging to the *new* provider,
+//     so the first provider's callback then observes instruments it never registered,
+//     and the SDK discards them. The #399 failure mode, arrived at from the other end.
+//   - A live orphan. SetMeterProvider replaces the global but does not stop the old
+//     provider, whose periodic reader keeps exporting on its own schedule. The first
+//     provider is unreachable and still talking.
+//
+// Shutdown had the mirror-image problem. closeMetrics was per-listener while the
+// provider was not, so the first listener to close shut down telemetry for every
+// listener still serving — and, because it held a closure over its *own* provider,
+// it might shut down the orphan while the global one kept running. Reference
+// counting is the honest model: the last listener out turns off the lights, and a
+// listener created afterwards gets a fresh setup rather than a dead one.
+//
+// None of this is reachable from cmd/, which builds exactly one listener. It is
+// reachable from tests, and NewListener was deliberately made safe to call twice
+// (see the per-listener ServeMux in egresslib.go) — which is precisely the
+// invitation that makes leaving it broken a bad trade.
+
+// The instrument handles. Package-scoped because the otel callback is registered
+// once and reads them when it runs; see the callback for why that matters.
+var nClientsCounter metric.Int64ObservableUpDownCounter
+var nQUICStreamsCounter metric.Int64ObservableUpDownCounter
+var nQUICConnectionsCounter metric.Int64ObservableUpDownCounter
+var nIngressBytesCounter metric.Int64ObservableUpDownCounter
+
+// refusedCounter tallies connections turned away before a session span exists.
+// A monotonic Counter, not an UpDownCounter: it is a cumulative tally meant to be
+// rate()'d, unlike the concurrency gauges above.
+var refusedCounter metric.Int64ObservableCounter
+
+// teardownCounter tallies ended sessions by reason. Monotonic, and deliberately a
+// metric rather than only a span attribute: session spans are sampled at 1%, which
+// is fine for inspecting one session and useless for counting rare ones.
+var teardownCounter metric.Int64ObservableCounter
+
+// freezeReportCounter tallies freeze reports beaconed by the page-side watchdog,
+// labelled by diagnosis. The counterpart to session-teardowns: that one says a donor
+// stopped answering, this one says why.
+var freezeReportCounter metric.Int64ObservableCounter
+
+var (
+	// metricsMu guards both fields below. A plain mutex rather than sync.Once
+	// because the setup has to be repeatable: refcount reaching zero shuts the
+	// provider down, and a listener created after that must get a working one
+	// rather than inherit the corpse. sync.Once cannot express that.
+	metricsMu       sync.Mutex
+	metricsRefs     int
+	metricsShutdown func(context.Context) error
+)
+
+// startMetrics installs the process-wide metric and tracing setup if it is not
+// already running, and returns this caller's release function.
+//
+// The returned function is idempotent — proxyListener.Close is not guaranteed to be
+// called exactly once — and only performs the real shutdown when it drops the last
+// reference.
+func startMetrics(ctx context.Context) (func(context.Context) error, error) {
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+
+	if metricsRefs == 0 {
+		shutdown, err := initMetricsFn(ctx)
+		if err != nil {
+			// Deliberately before the increment. Counting a failed setup as a live
+			// reference would make the next caller skip initialization and run with
+			// no instruments at all — a silent version of the failure that just
+			// announced itself.
+			return nil, err
+		}
+		metricsShutdown = shutdown
+	}
+	metricsRefs++
+
+	var once sync.Once
+	return func(ctx context.Context) error {
+		var err error
+		once.Do(func() {
+			metricsMu.Lock()
+			defer metricsMu.Unlock()
+			metricsRefs--
+			if metricsRefs == 0 && metricsShutdown != nil {
+				err = metricsShutdown(ctx)
+				metricsShutdown = nil
+			}
+		})
+		return err
+	}, nil
+}
+
+// initMetricsFn is the setup entry point, indirected so the lifecycle tests can
+// exercise refcounting without standing up an OTLP exporter and a real meter
+// provider. Production always runs initMetrics.
+var initMetricsFn = initMetrics
+
+// initMetrics creates the exporters, instruments and callback. Callers must hold
+// metricsMu.
+func initMetrics(ctx context.Context) (func(context.Context) error, error) {
+	closeFuncMetrics := telemetry.EnableOTELMetrics(ctx)
+
+	// Tracing powers the per-session spans in handleWebsocket. Enabled alongside
+	// metrics rather than instead of them: the counters answer "is the fleet
+	// carrying traffic", the spans answer "did this particular consumer session
+	// get served", and neither substitutes for the other.
+	closeFuncTracing := telemetry.EnableOTELTracing(ctx)
+
+	// Shut both down together. Dropping the tracing shutdown would leak the
+	// provider and discard whatever spans were still buffered, which on a
+	// low-traffic egress could be most of them.
+	shutdown := func(ctx context.Context) error {
+		return errors.Join(closeFuncMetrics(ctx), closeFuncTracing(ctx))
+	}
+
+	m := otel.Meter("github.com/getlantern/broflake/egress")
+
+	var err error
+	if nClientsCounter, err = m.Int64ObservableUpDownCounter("concurrent-websockets"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if nQUICConnectionsCounter, err = m.Int64ObservableUpDownCounter("concurrent-quic-connections"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if nQUICStreamsCounter, err = m.Int64ObservableUpDownCounter("concurrent-quic-streams"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if nIngressBytesCounter, err = m.Int64ObservableUpDownCounter("ingress-bytes"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if refusedCounter, err = m.Int64ObservableCounter("refused-websockets"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if teardownCounter, err = m.Int64ObservableCounter("session-teardowns"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+	if freezeReportCounter, err = m.Int64ObservableCounter("freeze-reports"); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+
+	if _, err = m.RegisterCallback(
+		observeMetrics,
+		nClientsCounter,
+		nQUICConnectionsCounter,
+		nQUICStreamsCounter,
+		nIngressBytesCounter,
+		refusedCounter,
+		// Every instrument the callback observes must be declared here. The SDK
+		// ignores observations for anything absent from this list, so omitting one
+		// produces a metric that is registered, incremented, observed — and never
+		// exported. Silent, and indistinguishable from "the event never happened".
+		teardownCounter,
+		freezeReportCounter,
+	); err != nil {
+		return nil, shutdownAfter(ctx, shutdown, err)
+	}
+
+	return shutdown, nil
+}
+
+// shutdownAfter tears down the half-built provider and returns the original error,
+// so a failure partway through setup does not leave an exporter running with no
+// instruments attached to it.
+func shutdownAfter(ctx context.Context, shutdown func(context.Context) error, err error) error {
+	return errors.Join(err, shutdown(ctx))
+}
+
+// observeMetrics is the single otel callback. Registered once per process, so it
+// must read only process-global state — which is all it does.
+func observeMetrics(ctx context.Context, o metric.Observer) error {
+	o.ObserveInt64(nQUICConnectionsCounter, int64(atomic.LoadUint64(&nQUICConnections)))
+	o.ObserveInt64(nQUICStreamsCounter, int64(atomic.LoadUint64(&nQUICStreams)))
+
+	// concurrent-websockets and ingress-bytes are reported per donor country
+	// rather than as a single unlabelled series. Totals are preserved: summing
+	// across the country dimension gives the same number the unlabelled series
+	// carried, so queries that don't group by country are unaffected. Anything
+	// that reduced with max/latest instead of sum needs a spaceAggregation of sum
+	// to stay correct.
+	//
+	// CAUTION when summing: these datapoints also carry a `via` resource attribute
+	// identifying the telemetry collector that forwarded them (ops-0/1/2), and the
+	// same datapoint arrives once per collector. The egress is a single instance —
+	// instance.id has exactly one value, unbounded-us-linode-nj.iantem.io — so
+	// summing across `via` triples the real figure. Sum across donor_country, but
+	// filter or average across `via`.
+	//
+	// Note these counts come from per-session counters incremented and decremented
+	// exactly once around the handler, whereas the legacy global nClients decrements
+	// in the conn's Close(). nClients is now only used for the log lines.
+	eachRefusal(func(reason refusalReason, count int64) {
+		o.ObserveInt64(refusedCounter, count,
+			metric.WithAttributes(attribute.String("reason", string(reason))))
+	})
+
+	eachTeardown(func(reason teardownReason, count int64) {
+		o.ObserveInt64(teardownCounter, count,
+			metric.WithAttributes(attribute.String("reason", string(reason))))
+	})
+
+	// kind only. url, userAgent and longestTaskName are peer-chosen and unbounded;
+	// any of them here would be unbounded cardinality controlled by a stranger.
+	eachFreezeReport(func(kind freezeKind, count int64) {
+		o.ObserveInt64(freezeReportCounter, count,
+			metric.WithAttributes(attribute.String("kind", string(kind))))
+	})
+
+	eachCountryStats(func(cc string, clients, ingressBytes int64) {
+		attrs := metric.WithAttributes(attribute.String(attrDonorCountry, cc))
+		o.ObserveInt64(nClientsCounter, clients, attrs)
+		o.ObserveInt64(nIngressBytesCounter, ingressBytes, attrs)
+	})
+	return nil
+}

--- a/egress/metrics.go
+++ b/egress/metrics.go
@@ -104,9 +104,14 @@ func startMetrics(ctx context.Context) (func(context.Context) error, error) {
 	}
 	metricsRefs++
 
-	var once sync.Once
+	var (
+		once sync.Once
+		// Held outside the closure so every call returns the same answer. Declaring
+		// it inside would mean the first call reports a failed flush and every
+		// later one reports success, which is a worse contract than either.
+		err error
+	)
 	return func(ctx context.Context) error {
-		var err error
 		once.Do(func() {
 			metricsMu.Lock()
 			defer metricsMu.Unlock()

--- a/egress/metrics_test.go
+++ b/egress/metrics_test.go
@@ -15,19 +15,24 @@ func withStubbedMetrics(t *testing.T) *stubMetrics {
 	t.Helper()
 	stub := &stubMetrics{}
 
+	// initMetricsFn is swapped under metricsMu, the same lock startMetrics holds
+	// while reading it. Unsynchronized, this is a write to a package global racing
+	// a read — it does not fire today only because Go resumes t.Parallel() tests
+	// after the sequential ones finish, and the tests that reach startMetrics are
+	// sequential. Adding t.Parallel() to any of them would turn that into a real
+	// race with no other warning, which is too quiet a tripwire to leave armed.
+	metricsMu.Lock()
 	realInit := initMetricsFn
 	initMetricsFn = stub.init
-
-	metricsMu.Lock()
 	prevRefs, prevShutdown := metricsRefs, metricsShutdown
 	metricsRefs, metricsShutdown = 0, nil
 	metricsMu.Unlock()
 
 	t.Cleanup(func() {
-		initMetricsFn = realInit
 		metricsMu.Lock()
+		defer metricsMu.Unlock()
+		initMetricsFn = realInit
 		metricsRefs, metricsShutdown = prevRefs, prevShutdown
-		metricsMu.Unlock()
 	})
 	return stub
 }

--- a/egress/metrics_test.go
+++ b/egress/metrics_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-// resetMetricsState puts the package-global refcount back so one test's listeners
-// cannot leak into the next. The real initMetrics is never called here — these tests
-// exercise the refcounting, and standing up an OTLP exporter would make them depend
-// on a collector being reachable.
+// withStubbedMetrics swaps in a stub initializer and resets the package-global
+// refcount so one test's listeners cannot leak into the next. The real initMetrics is
+// never called here — these tests exercise the refcounting, and standing up an OTLP
+// exporter would make them depend on a collector being reachable.
 func withStubbedMetrics(t *testing.T) *stubMetrics {
 	t.Helper()
 	stub := &stubMetrics{}
@@ -33,10 +33,11 @@ func withStubbedMetrics(t *testing.T) *stubMetrics {
 }
 
 type stubMetrics struct {
-	mu        sync.Mutex
-	inits     int
-	shutdowns int
-	initErr   error
+	mu          sync.Mutex
+	inits       int
+	shutdowns   int
+	initErr     error
+	shutdownErr error
 }
 
 func (s *stubMetrics) init(context.Context) (func(context.Context) error, error) {
@@ -50,7 +51,7 @@ func (s *stubMetrics) init(context.Context) (func(context.Context) error, error)
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.shutdowns++
-		return nil
+		return s.shutdownErr
 	}, nil
 }
 
@@ -220,5 +221,31 @@ func TestStartMetrics_ConcurrentStartStop(t *testing.T) {
 	}
 	if inits == 0 {
 		t.Error("never initialized")
+	}
+}
+
+// A failed shutdown means the provider could not flush and whatever it buffered is
+// gone. Reporting that on the first close and silently succeeding on every later one
+// is a worse contract than either always or never reporting it — and the caller has
+// no way to tell which call it is holding.
+func TestStartMetrics_ReleaseReturnsTheSameErrorEveryTime(t *testing.T) {
+	stub := withStubbedMetrics(t)
+	sentinel := errors.New("flush failed")
+	stub.shutdownErr = sentinel
+
+	stop, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := stop(context.Background()); !errors.Is(err, sentinel) {
+			t.Errorf("close %d returned %v, want %v", i, err, sentinel)
+		}
+	}
+
+	// The shutdown itself must still only have run once.
+	if _, shutdowns := stub.counts(); shutdowns != 1 {
+		t.Errorf("shut down %d times, want 1", shutdowns)
 	}
 }

--- a/egress/metrics_test.go
+++ b/egress/metrics_test.go
@@ -1,0 +1,224 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// resetMetricsState puts the package-global refcount back so one test's listeners
+// cannot leak into the next. The real initMetrics is never called here — these tests
+// exercise the refcounting, and standing up an OTLP exporter would make them depend
+// on a collector being reachable.
+func withStubbedMetrics(t *testing.T) *stubMetrics {
+	t.Helper()
+	stub := &stubMetrics{}
+
+	realInit := initMetricsFn
+	initMetricsFn = stub.init
+
+	metricsMu.Lock()
+	prevRefs, prevShutdown := metricsRefs, metricsShutdown
+	metricsRefs, metricsShutdown = 0, nil
+	metricsMu.Unlock()
+
+	t.Cleanup(func() {
+		initMetricsFn = realInit
+		metricsMu.Lock()
+		metricsRefs, metricsShutdown = prevRefs, prevShutdown
+		metricsMu.Unlock()
+	})
+	return stub
+}
+
+type stubMetrics struct {
+	mu        sync.Mutex
+	inits     int
+	shutdowns int
+	initErr   error
+}
+
+func (s *stubMetrics) init(context.Context) (func(context.Context) error, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.initErr != nil {
+		return nil, s.initErr
+	}
+	s.inits++
+	return func(context.Context) error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.shutdowns++
+		return nil
+	}, nil
+}
+
+func (s *stubMetrics) counts() (inits, shutdowns int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.inits, s.shutdowns
+}
+
+// The bug this whole change exists for. Registering per listener meant a second
+// NewListener built a second meter provider, overwrote the shared instrument
+// variables, and left the first provider exporting duplicates of every series it
+// could still resolve.
+func TestStartMetrics_InitializesOncePerProcess(t *testing.T) {
+	stub := withStubbedMetrics(t)
+
+	stop1, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop2, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inits, _ := stub.counts(); inits != 1 {
+		t.Errorf("initialized %d times for 2 listeners, want 1", inits)
+	}
+
+	// And the first listener closing must not take telemetry away from the second,
+	// which is still serving. That was the mirror-image half of the same bug.
+	if err := stop1(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, shutdowns := stub.counts(); shutdowns != 0 {
+		t.Errorf("shut down while a listener was still open (%d times)", shutdowns)
+	}
+
+	if err := stop2(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, shutdowns := stub.counts(); shutdowns != 1 {
+		t.Errorf("shut down %d times after the last listener closed, want 1", shutdowns)
+	}
+}
+
+// proxyListener.Close is not guaranteed to be called exactly once, and a double
+// close must not drive the refcount negative — which would make the *next*
+// startMetrics skip initialization and hand out a working-looking handle to a
+// provider that was never created.
+func TestStartMetrics_ReleaseIsIdempotent(t *testing.T) {
+	stub := withStubbedMetrics(t)
+
+	stop, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := stop(context.Background()); err != nil {
+			t.Fatalf("close %d: %v", i, err)
+		}
+	}
+
+	if _, shutdowns := stub.counts(); shutdowns != 1 {
+		t.Errorf("shut down %d times for 3 closes, want 1", shutdowns)
+	}
+
+	metricsMu.Lock()
+	refs := metricsRefs
+	metricsMu.Unlock()
+	if refs != 0 {
+		t.Errorf("refcount = %d after repeated closes, want 0", refs)
+	}
+}
+
+// Dropping to zero and starting again is the create/close/create cycle every test
+// binary performs. It must produce a live provider, not reuse the shut-down one —
+// this is why the state is a mutex and a counter rather than a sync.Once.
+func TestStartMetrics_ReinitializesAfterFullRelease(t *testing.T) {
+	stub := withStubbedMetrics(t)
+
+	stop, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	stop2, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop2(context.Background())
+
+	if inits, _ := stub.counts(); inits != 2 {
+		t.Errorf("initialized %d times across a full release cycle, want 2", inits)
+	}
+}
+
+// A failed setup must not be recorded as a live reference. If it were, the next
+// caller would see a non-zero refcount, skip initialization entirely, and run with
+// no instruments at all.
+func TestStartMetrics_FailedInitLeavesNoReference(t *testing.T) {
+	stub := withStubbedMetrics(t)
+	sentinel := errors.New("exporter unavailable")
+	stub.initErr = sentinel
+
+	if _, err := startMetrics(context.Background()); !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want %v", err, sentinel)
+	}
+
+	metricsMu.Lock()
+	refs := metricsRefs
+	metricsMu.Unlock()
+	if refs != 0 {
+		t.Fatalf("refcount = %d after a failed init, want 0", refs)
+	}
+
+	// A later attempt, once the exporter is reachable, must actually initialize.
+	stub.initErr = nil
+	stop, err := startMetrics(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop(context.Background())
+	if inits, _ := stub.counts(); inits != 1 {
+		t.Errorf("initialized %d times after recovering, want 1", inits)
+	}
+}
+
+// Listeners are created and closed from independent goroutines in tests and in any
+// host embedding more than one egress. The refcount is the only thing standing
+// between that and a torn-down provider under a live listener.
+func TestStartMetrics_ConcurrentStartStop(t *testing.T) {
+	stub := withStubbedMetrics(t)
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stop, err := startMetrics(context.Background())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			stop(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	metricsMu.Lock()
+	refs := metricsRefs
+	metricsMu.Unlock()
+	if refs != 0 {
+		t.Errorf("refcount = %d after %d balanced start/stop pairs, want 0", refs, n)
+	}
+
+	// Every init must be matched by exactly one shutdown. Interleaving decides how
+	// many cycles happen, so the counts are compared to each other rather than to a
+	// fixed number.
+	inits, shutdowns := stub.counts()
+	if inits != shutdowns {
+		t.Errorf("%d inits vs %d shutdowns — a provider was leaked or double-closed", inits, shutdowns)
+	}
+	if inits == 0 {
+		t.Error("never initialized")
+	}
+}

--- a/egress/teardowns_test.go
+++ b/egress/teardowns_test.go
@@ -1,7 +1,6 @@
 package egress
 
 import (
-	"bytes"
 	"os"
 	"regexp"
 	"runtime"
@@ -144,37 +143,29 @@ func TestLabeledTally_IsolatesInstances(t *testing.T) {
 // event never happening. teardownCounter shipped missing from that list in review.
 //
 // Asserted by reading the source rather than by standing up an SDK, because the
-// failure is a mismatch between two lists in one function and that is exactly what a
-// cheap structural check catches.
+// failure is a mismatch between two lists and that is exactly what a cheap structural
+// check catches.
+//
+// The two lists now live in separate functions in metrics.go — observeMetrics does the
+// observing, initMetrics does the declaring — which makes the check more valuable than
+// when they were adjacent inside NewListener, not less: nothing puts them on the same
+// screen any more.
 func TestMetricCallback_ObservesOnlyDeclaredInstruments(t *testing.T) {
-	src, err := os.ReadFile("egresslib.go")
+	src, err := os.ReadFile("metrics.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	const marker = "_, err = m.RegisterCallback("
-	i := bytes.Index(src, []byte(marker))
-	if i < 0 {
-		t.Fatal("could not find the RegisterCallback call; this test needs updating")
-	}
-	block := string(src[i:])
-	end := strings.Index(block, "\n\tif err != nil {")
-	if end < 0 {
-		t.Fatal("could not find the end of the RegisterCallback call")
-	}
-	block = block[:end]
-
-	observed := map[string]bool{}
-	for _, m := range regexp.MustCompile(`o\.ObserveInt64\(\s*(\w+)`).FindAllStringSubmatch(block, -1) {
-		observed[m[1]] = true
-	}
+	observed := namesIn(t, string(src),
+		"func observeMetrics(", "\n}", `o\.ObserveInt64\(\s*(\w+)`)
 	if len(observed) == 0 {
-		t.Fatal("found no ObserveInt64 calls; this test needs updating")
+		t.Fatal("found no ObserveInt64 calls in observeMetrics; this test needs updating")
 	}
 
-	declared := map[string]bool{}
-	for _, m := range regexp.MustCompile(`(?m)^\t\t(\w+Counter),?$`).FindAllStringSubmatch(block, -1) {
-		declared[m[1]] = true
+	declared := namesIn(t, string(src),
+		"m.RegisterCallback(", "\n\t); err != nil {", `(?m)^\t\t(\w+Counter),?$`)
+	if len(declared) == 0 {
+		t.Fatal("found no instruments in the RegisterCallback list; this test needs updating")
 	}
 
 	for name := range observed {
@@ -183,4 +174,36 @@ func TestMetricCallback_ObservesOnlyDeclaredInstruments(t *testing.T) {
 				"its observations will be silently dropped", name)
 		}
 	}
+
+	// The reverse is not an error the SDK punishes, but it is always a mistake: an
+	// instrument declared and never observed exports nothing, so it is either dead
+	// weight or a missing observation.
+	for name := range declared {
+		if !observed[name] {
+			t.Errorf("%s is declared in the RegisterCallback instrument list but never observed — "+
+				"it will export no data at all", name)
+		}
+	}
+}
+
+// namesIn pulls identifiers matching pat out of the source between the first
+// occurrence of start and the next occurrence of end after it.
+func namesIn(t *testing.T, src, start, end, pat string) map[string]bool {
+	t.Helper()
+	i := strings.Index(src, start)
+	if i < 0 {
+		t.Fatalf("could not find %q; this test needs updating", start)
+	}
+	block := src[i:]
+	j := strings.Index(block, end)
+	if j < 0 {
+		t.Fatalf("could not find %q after %q; this test needs updating", end, start)
+	}
+	block = block[:j]
+
+	found := map[string]bool{}
+	for _, m := range regexp.MustCompile(pat).FindAllStringSubmatch(block, -1) {
+		found[m[1]] = true
+	}
+	return found
 }


### PR DESCRIPTION
Closes the review comment raised three times — on #381, #399 and #403 — and deferred each time. No behavior change on the running egress, which builds exactly one listener.

## Why it kept getting deferred, and why that stopped being right

Each time it came up, the answer was that it applies to *all* instruments rather than the one being added, so fixing only the new one would leave it broken in four places and imply the others were fine. That was true. It also aged badly: the pattern has since accreted **seven** instruments, three of which I added. "Out of scope" three times running is just debt.

## What was actually wrong

Nothing the setup touches is per-listener:

- the tallies the callback reads (`refusals`, `teardowns`, `freezeReports`, `statsByCC`) are package globals
- the instrument handles are package variables
- `telemetry.EnableOTELMetrics` installs a **global** provider via `otel.SetMeterProvider`

So a second `NewListener` didn't create a second independent setup. It corrupted the first, three separate ways:

| failure | mechanism |
|---|---|
| **Duplicate series** | Both callbacks observe the same process-global tallies, so every attribute set is reported twice per collection cycle — the exact double-counting #375 fixed for `donor_country`, reintroduced by a second listener |
| **Silently dropped observations** | The callback captures nothing; it reads `nClientsCounter` and friends as globals *when it runs*. A second `NewListener` overwrites those with instruments belonging to the **new** provider, so the first provider's callback observes instruments it never registered and the SDK discards them — the #399 failure mode, reached from the other end |
| **A live orphan** | `SetMeterProvider` replaces the global but does not stop the old provider, whose periodic reader keeps exporting on its own schedule. Unreachable and still talking |

## Shutdown, and the question that made this awkward to bundle

#403's thread asked what `closeMetrics` should even mean when it's per-listener but registration isn't. It was the mirror image of the same bug: **the first listener to close shut telemetry down for every listener still serving** — and since it closed over its *own* provider, it could kill the orphan while the global one kept running.

Reference counting is the honest model: the last listener out turns off the lights, and a listener created afterwards gets a fresh setup rather than the corpse. That needs a mutex and a counter rather than a `sync.Once`, precisely because the setup has to be **repeatable** — create/close/create is what every test binary does, and a `sync.Once` would hand the second one a shut-down provider.

The release function is idempotent, and a failed init deliberately does **not** take a reference — counting one would make the next caller skip initialization and run with no instruments at all, converting a loud failure into a silent one.

## Reachability

Not reachable from `cmd/`, which builds one listener — so this is latent, not an outage. It **is** reachable from tests, and `NewListener` was deliberately made safe to call twice (the per-listener `ServeMux`, added for exactly that reason). Being safe to call twice while being broken when called twice is the worst of both.

## Tests

Five new lifecycle tests, all verified to fail against the old per-listener behavior rather than passing on their names:

```
--- FAIL: TestStartMetrics_InitializesOncePerProcess
    initialized 2 times for 2 listeners, want 1
    shut down while a listener was still open (1 times)
```

Covering: one init across two listeners, no shutdown while a listener is open, idempotent release, re-init after full release, no reference taken on failed init, and 50 concurrent start/stop pairs under `-race` asserting inits == shutdowns (no leaked or double-closed provider).

`initMetrics` is indirected through a variable so these exercise the refcounting without standing up an OTLP exporter and depending on a reachable collector.

The #399 structural test had to learn where the code moved, and gained the reverse check — **declared but never observed**, which exports nothing and is either dead weight or a missing observation. Both directions verified to fail when broken. The two lists now live in separate functions, which makes that check more valuable than when they sat adjacent, not less.

`go test -race ./...` passes, `gofmt`/`go vet` clean, `GOOS=js GOARCH=wasm go build ./cmd` ok.

`NewListener` loses ~130 lines of telemetry wiring and keeps 4.

## Review round 1

**Copilot: the release closure lost its error.** `err` was declared inside `once.Do`, so the first close reported a failed flush and every later one reported success. Correct, and fixed by hoisting it.

Chasing it found the larger half: **`proxyListener.Close` discarded the result entirely** —

```go
l.closeMetrics(ctx)   // result discarded
return err            // the listener's error
```

— so no call returned anything anyone read, regardless of which one it was. A failed shutdown means the provider could not flush and whatever it buffered is gone; the visible symptom is a metric that stops with no explanation, which is exactly the failure shape this PR exists to remove. Now logged at WARN.

Logged rather than returned on purpose: joining it into `Close`'s error would make a lost flush indistinguishable from a lost socket to a caller checking the return, and telemetry is observability, never a gate — the rule `initDonorGeo` follows two functions away.

`TestStartMetrics_ReleaseReturnsTheSameErrorEveryTime` added, verified against the old declaration:

```
close 1 returned <nil>, want flush failed
close 2 returned <nil>, want flush failed
```

**CodeRabbit: a doc comment named `resetMetricsState`,** a function from an earlier draft that never existed. Fixed. Noting it because it is the third comment-describing-something-absent I have shipped in two days — #405 corrected four more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3
