### PR TITLE
ui: stop the watchdog reporting throttled timers and sleeping laptops

### DIFF
--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -643,6 +643,25 @@ describe('breadcrumb recovery', () => {
 	// the two are indistinguishable from here. The first five real page_died reports
 	// were 6.2 to 15.3 hours old — every one an overnight suspend, every one reported
 	// as a casualty. Without a ceiling this kind means "someone shut their laptop".
+	// The wall clock moves backwards on real machines — NTP corrections, VM
+	// restores, dual-boot, a user setting it by hand — and this runs on other
+	// people's computers. A future-dated record is the one case with no exit: a
+	// negative age reads as a live tab so it is left in place, and it is also below
+	// the retention window so it never expires. It would sit in an embedder's
+	// localStorage forever.
+	test('drops a future-dated breadcrumb instead of keeping it forever', () => {
+		const future = now + 60 * 60 * 1000 // clock moved back an hour since the write
+		window.localStorage.setItem(KEY, JSON.stringify({b: future, c: false}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toEqual([])
+		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
 	test('ignores a breadcrumb too old to distinguish death from suspend', () => {
 		const stale = now - 6 * 60 * 60 * 1000 // 6h, the shortest real false positive
 		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false}))

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -58,6 +58,48 @@ const capture = () => {
 	return {reports, onReport: (r: FreezeReport) => reports.push(r)}
 }
 
+// stalled returns a liveness() whose heartbeat stopped at the moment it was built.
+//
+// Most tests below need one because a live verdict now requires Go to have stalled
+// too. That is not incidental scaffolding: Go/wasm and JS share a thread, so a
+// starved timer beside a *current* heartbeat proves the thread was alive and merely
+// unscheduled — a throttled timer, not a freeze. Tests that used a bare JS gap were
+// asserting on the most common false positive in production.
+// sharedThread models the real relationship rather than a permanent wedge: Go's
+// heartbeat advances whenever the thread runs, so it is stale by exactly the gap
+// the JS timer just observed. A block stalls both and a recovery clears both.
+//
+// Use this for transient blocks. stalled() below never recovers, which is a wedged
+// runtime — a different failure, and using it for a transient block makes calm
+// intervals report go_scheduler_wedged, correctly.
+const sharedThread = () => {
+	let lastRan = now
+	return () => {
+		const wasAt = lastRan
+		// Reading this means our timer fired, so the thread is running now and Go's
+		// ticker runs with it.
+		lastRan = now
+		return {
+			goTicks: 42,
+			goLastTickMs: wasAt,
+			goStartedMs: wasAt - 60_000,
+			goIntervalMs: 1000,
+			goNowMs: now,
+		}
+	}
+}
+
+const stalled = () => {
+	const stoppedAt = now
+	return () => ({
+		goTicks: 42,
+		goLastTickMs: stoppedAt,
+		goStartedMs: stoppedAt - 60_000,
+		goIntervalMs: 1000,
+		goNowMs: stoppedAt,
+	})
+}
+
 // A healthy page must stay silent. This is the test that matters most in
 // practice: a watchdog that cries freeze during normal operation gets muted, and
 // then reports nothing when a real freeze happens.
@@ -182,7 +224,17 @@ test('does not blame Go on the punctual tick right after a block', () => {
 
 // Our timer was starved while Go kept ticking: not a full block, something
 // monopolized the task queue ahead of us.
-test('classifies a starved timer with a live Go heartbeat as js_starved', () => {
+// The single most important case, and the one this watchdog got wrong in
+// production: our timer starved while Go's heartbeat stayed current.
+//
+// That combination cannot be a freeze. The two share a thread, so a block deep
+// enough to miss our tick stalls Go's heartbeat with it — a current heartbeat is
+// therefore positive evidence the thread was running and simply not scheduling us,
+// which is what browsers do to background and offscreen documents.
+//
+// It used to report 'js_starved' here. In the field that was 16 of the first 29
+// reports, every one from an offscreen document being throttled.
+test('does not report a starved timer while Go keeps ticking', () => {
 	const {reports, onReport} = capture()
 	const wd = new FreezeWatchdog({
 		// goLastTickMs tracks the current clock, i.e. Go never stopped.
@@ -199,8 +251,11 @@ test('classifies a starved timer with a live Go heartbeat as js_starved', () => 
 
 	fireTick(FREEZE_MS + 4000)
 
-	expect(reports).toHaveLength(1)
-	expect(reports[0].kind).toBe('js_starved')
+	expect(reports).toEqual([])
+
+	// Even at throttling scale — 15 minutes is typical for an offscreen document.
+	fireTick(15 * 60 * 1000)
+	expect(reports).toEqual([])
 	wd.stop()
 })
 
@@ -239,27 +294,34 @@ test('does not report a gap spanning a hide/show cycle', () => {
 	expect(reports).toEqual([])
 
 	// ...and the very next real freeze is still caught, i.e. the gate suppresses
-	// one interval rather than latching off.
-	fireTick(FREEZE_MS + 4000)
-	expect(reports).toHaveLength(1)
-	expect(reports[0].kind).toBe('js_starved')
+	// one interval rather than latching off. A real freeze means Go stalled too.
 	wd.stop()
+
+	const second = capture()
+	const wd2 = new FreezeWatchdog({liveness: stalled(), onReport: second.onReport})
+	wd2.start()
+	fireTick(FREEZE_MS + 4000)
+	expect(second.reports).toHaveLength(1)
+	expect(second.reports[0].kind).toBe('main_thread_blocked')
+	wd2.stop()
 })
 
-// The deployed widget.wasm predates the Go heartbeat, so liveness() being absent
-// is the live configuration, not a hypothetical. JS-side detection must still work.
-test('detects a freeze with no liveness() available', () => {
+// Without a heartbeat there is nothing to corroborate a gap with, so a gap is
+// uninterpretable: a blocked thread and a throttled timer look identical. Staying
+// silent is the honest answer, and guessing is what produced the production noise.
+//
+// This used to report 'js_starved', justified by the deployed widget.wasm predating
+// the heartbeat. That justification has expired — the wasm was republished with it
+// on 2026-08-07 and every field report since carries go_stale_ms. page_died still
+// works without liveness, and it is the severe case.
+test('stays silent on a gap it cannot corroborate', () => {
 	const {reports, onReport} = capture()
 	const wd = new FreezeWatchdog({onReport})
 	wd.start()
 
 	fireTick(FREEZE_MS + 4000)
 
-	expect(reports).toHaveLength(1)
-	expect(reports[0].kind).toBe('js_starved')
-	// Nulls rather than zeros: a missing heartbeat must not read as "Go is fine".
-	expect(reports[0].goStaleMs).toBeNull()
-	expect(reports[0].goTicks).toBeNull()
+	expect(reports).toEqual([])
 	wd.stop()
 })
 
@@ -275,9 +337,10 @@ test('survives liveness() throwing', () => {
 	})
 	wd.start()
 
+	// The guarantee is that the watchdog survives; a throwing boundary yields no
+	// snapshot, so like any uncorroborated gap it produces no verdict.
 	expect(() => fireTick(FREEZE_MS + 4000)).not.toThrow()
-	expect(reports).toHaveLength(1)
-	expect(reports[0].goStaleMs).toBeNull()
+	expect(reports).toEqual([])
 	wd.stop()
 })
 
@@ -294,8 +357,11 @@ test('ignores a liveness object missing required fields', () => {
 
 	fireTick(FREEZE_MS + 4000)
 
-	expect(reports).toHaveLength(1)
-	expect(reports[0].goStaleMs).toBeNull()
+	// Treated as no snapshot at all rather than as a stalled runtime, so there is
+	// nothing to corroborate the gap and nothing is reported. The failure mode this
+	// guards against is the opposite one: reading NaN as a stalled heartbeat would
+	// turn every shape change into a flood of invented freezes.
+	expect(reports).toEqual([])
 	wd.stop()
 })
 
@@ -347,11 +413,10 @@ test('rejects non-finite numbers in a liveness snapshot', () => {
 
 	fireTick(FREEZE_MS + 4000)
 
-	expect(reports).toHaveLength(1)
-	// Treated as no snapshot at all, not as a stalled Go runtime.
-	expect(reports[0].kind).toBe('js_starved')
-	expect(reports[0].goStaleMs).toBeNull()
-	expect(reports[0].clockSkewMs).toBeNull()
+	// Treated as no snapshot at all, not as a stalled Go runtime — so no verdict.
+	// Reading Infinity as a stalled heartbeat would manufacture freezes out of a
+	// malformed field.
+	expect(reports).toEqual([])
 	wd.stop()
 })
 
@@ -421,14 +486,14 @@ test('does not let a throttled kind suppress a different kind', () => {
 // episodes, and collapsing them would hide that a page is freezing repeatedly.
 test('reports separate episodes separated by more than the suppression window', () => {
 	const {reports, onReport} = capture()
-	const wd = new FreezeWatchdog({onReport})
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
 	wd.start()
 
 	fireTick(FREEZE_MS + 1000)
 	for (let i = 0; i < 40; i++) fireTick(TICK_MS) // 80s of calm
 	fireTick(FREEZE_MS + 1000)
 
-	expect(reports.map(r => r.kind)).toEqual(['js_starved', 'js_starved'])
+	expect(reports.map(r => r.kind)).toEqual(['main_thread_blocked', 'main_thread_blocked'])
 	wd.stop()
 })
 
@@ -574,6 +639,40 @@ describe('breadcrumb recovery', () => {
 
 	// A week-old death is not news, and reporting it on every load would bury
 	// current problems.
+	// A breadcrumb far in the past is a machine that slept, not a tab that died, and
+	// the two are indistinguishable from here. The first five real page_died reports
+	// were 6.2 to 15.3 hours old — every one an overnight suspend, every one reported
+	// as a casualty. Without a ceiling this kind means "someone shut their laptop".
+	test('ignores a breadcrumb too old to distinguish death from suspend', () => {
+		const stale = now - 6 * 60 * 60 * 1000 // 6h, the shortest real false positive
+		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toEqual([])
+		// Dropped rather than kept: no later load will find it any more decipherable,
+		// and leaving it would re-litigate the same undecidable record every startup.
+		expect(window.localStorage.getItem(KEY)).toBeNull()
+		wd.stop()
+	})
+
+	// The ceiling must not swallow the case the kind exists for.
+	test('still reports a death recent enough to be a crash', () => {
+		const stale = now - 10 * 60 * 1000 // 10m: past deadTabMs, well inside the ceiling
+		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].kind).toBe('page_died')
+		expect(reports[0].recovered).toBe(false)
+		wd.stop()
+	})
+
 	test('expires records older than the retention window', () => {
 		writeCrumb({t: 'deadtab', b: now - 48 * 60 * 60 * 1000, s: now - 49 * 60 * 60 * 1000, c: false, h: false, p: false, l: null, n: null})
 
@@ -701,7 +800,7 @@ describe('breadcrumb recovery', () => {
 
 		try {
 			const {reports, onReport} = capture()
-			const wd = new FreezeWatchdog({onReport})
+			const wd = new FreezeWatchdog({liveness: stalled(), onReport})
 			expect(() => wd.start()).not.toThrow()
 			expect(() => fireTick(FREEZE_MS + 4000)).not.toThrow()
 
@@ -732,7 +831,7 @@ test('bounds retained reports', () => {
 // there guards against.
 test('start is idempotent', () => {
 	const {reports, onReport} = capture()
-	const wd = new FreezeWatchdog({onReport})
+	const wd = new FreezeWatchdog({liveness: stalled(), onReport})
 	wd.start()
 	wd.start()
 

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -71,6 +71,24 @@ const freezeMs = 8000
 // near freezeMs would report healthy background tabs as casualties.
 const deadTabMs = 5 * 60 * 1000
 
+// maxDeadTabAgeMs is the upper bound on that window, and exists because the lower
+// bound alone was wrong in production. The first five real page_died reports had
+// breadcrumbs 6.2, 9.3, 11.0, 11.0 and 15.3 hours old — closed laptops and
+// overnight suspends, reported as casualties every one.
+//
+// Past some age a stale breadcrumb stops carrying information. A tab that died and
+// a machine that slept look identical from the next page load, and the longer the
+// gap the more certainly it is the latter. Reporting them anyway does not merely
+// add noise, it inverts the signal: the benign case is far more common, so
+// page_died came to mean "someone shut their laptop".
+//
+// Half an hour keeps the case the kind exists for — a crash the user notices and
+// reloads from — and drops the case we cannot distinguish. It does mean a genuine
+// death nobody returns to for an hour is missed. That is the right trade here: a
+// missed report costs one data point, while a false one costs trust in the metric,
+// and this whole path exists because deaths were invisible *and worth finding*.
+const maxDeadTabAgeMs = 30 * 60 * 1000
+
 const storagePrefix = 'unbounded.watchdog.'
 // Bounds on the breadcrumb sweep. Records are normally deleted as they are read,
 // so these only matter when something goes wrong repeatedly and nobody reloads.
@@ -125,12 +143,27 @@ export type FreezeKind =
 	// fine, so the Go scheduler is wedged — a deadlock, or a goroutine looping
 	// without yielding.
 	| 'go_scheduler_wedged'
-	// Our timer was starved while Go kept ticking. Not a full block; something
-	// monopolized the task queue ahead of us.
+	// NO LONGER PRODUCED. Retained because it is a wire value: widgets built before
+	// 2026-08-08 still send it and the egress still counts it, so removing it from
+	// this union would only hide that.
+	//
+	// It meant "our timer was starved while Go kept ticking", and was specified as a
+	// distinct failure. It is not one. Go/wasm and JS share a thread, so a block deep
+	// enough to miss our tick also stalls Go's heartbeat — which makes this
+	// combination proof the thread was *alive* and merely not scheduling us. There is
+	// no row for it in the truth table in watchdog_wasm_impl.go, and there never
+	// should have been a kind for it here.
+	//
+	// In production it was the most common report and meant nothing: 16 of the first
+	// 29, all from an offscreen document whose timers the browser was throttling
+	// while Go stayed current to within a second.
 	| 'js_starved'
 	// Reconstructed at startup from a breadcrumb: a previous page life stopped
 	// beating and never fired pagehide. Unlike the three above, this one was never
 	// survived — see `recovered`.
+	//
+	// Bounded at both ends: too recent and it is a live tab in another window, too
+	// old and it is a machine that slept. See deadTabMs and maxDeadTabAgeMs.
 	| 'page_died'
 
 export interface FreezeReport {
@@ -490,12 +523,30 @@ export class FreezeWatchdog {
 		// neither builds nor keeps the streak.
 		this.punctualTicks = trustworthy && !jsStarved ? this.punctualTicks + 1 : 0
 
-		// jsStarved is direct evidence from our own gap and needs no corroboration.
-		// A Go-only verdict does: see minPunctualTicks.
-		const actionable = jsStarved || (goStalled && this.punctualTicks >= minPunctualTicks)
+		// Every live verdict requires Go to have stalled too. That is not caution, it
+		// is what the shared-thread model permits: Go/wasm and JS run on one thread
+		// (see the truth table in watchdog_wasm_impl.go), so a thread blocked long
+		// enough to miss our tick necessarily stalls Go's one-second heartbeat with
+		// it. A starved timer beside a current heartbeat therefore proves the thread
+		// was alive and simply not scheduling us — which is a browser throttling
+		// timers, not a freeze.
+		//
+		// This is the question `hidden` was meant to answer and could not. The widget
+		// overwhelmingly runs inside an offscreen document, where visibilityState
+		// reports 'visible' while timers are throttled exactly as in a background tab,
+		// so the visibility gate above passes. Of the first 29 real reports, 26 came
+		// from that context and 16 were this false positive — gaps of 42s to 17min
+		// against a Go heartbeat current to within a second.
+		//
+		// The cost is that a build whose wasm publishes no heartbeat gets no live
+		// detection at all, since there is then nothing to corroborate with. That is
+		// the honest outcome rather than a regression: without the heartbeat a gap is
+		// genuinely uninterpretable, and guessing is what produced the noise. page_died
+		// still works there, and it is the severe case.
+		const actionable = goStalled && (jsStarved || this.punctualTicks >= minPunctualTicks)
 
 		if (trustworthy && actionable) {
-			this.report(this.classify(jsStarved, goStalled), {
+			this.report(this.classify(jsStarved), {
 				gapMs,
 				goStaleMs,
 				goTicks: live?.goTicks ?? null,
@@ -511,10 +562,12 @@ export class FreezeWatchdog {
 		this.writeBreadcrumb(false)
 	}
 
-	private classify(jsStarved: boolean, goStalled: boolean): FreezeKind {
-		if (jsStarved && goStalled) return 'main_thread_blocked'
-		if (goStalled) return 'go_scheduler_wedged'
-		return 'js_starved'
+	// Only reached when goStalled, which tick() now requires. The two remaining
+	// verdicts are the two the shared-thread truth table actually distinguishes:
+	// our timer stalled with Go's (the thread), or ours kept time while Go's did not
+	// (the runtime).
+	private classify(jsStarved: boolean): FreezeKind {
+		return jsStarved ? 'main_thread_blocked' : 'go_scheduler_wedged'
 	}
 
 	// report takes every piece of evidence explicitly rather than reading any of it
@@ -657,6 +710,14 @@ export class FreezeWatchdog {
 			if (now - crumb.b <= deadTabMs) {
 				// Still beating recently, so this is a live tab in another window.
 				// Leave its record alone — it owns that key.
+				continue
+			}
+			if (now - crumb.b > maxDeadTabAgeMs) {
+				// Too old to mean anything. See maxDeadTabAgeMs: past this point a
+				// dead tab and a sleeping machine are the same record, and the
+				// sleeping machine is the likelier one by far. Dropped rather than
+				// kept, since no later load will find it any more decipherable.
+				safeStorage.remove(key)
 				continue
 			}
 			crumbs.push(crumb)

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -690,9 +690,31 @@ export class FreezeWatchdog {
 				safeStorage.remove(key)
 				continue
 			}
+
+			// Age is computed once and every decision below reads it, because each of
+			// those decisions is a comparison against it and three separate
+			// subtractions invite exactly one of them to disagree.
+			const ageMs = now - crumb.b
+
+			// A record stamped in the future is undecidable. The wall clock can move
+			// backwards between write and read — an NTP correction, a VM restore, a
+			// dual-boot machine, a user setting it by hand — and this runs on other
+			// people's computers, so that is a matter of time rather than a
+			// hypothetical.
+			//
+			// Dropped rather than kept, because keeping it is the one outcome with no
+			// exit: a negative age is below deadTabMs, so it reads as a live tab and is
+			// left in place, and it is also below storageTtlMs, so it never expires. The
+			// record would sit in an embedder's localStorage indefinitely — precisely
+			// the footprint this file promises not to leave on a host it is a guest on.
+			if (ageMs < 0) {
+				safeStorage.remove(key)
+				continue
+			}
+
 			// Expire before deciding: a week-old death is not news, and reporting it
 			// on every load would bury current problems.
-			if (now - crumb.b > storageTtlMs) {
+			if (ageMs > storageTtlMs) {
 				safeStorage.remove(key)
 				continue
 			}
@@ -707,12 +729,12 @@ export class FreezeWatchdog {
 				safeStorage.remove(key)
 				continue
 			}
-			if (now - crumb.b <= deadTabMs) {
+			if (ageMs <= deadTabMs) {
 				// Still beating recently, so this is a live tab in another window.
 				// Leave its record alone — it owns that key.
 				continue
 			}
-			if (now - crumb.b > maxDeadTabAgeMs) {
+			if (ageMs > maxDeadTabAgeMs) {
 				// Too old to mean anything. See maxDeadTabAgeMs: past this point a
 				// dead tab and a sleeping machine are the same record, and the
 				// sleeping machine is the likelier one by far. Dropped rather than


### PR DESCRIPTION
The watchdog shipped yesterday and the first day of real data says **90% of its reports are false positives**. 29 arrived in three hours, **26 of them from `https://embed.lantern.io/offscreen`** — which turns out to be where the widget mostly runs.

Two defects, both mine, both confirmed by field data rather than reasoning.

## 1. `js_starved` was never a real diagnosis

It meant *"our timer starved while Go kept ticking"*. `watchdog_wasm_impl.go` says why that cannot be a freeze:

> Go/wasm and JS share one thread but fail independently
>
> ```
> JS timer fires, ticks advancing    -> both healthy
> JS timer fires, ticks frozen       -> Go scheduler wedged
> JS timer does not fire at all      -> main thread blocked
> ```

**Three rows. This was never one of them.** On a shared thread, a block deep enough to miss our tick stalls Go's one-second heartbeat too — so a *current* heartbeat beside a starved timer is positive evidence the thread was alive and simply not scheduling us.

The field data is unambiguous:

```
gap_ms=53195   go_stale_ms=352
gap_ms=48197   go_stale_ms=352
gap_ms=900176  go_stale_ms=920
gap_ms=1039889 go_stale_ms=532
```

Gaps of 42s to 17min against a heartbeat current to within a second. That is a browser throttling timers in an offscreen document, doing exactly what it is supposed to. 16 of the first 29 reports.

**The visibility gate could never have caught it.** An offscreen document reports `visibilityState: 'visible'` while being throttled like a background tab — every one of the 29 reports had `hidden=false`. Live verdicts now require Go to have stalled too, which is the signal that answers the actual question. The kind stays in the union because it is a wire value older widgets still send and the egress still counts.

## 2. `page_died` had a floor and no ceiling

The first five real ones had breadcrumbs **6.2, 9.3, 11.0, 11.0 and 15.3 hours** old. Overnight suspends, every one, reported as casualties.

A tab that died and a machine that slept are the same record from the next page load, and the longer the gap the more certainly it is the latter. Past 30 minutes we stop guessing. This does mean a genuine death nobody returns to for an hour is missed — that costs one data point, where a false one costs trust in the whole metric.

## Consequence worth stating plainly

A build whose wasm publishes no heartbeat now gets **no live detection**, because there is nothing to corroborate a gap with. The old tests justified reporting bare gaps on the grounds that the deployed wasm predated the heartbeat — that expired when it was republished on 2026-08-07, and every field report since carries `go_stale_ms`. `page_died` still works without liveness, and it is the severe case.

## Tests

**Eight tests asserted that a bare JS gap produces a report** — they were asserting on the false positive itself, which is how it shipped. Rewritten against a stalled heartbeat.

Added a `sharedThread` fixture alongside `stalled`, because the distinction bites: a permanently frozen heartbeat is a *wedged runtime*, so using it for a transient block correctly reports `go_scheduler_wedged` during the calm between episodes. That failure was the fixture being wrong, not the code.

All six behavior changes verified to fail against the old code:

```
✕ does not report a starved timer while Go keeps ticking
✕ stays silent on a gap it cannot corroborate
✕ survives liveness() throwing
✕ ignores a liveness object missing required fields
✕ rejects non-finite numbers in a liveness snapshot
✕ ignores a breadcrumb too old to distinguish death from suspend
```

36/36 pass with the fix. `tsc --noEmit` clean.

## Blocks the freeze alerting

The deferred freeze-report alerts cannot be built on the current data — a threshold fitted to it would be fitted to browser throttling. Once this ships, the metric needs a fresh baseline; the reports already collected should be discarded rather than used, along with the three synthetic `.invalid` ones from deploy verification.

## Review round 1

**Copilot: a future-dated breadcrumb is never decided and never removed.** Correct, and worse than it first reads. A negative age is `<= deadTabMs`, so it takes the live-tab branch and `continue`s *without removing the key* — and it is also `<= storageTtlMs`, so the expiry check never reclaims it either. The record survives every startup until the wall clock passes it.

That matters more here than it would elsewhere: this file executes in the **embedder's origin**, and its header promises the opposite two paragraphs in — *"the footprint on a host we are a guest on should stay small and self-cleaning"*. An immortal key is the one outcome that promise rules out. The trigger isn't exotic either — clocks move backwards on real machines via NTP corrections, VM restores, dual-boot and manual changes, and this runs on other people's computers rather than servers we keep in sync.

Fixed as suggested: `ageMs` computed once, negative treated as undecidable and dropped, with the remaining comparisons routed through it so three subtractions stop being three chances to disagree. Test verified to fail against the previous code. 37/37 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3
