### PR TITLE
clientcore: make worker teardown cancellable and bound the engine stop wait

### DIFF
--- a/clientcore/broflake.go
+++ b/clientcore/broflake.go
@@ -23,6 +23,10 @@ type BroflakeEngine struct {
 	netstateStop      chan struct{}
 	ctx               context.Context
 	cancel            context.CancelFunc
+	// stopGrace bounds how long stop() waits for workers before cancelling the
+	// engine ctx anyway. Per-engine rather than a package var so tests can shorten
+	// it without racing a concurrent stop().
+	stopGrace time.Duration
 }
 
 func NewBroflakeEngine(cTable, pTable *WorkerTable, ui UI, wg *sync.WaitGroup, netstated, tag string) *BroflakeEngine {
@@ -36,6 +40,7 @@ func NewBroflakeEngine(cTable, pTable *WorkerTable, ui UI, wg *sync.WaitGroup, n
 		tag:               tag,
 		netstateHeartbeat: time.Minute,
 		netstateStop:      make(chan struct{}),
+		stopGrace:         defaultStopGrace,
 		ctx:               ctx,
 		cancel:            cancel,
 	}
@@ -77,16 +82,34 @@ func (b *BroflakeEngine) start() {
 	}
 }
 
+// defaultStopGrace bounds how long stop() waits for workers to exit before
+// cancelling the engine ctx regardless. Generous enough for a worker to finish a
+// state (the longest state timeout is NATFailTimeout, 5s).
+const defaultStopGrace = 10 * time.Second
+
 func (b *BroflakeEngine) stop() {
 	b.cTable.Stop()
 	b.pTable.Stop()
 
 	go func() {
-		b.wg.Wait()
+		// Prefer cancelling the engine ctx only after workers exit: some worker states
+		// block on com.tx sends, and stopping the routers earlier can strand a worker on
+		// a full buffer. But that wait must be bounded — a worker parked in an unguarded
+		// com.tx send never returns, and without a deadline wg.Wait() would hold the
+		// engine ctx, and therefore the bus, both routers and every other worker, for the
+		// lifetime of the process. Every re-create then leaks a whole stack.
+		waited := make(chan struct{})
+		go func() {
+			b.wg.Wait()
+			close(waited)
+		}()
+		select {
+		case <-waited:
+		case <-time.After(b.stopGrace):
+			slog.Debug("Broflake stop: workers did not exit before deadline, cancelling anyway",
+				"grace", b.stopGrace)
+		}
 
-		// Cancel the engine ctx only after workers exit. Some worker states block on com.tx
-		// sends, and stopping routers earlier can strand a worker on a full buffer and hang
-		// wg.Wait.
 		b.cancel()
 
 		if b.netstated != "" {

--- a/clientcore/consumer.go
+++ b/clientcore/consumer.go
@@ -50,7 +50,9 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			slog.Debug("Consumer state 0, constructing RTCPeerConnection...")
 
 			// We're resetting this slot, so send a nil path assertion IPC message
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}) {
+				return 0, input
+			}
 
 			// Populate the STUN cache if necessary
 			if scache.size() == 0 {
@@ -556,7 +558,9 @@ func NewConsumerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			// Send a path assertion IPC message representing the connectivity now provided by this slot
 			// TODO: post-MVP we shouldn't be hardcoding (*, 1) here...
 			allowAll := []common.Endpoint{{Host: "*", Distance: 1}}
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}) {
+				return 0, input
+			}
 
 			// Inbound from datachannel (widget → us) and outbound
 			// (us → widget) counters. One-second summaries follow so

--- a/clientcore/egress_consumer.go
+++ b/clientcore/egress_consumer.go
@@ -24,7 +24,9 @@ func NewEgressConsumerWebSocket(options *EgressOptions, wg *sync.WaitGroup) *Wor
 				Debug("Egress consumer state 0, opening WebSocket connection...")
 
 			// We're resetting this slot, so send a nil path assertion IPC message
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}) {
+				return 0, input
+			}
 
 			// TODO: interesting quirk here: if the table router which manages this WorkerFSM implements
 			// non-multiplexed just-in-time strategy wherein it creates a new websocket connection for
@@ -66,7 +68,9 @@ func NewEgressConsumerWebSocket(options *EgressOptions, wg *sync.WaitGroup) *Wor
 			// Send a path assertion IPC message representing the connectivity now provided by this slot
 			// TODO: post-MVP we shouldn't be hardcoding (*, 1) here...
 			allowAll := []common.Endpoint{{Host: "*", Distance: 1}}
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{Allow: allowAll}}) {
+				return 0, input
+			}
 
 			// WebSocket read loop:
 			readStatus := make(chan error)

--- a/clientcore/jit_egress_consumer.go
+++ b/clientcore/jit_egress_consumer.go
@@ -26,9 +26,11 @@ func NewJITEgressConsumer(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM
 			// downstream table that resources are available, and that they should begin offering connectivity
 			// opportunities. The differing syntax is just to help humans grok the system behavior.
 			allUponReq := common.Endpoint{Host: "$", Distance: 1}
-			com.tx <- IPCMsg{
+			if !sendCtx(ctx, com.tx, IPCMsg{
 				IpcType: PathAssertionIPC,
 				Data:    common.PathAssertion{Allow: []common.Endpoint{allUponReq}},
+			}) {
+				return 0, input
 			}
 
 			// Now we wait for a ConsumerInfo IPC message from the corresponding downstream worker indicating
@@ -46,9 +48,11 @@ func NewJITEgressConsumer(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM
 						// assertion, as a means to signal to downstream workers that there's no connectivity
 						// opportunity while also disambiguating from a nil path assertion. It's wacky and
 						// should be cleaned up here: https://github.com/getlantern/engineering/issues/2402
-						com.tx <- IPCMsg{
+						if !sendCtx(ctx, com.tx, IPCMsg{
 							IpcType: PathAssertionIPC,
 							Data:    common.PathAssertion{Allow: []common.Endpoint{allUponReq}, JITUnavailable: true},
+						}) {
+							return 0, input
 						}
 						consumerInfoMsg = msg.Data.(common.ConsumerInfo)
 						break waitforconsumerloop
@@ -96,7 +100,9 @@ func NewJITEgressConsumer(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM
 				slog.Debug("Couldn't connect to egress server", "addr", options.Addr, "error", err)
 
 				// We're resetting this slot, so send a nil path assertion
-				com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+				if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}) {
+					return 0, []interface{}{}
+				}
 
 				<-time.After(options.ErrorBackoff)
 				return 0, []interface{}{}
@@ -225,7 +231,9 @@ func NewJITEgressConsumer(options *EgressOptions, wg *sync.WaitGroup) *WorkerFSM
 			}
 
 			// We're resetting this slot, so send a nil path assertion
-			com.tx <- IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC, Data: common.PathAssertion{}}) {
+				return 0, []interface{}{}
+			}
 			return 0, []interface{}{}
 		}),
 	})

--- a/clientcore/producer.go
+++ b/clientcore/producer.go
@@ -132,7 +132,9 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			// We find out by sending an ConnectivityCheckIPC message, which asks the process responsible
 			// for path assertions to send a message reflecting the current state of our path assertion.
 			// If yes, we can proceed right now! If no, just wait for the next non-nil path assertion message...
-			com.tx <- IPCMsg{IpcType: ConnectivityCheckIPC}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: ConnectivityCheckIPC}) {
+				return 0, input
+			}
 
 			for {
 				select {
@@ -574,9 +576,11 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			slog.Debug("Producer state 5...")
 
 			// Announce the new connectivity situation for this slot
-			com.tx <- IPCMsg{
+			if !sendCtx(ctx, com.tx, IPCMsg{
 				IpcType: ConsumerInfoIPC,
 				Data:    common.ConsumerInfo{Addr: remoteAddr, Tag: offer.Tag, SessionID: consumerSessionID, Country: offer.Country},
+			}) {
+				return 0, input
 			}
 
 			// Inbound from datachannel (consumer → widget) and outbound
@@ -674,7 +678,9 @@ func NewProducerWebRTC(options *WebRTCOptions, wg *sync.WaitGroup) *WorkerFSM {
 			peerConnection.Close() // TODO: there's an err we should handle here
 
 			// We've reset this slot, so announce the nil connectivity situation
-			com.tx <- IPCMsg{IpcType: ConsumerInfoIPC, Data: common.ConsumerInfo{}}
+			if !sendCtx(ctx, com.tx, IPCMsg{IpcType: ConsumerInfoIPC, Data: common.ConsumerInfo{}}) {
+				return 0, input
+			}
 			return 0, []interface{}{}
 		}),
 	})

--- a/clientcore/protocol.go
+++ b/clientcore/protocol.go
@@ -97,6 +97,14 @@ func closeWorkerResource(input []any) {
 // On false the caller must return without clearing its input, so the FSM's exit
 // path can still close any resource that input carries.
 func sendCtx(ctx context.Context, ch chan<- IPCMsg, msg IPCMsg) bool {
+	// Check cancellation before the select. When both cases are ready — a cancelled
+	// ctx and a buffer with room — select picks pseudo-randomly, so without this an
+	// already-cancelled worker could still enqueue a control-plane message during
+	// teardown.
+	if ctx.Err() != nil {
+		return false
+	}
+
 	select {
 	case ch <- msg:
 		return true

--- a/clientcore/protocol.go
+++ b/clientcore/protocol.go
@@ -29,10 +29,17 @@ type WorkerFSM struct {
 
 // Construct a new WorkerFSM
 func NewWorkerFSM(wg *sync.WaitGroup, states []FSMstate) *WorkerFSM {
+	// ctx/cancel are initialized here, not at the top of Start()'s goroutine, so a
+	// Stop() that beats the goroutine still cancels instead of reading a nil
+	// cancel and no-op'ing (or panicking). Same reasoning as NewQUICLayer — do not
+	// move this write back into the goroutine.
+	ctx, cancel := context.WithCancel(context.Background())
 	fsm := WorkerFSM{
-		com:   newIpcChan(workerBufferSz),
-		state: states,
-		wg:    wg,
+		com:    newIpcChan(workerBufferSz),
+		state:  states,
+		wg:     wg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 
 	return &fsm
@@ -50,7 +57,6 @@ func (fsm *WorkerFSM) Start() {
 			}
 		}()
 		slog.Debug("Starting WorkerFSM...")
-		fsm.ctx, fsm.cancel = context.WithCancel(context.Background())
 
 		for {
 			select {
@@ -78,8 +84,34 @@ func closeWorkerResource(input []any) {
 	}
 }
 
+// sendCtx sends msg on ch, abandoning the send if ctx is cancelled first, and
+// reports whether the send happened.
+//
+// Control-plane messages must go through this rather than a bare `ch <- msg`. A
+// bare send on a full buffer whose drain has already been torn down never returns,
+// so the state never returns, the FSM never reaches its ctx.Done() check, and its
+// wg.Done() never runs — which blocks BroflakeEngine.stop() and strands the whole
+// stack. Data-plane sends are deliberately different: they use a non-blocking send
+// with a default case, dropping chunks rather than waiting.
+//
+// On false the caller must return without clearing its input, so the FSM's exit
+// path can still close any resource that input carries.
+func sendCtx(ctx context.Context, ch chan<- IPCMsg, msg IPCMsg) bool {
+	select {
+	case ch <- msg:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // Stop this WorkerFSM (takes effect upon returning from the currently executing state)
 func (fsm *WorkerFSM) Stop() {
+	// Guard the struct-literal case: a WorkerFSM not built via NewWorkerFSM has a
+	// nil cancel, and calling it panics.
+	if fsm.cancel == nil {
+		return
+	}
 	fsm.cancel()
 }
 

--- a/clientcore/worker_stop_test.go
+++ b/clientcore/worker_stop_test.go
@@ -1,0 +1,221 @@
+package clientcore
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Teardown tests for the worker/engine stop path. A worker that cannot be
+// cancelled while blocked on a control-plane send strands its wg.Done(), which
+// blocks BroflakeEngine.stop() and retains the bus, both routers and every other
+// worker for the process lifetime — so each re-create of an outbound built on
+// broflake accumulates a whole stack.
+//
+// These use synthetic FSM states rather than a real NewBroflake so nothing touches
+// STUN, freddie or an egress server.
+
+// sendCtxState models a control-plane send written the way the states must write
+// it: abandonable via ctx.
+func sendCtxState(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+	if !sendCtx(ctx, com.tx, IPCMsg{IpcType: PathAssertionIPC}) {
+		return 0, input
+	}
+	return 0, nil
+}
+
+// wedgedState blocks unabandonably, standing in for any future unguarded blocking
+// operation. Used only to prove stop() stays bounded regardless.
+func wedgedState(ctx context.Context, com *ipcChan, input []interface{}) (int, []interface{}) {
+	com.tx <- IPCMsg{IpcType: PathAssertionIPC}
+	return 0, nil
+}
+
+// fillTx saturates the worker's tx buffer so the next send on it blocks — the
+// state a worker is left in when its drain is torn down before the engine stops.
+func fillTx(t *testing.T, fsm *WorkerFSM) {
+	t.Helper()
+	for i := 0; i < cap(fsm.com.tx); i++ {
+		select {
+		case fsm.com.tx <- IPCMsg{IpcType: ChunkIPC}:
+		default:
+			t.Fatalf("tx buffer full after %d of %d sends", i, cap(fsm.com.tx))
+		}
+	}
+}
+
+func waitWg(wg *sync.WaitGroup, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// TestNewWorkerFSMInitializesCtx is the WorkerFSM counterpart of
+// TestQUICLayerCloseBeforeListen: ctx/cancel must exist before Start()'s goroutine
+// runs, so Stop() cannot race the write or read a nil cancel.
+func TestNewWorkerFSMInitializesCtx(t *testing.T) {
+	fsm := NewWorkerFSM(&sync.WaitGroup{}, []FSMstate{sendCtxState})
+	if fsm.ctx == nil || fsm.cancel == nil {
+		t.Fatal("NewWorkerFSM must initialize ctx/cancel before Start()'s goroutine can run")
+	}
+}
+
+// TestWorkerFSMStopBeforeStart covers Stop() arriving before Start(), e.g. a
+// connect torn down immediately. Previously this called a nil CancelFunc.
+func TestWorkerFSMStopBeforeStart(t *testing.T) {
+	fsm := NewWorkerFSM(&sync.WaitGroup{}, []FSMstate{sendCtxState})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop() before Start() panicked: %v", r)
+		}
+	}()
+	fsm.Stop()
+
+	if fsm.ctx.Err() == nil {
+		t.Fatal("Stop() before Start() did not cancel the context")
+	}
+}
+
+// TestSendCtxAbandonsOnCancel is the unit-level contract: a send into a full
+// channel must give up once ctx is cancelled.
+func TestSendCtxAbandonsOnCancel(t *testing.T) {
+	ch := make(chan IPCMsg, 1)
+	ch <- IPCMsg{} // full
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan bool, 1)
+	go func() { done <- sendCtx(ctx, ch, IPCMsg{}) }()
+	select {
+	case sent := <-done:
+		if sent {
+			t.Fatal("sendCtx reported a send into a full channel")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("sendCtx did not abandon the send after ctx was cancelled")
+	}
+}
+
+// TestWorkerFSMStopReleasesWorkerOnUndrainedSend is the regression test for the
+// leak: a worker parked in a control-plane send with nothing draining tx must
+// still exit when Stop() cancels it.
+func TestWorkerFSMStopReleasesWorkerOnUndrainedSend(t *testing.T) {
+	var wg sync.WaitGroup
+	fsm := NewWorkerFSM(&wg, []FSMstate{sendCtxState})
+	fillTx(t, fsm)
+
+	fsm.Start()
+	time.Sleep(100 * time.Millisecond) // let the goroutine reach the blocked send
+	fsm.Stop()
+
+	if !waitWg(&wg, 3*time.Second) {
+		t.Fatal("worker did not exit after Stop() while blocked on a control-plane send; " +
+			"its wg.Done() never runs, so BroflakeEngine.stop()'s wait cannot complete")
+	}
+}
+
+// TestBroflakeEngineStopCancelsCtxDespiteWedgedWorker is the backstop: even a
+// worker that cannot be cancelled must not hold the engine ctx, because that ctx
+// keeps the bus and both routers alive.
+func TestBroflakeEngineStopCancelsCtxDespiteWedgedWorker(t *testing.T) {
+	var wg sync.WaitGroup
+	wedged := NewWorkerFSM(&wg, []FSMstate{wedgedState})
+	fillTx(t, wedged)
+
+	ui := &UIImpl{}
+	engine := NewBroflakeEngine(
+		NewWorkerTable([]WorkerFSM{*wedged}),
+		NewWorkerTable([]WorkerFSM{}),
+		ui, &wg, "", "test",
+	)
+	engine.stopGrace = 200 * time.Millisecond
+	ui.Init(engine)
+
+	engine.start()
+	time.Sleep(100 * time.Millisecond)
+	engine.stop()
+
+	select {
+	case <-engine.ctx.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("stop() never cancelled the engine ctx: an unbounded wait on a wedged worker " +
+			"retains the bus, routers and workers for the process lifetime")
+	}
+}
+
+// TestBroflakeEngineStopDoesNotLeakGoroutines is the end-to-end cost check. A
+// client re-creating an outbound every few minutes accumulates linearly on
+// anything retained per cycle, which presents as CPU rising with uptime while disk
+// and network stay flat.
+func TestBroflakeEngineStopDoesNotLeakGoroutines(t *testing.T) {
+	const cycles = 10
+	base := runtime.NumGoroutine()
+
+	for i := 0; i < cycles; i++ {
+		var wg sync.WaitGroup
+		fsm := NewWorkerFSM(&wg, []FSMstate{sendCtxState})
+		fillTx(t, fsm)
+
+		engine := NewBroflakeEngine(
+			NewWorkerTable([]WorkerFSM{*fsm}),
+			NewWorkerTable([]WorkerFSM{}),
+			&UIImpl{}, &wg, "", "test",
+		)
+		engine.stopGrace = 200 * time.Millisecond
+		engine.start()
+		time.Sleep(20 * time.Millisecond)
+		engine.stop()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	leaked := runtime.NumGoroutine() - base
+	t.Logf("goroutines: base=%d after %d create/stop cycles=%d (leaked=%d)",
+		base, cycles, runtime.NumGoroutine(), leaked)
+	if leaked >= cycles {
+		t.Fatalf("leaked %d goroutines across %d create/stop cycles: each re-create retains a stack",
+			leaked, cycles)
+	}
+}
+
+// TestNoBareControlPlaneSends stops the pattern from being reintroduced across the
+// package. A bare `com.tx <- msg` statement is unabandonable; control-plane sends
+// must go through sendCtx. Data-plane sends use a non-blocking select with a
+// default, which appears as `case com.tx <- ...` and so does not match here.
+func TestNoBareControlPlaneSends(t *testing.T) {
+	bare := regexp.MustCompile(`^\s*com\.tx <- `)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if bare.MatchString(line) {
+				t.Errorf("%s:%d: bare `com.tx <-` send; use sendCtx so Stop() can cancel it:\n\t%s",
+					name, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}

--- a/clientcore/worker_stop_test.go
+++ b/clientcore/worker_stop_test.go
@@ -110,6 +110,25 @@ func TestSendCtxAbandonsOnCancel(t *testing.T) {
 	}
 }
 
+// TestSendCtxRefusesAfterCancel pins the deterministic case. With a cancelled ctx
+// and room in the buffer both select cases are ready, and select would pick
+// pseudo-randomly — so cancellation has to be checked first or a stopping worker
+// can still enqueue control-plane messages.
+func TestSendCtxRefusesAfterCancel(t *testing.T) {
+	ch := make(chan IPCMsg, 8) // room to spare, so the send case is always ready
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < 100; i++ {
+		if sendCtx(ctx, ch, IPCMsg{}) {
+			t.Fatalf("sendCtx sent on attempt %d despite a cancelled ctx", i)
+		}
+	}
+	if len(ch) != 0 {
+		t.Fatalf("sendCtx enqueued %d messages after cancellation", len(ch))
+	}
+}
+
 // TestWorkerFSMStopReleasesWorkerOnUndrainedSend is the regression test for the
 // leak: a worker parked in a control-plane send with nothing draining tx must
 // still exit when Stop() cancels it.


### PR DESCRIPTION
## Problem

A `WorkerFSM` parked in a control-plane send on `com.tx` could not be cancelled. The send had no ctx guard, so the state never returned; the FSM only checks `ctx.Done()` **between** states, so it never observed cancellation; so its `wg.Done()` never ran.

`BroflakeEngine.stop()` waited on that `WaitGroup` before cancelling the engine ctx, so **one** stranded worker retained the ctx — and with it the bus, both routers, and every other worker — for the lifetime of the process. Anything re-creating a broflake-backed outbound then accumulated a full WebRTC/ICE stack per cycle.

This is the residue of the July `QUICLayer` work: that fix moved `ctx/cancel` into `NewQUICLayer` and added a cancel check before re-listening, but `WorkerFSM` has the identical shape and got neither.

**Observed downstream** (Freshdesk 181174, Windows 9.1.18, CN): the unbounded outbound re-created 82 times in 13h at a flat ~6/hr, with CPU climbing to 80% while disk sat at 0 MB/s and network at 0 Mbps — the signature of a per-event leak rather than a spin. Reproduced here at ~2-3 goroutines leaked per create/stop cycle with a *minimal* 1-worker table; production runs 10 workers plus bus and routers per stack.

## Changes

- **`NewWorkerFSM` initializes `ctx`/`cancel`** instead of leaving it to the top of `Start()`'s goroutine, so `Stop()` can neither race the write nor call a nil `CancelFunc`. It previously **panicked** on `Stop()` before `Start()` — reachable from any fast connect/teardown.
- **`Stop()` nil-guards `cancel`** for the struct-literal case, mirroring `ListenAndMaintainQUICConnection`'s guard.
- **New `sendCtx` helper**; all **11** bare control-plane sends now abandon on cancellation — `consumer.go` (2), `producer.go` (3), `egress_consumer.go` (2), `jit_egress_consumer.go` (4). The abandon path deliberately returns the state's `input` unchanged so the FSM exit path can still `closeWorkerResource` anything it carries (returning `nil` would drop a live PeerConnection). Data-plane sends are untouched — they intentionally drop chunks rather than wait.
- **`stop()` bounds its wait** at `BroflakeEngine.stopGrace` (10s) then cancels regardless, so any future unguarded blocking state degrades to a bounded leak instead of a permanent one. A per-engine field rather than a package var, because a mutable global here is read by the stop goroutine and `-race` catches the write.

## Testing

`clientcore/worker_stop_test.go` — synthetic FSM states, so nothing touches STUN, freddie, or an egress server:

| test | guards |
|---|---|
| `TestNewWorkerFSMInitializesCtx` | ctx/cancel exist pre-`Start()` |
| `TestWorkerFSMStopBeforeStart` | no panic, and cancellation actually lands |
| `TestSendCtxAbandonsOnCancel` | the helper's contract |
| `TestWorkerFSMStopReleasesWorkerOnUndrainedSend` | the leak itself |
| `TestBroflakeEngineStopCancelsCtxDespiteWedgedWorker` | the bounded-wait backstop |
| `TestBroflakeEngineStopDoesNotLeakGoroutines` | 10 create/stop cycles return to baseline |
| `TestNoBareControlPlaneSends` | source-level guard against reintroducing the pattern at any of the 11 sites |

`go test -race ./...` passes across the whole module. Before these changes the leak test showed 30 goroutines leaked over 10 cycles; it now reports `leaked=0`.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none (no findings raised)
- Dismissed: none

## Follow-ups (not in this PR)

- `lantern-box`: `unbounded.Outbound.Close()` closes the QUIC layer (the drain) *before* stopping the engine, which is what strands the workers in the first place. It should tear down in reverse-of-construction order, and it never closes `broflakeConn`.
- `sing-box-minimal`: `Manager.Create` still runs all start stages on the new outbound before closing the same-tag predecessor, so every re-create briefly runs two live stacks.
- `clientcore/user.go:114,116` discard the `cancel` from `WithCancel`/`WithDeadline`; `go vet` flags both as context leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE