### PR TITLE
ui: stop reporting parked processes as main-thread blocks

### DIFF
--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -360,6 +360,32 @@ test('does not carry the freeze latch across a re-arm', () => {
 	wd.stop()
 })
 
+// Copilot's round-2 finding, and a bug that predates this PR: onVisibilityChange only
+// latches on the transition *to* hidden, so an interval that BEGINS hidden started with
+// a false latch and had its throttled gap judged as if the tab were visible throughout.
+//
+// Reachable from every caller of the reset: start() on a background tab, a bfcache
+// restore into one, and a Page Lifecycle resume, which commonly resumes still-hidden.
+// Fixed by seeding the latch from current visibility rather than clearing it.
+test('does not report a throttled gap when the interval began hidden', () => {
+	const {reports, onReport} = capture()
+	visibility = 'hidden'
+
+	// Arms while already hidden, so nothing ever fires visibilitychange.
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	// A minute of throttling, then the user comes back. Under maxBlockMs, so this
+	// proves the visibility seeding rather than the size ceiling.
+	advance(60_000)
+	visibility = 'visible'
+	document.dispatchEvent(new Event('visibilitychange'))
+	fireTick(2000)
+
+	expect(reports).toEqual([])
+	wd.stop()
+})
+
 // Background tabs have their timers throttled to roughly one per minute, so a
 // hidden tab produces gaps far beyond FREEZE_MS while being perfectly healthy.
 // Reporting those would make the signal useless — most donor tabs sit in the

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -312,6 +312,54 @@ test('does not report a gap spanning a Page Lifecycle freeze', () => {
 	wd.stop()
 })
 
+// CodeRabbit's finding on #411: onResume resets the timing baseline, so the next gap
+// no longer spans the freeze — but the latch stayed set and suppressed that interval
+// anyway. The tick right after a thaw is a plausible place for a real block, since a
+// resuming page often has catch-up work.
+test('reports a block in the first interval after a resume', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	document.dispatchEvent(new Event('freeze'))
+	advance(10 * 60 * 1000) // frozen for ten minutes
+	document.dispatchEvent(new Event('resume'))
+
+	// A genuine block, measured entirely after the resume reset the baseline.
+	fireTick(20_000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('main_thread_blocked')
+	// And the gap is the post-resume interval, not the frozen stretch.
+	expect(reports[0].gapMs).toBeLessThan(60_000)
+	wd.stop()
+})
+
+// Copilot's finding on the same PR, and the same root cause seen from the other side:
+// the latch was cleared only in tick(), so a re-arm between a freeze and the next tick
+// carried it into the following interval. armTimer() already reset the sibling latch.
+//
+// Driven through pagehide/pageshow on ONE instance, which is the path that actually
+// occurs: the watchdog is a per-page singleton, so a fresh object cannot carry stale
+// state and a test that built one would pass no matter what the code did.
+test('does not carry the freeze latch across a re-arm', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	// Frozen, then cached and restored before any tick consumes the latch.
+	document.dispatchEvent(new Event('freeze'))
+	window.dispatchEvent(new Event('pagehide'))
+	advance(10 * 60 * 1000)
+	window.dispatchEvent(new Event('pageshow'))
+
+	fireTick(20_000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('main_thread_blocked')
+	wd.stop()
+})
+
 // Background tabs have their timers throttled to roughly one per minute, so a
 // hidden tab produces gaps far beyond FREEZE_MS while being perfectly healthy.
 // Reporting those would make the signal useless — most donor tabs sit in the

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -259,6 +259,59 @@ test('does not report a starved timer while Go keeps ticking', () => {
 	wd.stop()
 })
 
+// The third false-positive class, and the one no clock comparison can catch. When a
+// laptop sleeps or Chrome parks a backgrounded page, our timer and Go's heartbeat
+// stop together and resume together — which is precisely the fingerprint of a real
+// main-thread block. Only the magnitude separates them.
+//
+// Modeled on the field data: 48 of 59 sampled reports were 13-17 minute gaps with
+// gap and goStale within ~1.5s of each other, against 11 real blocks of 10-45s.
+test('does not report a gap that parked the whole context', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	// 15 minutes, the median of the suspended cluster. sharedThread stalls Go by the
+	// same gap, so this is indistinguishable from a block except by size.
+	fireTick(15 * 60 * 1000)
+
+	expect(reports).toEqual([])
+	wd.stop()
+})
+
+// ...and the ceiling must not swallow a real block, which is the whole point of
+// putting it in the empty band between the two populations rather than near either.
+test('still reports a block short enough to be one', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	// 45s: the longest real block observed in the field, well under the 2min ceiling.
+	fireTick(45_000)
+
+	expect(reports).toHaveLength(1)
+	expect(reports[0].kind).toBe('main_thread_blocked')
+	wd.stop()
+})
+
+// Chrome fires 'freeze' when it parks a backgrounded page outright. Such a page runs
+// nothing at all, so the gap is meaningless — but by the time we tick again it is
+// thawed and looks entirely normal, which is why the event has to be latched.
+test('does not report a gap spanning a Page Lifecycle freeze', () => {
+	const {reports, onReport} = capture()
+	const wd = new FreezeWatchdog({liveness: sharedThread(), onReport})
+	wd.start()
+
+	document.dispatchEvent(new Event('freeze'))
+	// Deliberately under maxBlockMs, so this proves the freeze gate rather than the
+	// size ceiling — the two guards are independent and browsers without Page
+	// Lifecycle rely on the ceiling alone.
+	fireTick(30_000)
+
+	expect(reports).toEqual([])
+	wd.stop()
+})
+
 // Background tabs have their timers throttled to roughly one per minute, so a
 // hidden tab produces gaps far beyond FREEZE_MS while being perfectly healthy.
 // Reporting those would make the signal useless — most donor tabs sit in the

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -65,6 +65,32 @@ const tickMs = 2000
 // point is to catch what a user would call a freeze, not every long frame.
 const freezeMs = 8000
 
+// maxBlockMs is the longest gap still worth calling a block rather than a parked
+// process, and it closes the last of the three false-positive classes this
+// watchdog shipped with.
+//
+// The other two were asymmetric — one clock stopped and the other did not — so
+// comparing them separated signal from noise. This one is symmetric: when a laptop
+// sleeps, or Chrome freezes a backgrounded page, the whole context stops, so our
+// timer and Go's heartbeat stall together and resume together. That is exactly the
+// fingerprint of a genuine main-thread block, and no comparison between the two can
+// tell them apart. Only the magnitude can.
+//
+// Measured over six hours, the split was clean and bimodal: 11 gaps between 10.5s
+// and 45.2s, then 48 clustered at 13-17 minutes with gap and goStale within ~1.5s
+// of each other. Nothing in between. The upper cluster is not a thread blocked for
+// a quarter of an hour, which is not a thing that happens and recovers; it is a
+// process that was not running.
+//
+// Two minutes sits in the empty band — 2.6x above the longest observed real block,
+// 6x below the shortest observed suspension — deliberately not tight against either
+// edge, because a threshold fitted to one day of data is how the donor-wedge alert
+// ended up firing twice on ordinary variation.
+//
+// A page genuinely wedged for longer than this is missed. It is also, from here,
+// indistinguishable from a closed lid.
+const maxBlockMs = 2 * 60 * 1000
+
 // deadTabMs is how stale a breadcrumb must be before startup calls that tab dead.
 // Much larger than freezeMs on purpose: a *live* tab in another window that has
 // been backgrounded is throttled to roughly one timer per minute, so anything
@@ -336,6 +362,11 @@ export class FreezeWatchdog {
 	// alone would miss it: the tab is visible again by then, but the gap it
 	// produced was throttling, not a freeze.
 	private hiddenSinceLastTick = false
+	// frozenSinceLastTick is the same idea for the Page Lifecycle 'freeze' event,
+	// which fires when the browser parks a backgrounded page outright. Unlike being
+	// hidden, a frozen page runs nothing at all — including Go — so the gap it
+	// produces is invisible to every other check here. See maxBlockMs.
+	private frozenSinceLastTick = false
 	private longestTaskMs: number | null = null
 	private longestTaskName: string | null = null
 	// Consecutive on-time ticks, i.e. how much evidence we have that the thread is
@@ -366,6 +397,11 @@ export class FreezeWatchdog {
 
 		this.observeLongTasks()
 		document.addEventListener('visibilitychange', this.onVisibilityChange)
+		// Page Lifecycle. Not universally supported — Chrome fires these, Safari and
+		// Firefox largely do not — which is why maxBlockMs backstops it rather than
+		// this being the only guard.
+		document.addEventListener('freeze', this.onFreeze)
+		document.addEventListener('resume', this.onResume)
 		// pagehide rather than unload: unload does not fire reliably on mobile
 		// Safari, and treating a normal navigation as a death would drown the real
 		// signal in false positives.
@@ -381,6 +417,8 @@ export class FreezeWatchdog {
 		this.observer?.disconnect()
 		this.observer = undefined
 		document.removeEventListener('visibilitychange', this.onVisibilityChange)
+		document.removeEventListener('freeze', this.onFreeze)
+		document.removeEventListener('resume', this.onResume)
 		window.removeEventListener('pagehide', this.onPageHide)
 		window.removeEventListener('pageshow', this.onPageShow)
 		// An explicit stop is a clean exit; leaving the record un-flagged would
@@ -468,6 +506,22 @@ export class FreezeWatchdog {
 		if (document.visibilityState !== 'visible') this.hiddenSinceLastTick = true
 	}
 
+	// A frozen page is not running, so the gap across a freeze is the browser parking
+	// us rather than anything failing. Latched the same way as the visibility gate,
+	// because by the time we tick again the page is thawed and nothing else says it
+	// ever stopped.
+	private onFreeze = (): void => {
+		this.frozenSinceLastTick = true
+	}
+
+	// 'resume' carries no gap information on its own — the next tick measures it —
+	// but the baseline has to be reset here, or that tick reports the whole frozen
+	// stretch as one enormous gap.
+	private onResume = (): void => {
+		this.lastTickAt = Date.now()
+		this.punctualTicks = 0
+	}
+
 	private onPageHide = (): void => {
 		// Mark the exit clean so the next load does not mistake this navigation for
 		// a death. This is the one write that must not be skipped.
@@ -505,7 +559,22 @@ export class FreezeWatchdog {
 		// A tab that was hidden at any point since the last tick had its timers
 		// throttled, so its gap says nothing about freezing. Reset the baselines
 		// and wait for a clean interval rather than reporting throttling as a bug.
-		const trustworthy = !hidden && !this.hiddenSinceLastTick
+		//
+		// A gap spanning a Page Lifecycle freeze is the same story with a stronger
+		// cause: the page was not running at all, so nothing about the interval is
+		// evidence of anything. Latched at the event because by tick time the page is
+		// thawed and looks entirely normal.
+		const frozen = this.frozenSinceLastTick
+		this.frozenSinceLastTick = false
+
+		// gapMs beyond maxBlockMs is a parked process, not a blocked thread. This has
+		// to be judged on magnitude alone: when the whole context stops, our clock and
+		// Go's stop together, which is byte-for-byte the fingerprint of a real block.
+		// It is the backstop for every case the freeze event misses — OS sleep, and
+		// browsers that do not implement Page Lifecycle at all.
+		const parked = gapMs > maxBlockMs
+
+		const trustworthy = !hidden && !this.hiddenSinceLastTick && !frozen && !parked
 		this.hiddenSinceLastTick = false
 
 		const live = this.readLiveness()

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -433,21 +433,27 @@ export class FreezeWatchdog {
 	private armTimer(): void {
 		this.lastTickAt = Date.now()
 		this.punctualTicks = 0
-		this.clearIntervalLatches()
+		this.resetIntervalLatches()
 		this.writeBreadcrumb(false)
 		this.timer = setInterval(this.tick, tickMs)
 	}
 
-	// clearIntervalLatches drops both "something happened since the last tick" flags.
+	// resetIntervalLatches re-seeds both "something happened since the last tick" flags
+	// for the interval starting now.
 	//
-	// They exist as a pair and must be cleared as a pair, which is exactly what went
+	// They exist as a pair and must be maintained as a pair, which is exactly what went
 	// wrong when the freeze latch was added: hiddenSinceLastTick was already reset in
-	// three places and the new flag only in one, so it survived a stop/start cycle and
-	// a pageshow, and poisoned the first interval afterwards. Both reviewers found a
-	// different symptom of it. A single method is the cheapest way to stop the next
-	// latch from diverging the same way.
-	private clearIntervalLatches(): void {
-		this.hiddenSinceLastTick = false
+	// three places and the new flag only in one, so it survived a re-arm and poisoned
+	// the interval afterwards.
+	//
+	// Note it SEEDS rather than clears. onVisibilityChange only latches on the
+	// transition *to* hidden, so a page that is already hidden when an interval begins
+	// would otherwise start with a false latch and have its throttled gap judged as if
+	// the tab had been visible throughout. That is reachable from every caller: start()
+	// on a background tab, a bfcache restore into one, and a Page Lifecycle resume,
+	// which commonly resumes still-hidden.
+	private resetIntervalLatches(): void {
+		this.hiddenSinceLastTick = document.visibilityState !== 'visible'
 		this.frozenSinceLastTick = false
 	}
 
@@ -542,7 +548,7 @@ export class FreezeWatchdog {
 		//
 		// The latch still protects the freeze-without-resume case: nothing clears it
 		// until either this handler or the next tick runs.
-		this.clearIntervalLatches()
+		this.resetIntervalLatches()
 	}
 
 	private onPageHide = (): void => {
@@ -591,7 +597,7 @@ export class FreezeWatchdog {
 		// assigning the other separately is what allowed them to drift apart.
 		const frozen = this.frozenSinceLastTick
 		const hiddenSince = this.hiddenSinceLastTick
-		this.clearIntervalLatches()
+		this.resetIntervalLatches()
 
 		// gapMs beyond maxBlockMs is a parked process, not a blocked thread. This has
 		// to be judged on magnitude alone: when the whole context stops, our clock and

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -433,9 +433,22 @@ export class FreezeWatchdog {
 	private armTimer(): void {
 		this.lastTickAt = Date.now()
 		this.punctualTicks = 0
-		this.hiddenSinceLastTick = false
+		this.clearIntervalLatches()
 		this.writeBreadcrumb(false)
 		this.timer = setInterval(this.tick, tickMs)
+	}
+
+	// clearIntervalLatches drops both "something happened since the last tick" flags.
+	//
+	// They exist as a pair and must be cleared as a pair, which is exactly what went
+	// wrong when the freeze latch was added: hiddenSinceLastTick was already reset in
+	// three places and the new flag only in one, so it survived a stop/start cycle and
+	// a pageshow, and poisoned the first interval afterwards. Both reviewers found a
+	// different symptom of it. A single method is the cheapest way to stop the next
+	// latch from diverging the same way.
+	private clearIntervalLatches(): void {
+		this.hiddenSinceLastTick = false
+		this.frozenSinceLastTick = false
 	}
 
 	private clearTimer(): void {
@@ -520,6 +533,16 @@ export class FreezeWatchdog {
 	private onResume = (): void => {
 		this.lastTickAt = Date.now()
 		this.punctualTicks = 0
+		// And drop the freeze latch, because resetting the baseline above has already
+		// dealt with the frozen stretch: the next gap is measured from now, so it does
+		// not span the freeze and there is nothing left to discount. Keeping the latch
+		// set would suppress one legitimate interval — and the interval right after a
+		// thaw is a plausible place for a real block, since a resuming page often has
+		// catch-up work to do.
+		//
+		// The latch still protects the freeze-without-resume case: nothing clears it
+		// until either this handler or the next tick runs.
+		this.clearIntervalLatches()
 	}
 
 	private onPageHide = (): void => {
@@ -564,8 +587,11 @@ export class FreezeWatchdog {
 		// cause: the page was not running at all, so nothing about the interval is
 		// evidence of anything. Latched at the event because by tick time the page is
 		// thawed and looks entirely normal.
+		// Snapshot both latches, then clear both together. Reading one inline and
+		// assigning the other separately is what allowed them to drift apart.
 		const frozen = this.frozenSinceLastTick
-		this.frozenSinceLastTick = false
+		const hiddenSince = this.hiddenSinceLastTick
+		this.clearIntervalLatches()
 
 		// gapMs beyond maxBlockMs is a parked process, not a blocked thread. This has
 		// to be judged on magnitude alone: when the whole context stops, our clock and
@@ -574,8 +600,7 @@ export class FreezeWatchdog {
 		// browsers that do not implement Page Lifecycle at all.
 		const parked = gapMs > maxBlockMs
 
-		const trustworthy = !hidden && !this.hiddenSinceLastTick && !frozen && !parked
-		this.hiddenSinceLastTick = false
+		const trustworthy = !hidden && !hiddenSince && !frozen && !parked
 
 		const live = this.readLiveness()
 		// Go stamps goLastTickMs with Date.now() from inside wasm specifically so it


### PR DESCRIPTION
Third and last false-positive class from the first day of real data. #410 removed the throttled-timer reports; with those gone, `main_thread_blocked` became the dominant kind at **50–100/hr**, and roughly **80% of it is laptops sleeping**.

## Why this one needed a different kind of fix

The previous two were **asymmetric** — one clock stopped and the other kept going — so comparing them separated signal from noise. This one is **symmetric**. When the whole context is parked, our timer and Go's heartbeat stop together and resume together, which is byte-for-byte the fingerprint of a genuine block:

```
gap=1035621 gostale=1034534
gap=1032134 gostale=1030561
gap=1029732 gostale=1028310
```

No comparison between the two can tell them apart. Only the magnitude can.

## The data is bimodal with nothing in between

Six hours, 59 sampled `main_thread_blocked` reports:

| | |
|---|---|
| real blocks | 11 gaps, **10.5s – 45.2s** |
| parked processes | 48 gaps, **13 – 17 min**, `gap ≈ goStale` |
| p50 | 13.9 min |

A thread is not blocked for a quarter of an hour and then fine.

## Two guards

**Page Lifecycle `freeze`/`resume`** — Chrome fires these when it parks a backgrounded page outright. Latched at the event like the visibility gate, because by the next tick the page is thawed and looks entirely normal.

**`maxBlockMs = 2min`** — the backstop for everything that event misses: OS sleep, and Safari/Firefox, which largely do not implement Page Lifecycle. Independent of the first guard on purpose, and the tests exercise them separately.

Two minutes sits in the **empty band** — 2.6× above the longest real block, 6× below the shortest suspension. Deliberately not tight against either edge: a threshold fitted to one day of data is exactly how the donor-wedge alert ended up firing twice on ordinary variation, and that mistake is two days old.

The cost is a page genuinely wedged for over two minutes, which from here is indistinguishable from a closed lid anyway.

## Tests

Three added; the two guards verified independently, both failing against the old code:

```
✕ does not report a gap that parked the whole context
✕ does not report a gap spanning a Page Lifecycle freeze
```

Plus `still reports a block short enough to be one` at 45s — the longest real block observed — so the ceiling is proven not to swallow the signal it is protecting.

40/40 pass. `tsc --noEmit` clean.

## After this

`freeze-reports` needs a third fresh baseline. Everything collected so far is some mix of throttled timers, sleeping laptops and my three synthetic `.invalid` probes; the residual real signal is roughly 11 blocks per 6 hours across the fleet. The deferred freeze alerting should be built on data from after this ships, not before.

## Review round 1

Both reviewers found **the same defect from opposite ends**, which is a fair verdict on the change: I added `frozenSinceLastTick` as a second per-interval latch and cleared it only in `tick()`, while its sibling `hiddenSinceLastTick` was already cleared in three places.

- **CodeRabbit** — `onResume` resets `lastTickAt`, so the next gap no longer spans the freeze; the latch had nothing left to discount and was suppressing a legitimate interval. The tick right after a thaw is a plausible place for a real block, since a resuming page often has catch-up work.
- **Copilot** — the latch survived a re-arm. Wider than the `stop()` case it cited: `onPageShow` → `armTimer()` is the path that actually happens, since the watchdog is a per-page singleton and every bfcache restore re-arms it.

Fixed the cause rather than the two symptoms. Both latches now go through `clearIntervalLatches()`, and `tick()` snapshots both and clears both together instead of reading one inline and assigning the other separately — the asymmetry that let them drift. The freeze-without-resume case still holds: nothing clears the latch until `onResume` or the next tick runs.

**My first version of the restart test was worthless.** It built a second `FreezeWatchdog`, and `frozenSinceLastTick` is an instance field — a fresh object always starts clean, so the assertion passed against the broken code. Rewritten to drive `pagehide`/`pageshow` on one instance. Both tests verified to fail against the pre-review code; 42/42 pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved freeze and resume handling to avoid false alerts when the app is suspended or parked.
  * Large gaps caused by background suspension are now ignored, while genuine main-thread blocks continue to be reported.
  * Added support for Page Lifecycle freeze events to suppress inaccurate follow-up reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
