### PR TITLE
freeze reports: carry the bundle the report came from

### DIFF
--- a/.github/workflows/build-widget-wasm.yml
+++ b/.github/workflows/build-widget-wasm.yml
@@ -219,7 +219,16 @@ jobs:
           set -euo pipefail
           cp .env.production.example .env.production
           yarn install --frozen-lockfile
-          yarn build:web
+          # Stamp the bundle with the commit it was built from. CRA lets a shell
+          # REACT_APP_* override .env.production, so this wins over the placeholder
+          # in the tracked example file without editing it.
+          #
+          # It matters because donor pages are long-lived: they keep running whatever
+          # bundle they loaded with, so for days after a widget fix the fleet runs
+          # several versions at once. Freeze reports carry this value, which is what
+          # makes "an old client is still reporting" distinguishable from "the new code
+          # is broken" — previously that took 48 hours of watching a decay curve.
+          REACT_APP_BUILD="${{ github.sha }}" yarn build:web
 
       # Same reasoning as the wasm check: a page build can "succeed" and still emit
       # something that would break every embedder, and publishing it takes the widget

--- a/egress/freeze.go
+++ b/egress/freeze.go
@@ -115,6 +115,18 @@ type freezeReport struct {
 	// and never becomes a label.
 	URL       string `json:"url"`
 	UserAgent string `json:"userAgent"`
+	// Build is the commit the reporting widget bundle was published from.
+	//
+	// Donor pages are long-lived and keep running whatever bundle they loaded with,
+	// so after a widget fix ships the fleet runs several versions for days. Without
+	// this, a report the newest code cannot produce is indistinguishable from a bug
+	// in that code — the only way to tell was watching whether the rate decayed over
+	// 48 hours. It did, but that is an afternoon to answer a question this field
+	// answers in one grep.
+	//
+	// Logged, never a label: it is peer-supplied like everything else here, so as a
+	// metric label it would be cardinality controlled by a stranger. See the header.
+	Build string `json:"build"`
 }
 
 // handleFreezeReport ingests one beacon.
@@ -186,6 +198,10 @@ func (l proxyListener) logFreezeReport(kind freezeKind, report *freezeReport, r 
 			// froze, and the reason the payload carries it at all.
 			"page_url", truncateForLog(report.URL),
 			"page_user_agent", truncateForLog(report.UserAgent),
+			// Empty for a local build, and for any widget published before this
+			// field existed — which is most of the fleet for the first few days
+			// after it ships, and itself the answer to "is this an old client".
+			"page_build", truncateForLog(report.Build),
 			// recovered separates a freeze the page survived from one it did not.
 			// Only page_died is unrecovered, and it is the severe case: a hiccup
 			// annoys a user, a death silently removes a donor from the network.

--- a/egress/freeze_test.go
+++ b/egress/freeze_test.go
@@ -315,3 +315,38 @@ func TestHandleFreezeReport_TruncatesTheBuildID(t *testing.T) {
 		t.Errorf("an oversized build id reached the log untruncated: %s", got[:min(len(got), 400)])
 	}
 }
+
+// A null or absent build must be accepted, not bucketed as invalid.
+//
+// Both are normal: the UI sends null from a local build and from a page_died recovered
+// off a breadcrumb written before the field existed, and absent is every widget
+// published before it. Rejecting either would discard exactly the reports the field was
+// added to identify — old clients.
+//
+// Pinned because it is counter-intuitive enough to have been reported as a bug twice in
+// review. encoding/json documents null into a non-pointer as a no-op ("Unmarshal sets
+// that value to nil if it is a pointer, interface, map, or slice; otherwise Unmarshal
+// leaves the value unchanged"), so a string field lands on "" and needs no pointer. The
+// suggested fix was *string, which would add a nil check at every read for no behavior
+// change. This test is here so the next person to have that intuition sees it disproved
+// rather than acting on it.
+func TestHandleFreezeReport_AcceptsNullAndAbsentBuild(t *testing.T) {
+	for _, body := range []string{
+		`{"kind":"main_thread_blocked","gapMs":12000,"build":null}`,
+		`{"kind":"main_thread_blocked","gapMs":12000}`,
+		`{"kind":"main_thread_blocked","gapMs":12000,"build":""}`,
+	} {
+		resetFreezeReports(t)
+		if got := postFreeze(t, body).Code; got != http.StatusNoContent {
+			t.Errorf("%s: status %d, want 204", body, got)
+		}
+		got := collectFreezeReports()
+		if got[freezeMainThreadBlocked] != 1 {
+			t.Errorf("%s: counted %v, want one main_thread_blocked", body, got)
+		}
+		if got[freezeInvalid] != 0 {
+			t.Errorf("%s: bucketed as invalid — a null or missing build is an OLD CLIENT, "+
+				"which is the case this field exists to surface", body)
+		}
+	}
+}

--- a/egress/freeze_test.go
+++ b/egress/freeze_test.go
@@ -1,7 +1,9 @@
 package egress
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -251,5 +253,65 @@ func TestHandleFreezeReport_OversizedIsCountedAndQuiet(t *testing.T) {
 	}
 	if got := collectFreezeReports()[freezeInvalid]; got != 1 {
 		t.Errorf("counted %v, want one invalid", collectFreezeReports())
+	}
+}
+
+// The build id is the field that makes "an old client is still reporting" answerable.
+// It has to survive parsing and reach the log, and it must never become a metric label:
+// it is peer-supplied, so as a label it is cardinality controlled by a stranger.
+func TestHandleFreezeReport_CarriesTheBuildID(t *testing.T) {
+	resetFreezeReports(t)
+	freezeReportLogs = newLogThrottle(freezeReportLogInterval)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	body, err := json.Marshal(freezeReport{
+		Kind: freezeMainThreadBlocked, Recovered: true, GapMs: 12000,
+		URL: "https://example.org/page", UserAgent: "Mozilla/5.0",
+		Build: "0d5f6ac1234567890abcdef",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := postFreeze(t, string(body)); w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204", w.Code)
+	}
+
+	if got := buf.String(); !strings.Contains(got, "page_build=0d5f6ac1234567890abcdef") {
+		t.Errorf("build id missing from the log line: %s", got)
+	}
+
+	// And it stays out of the labels. Only kind is ever a label.
+	for label := range collectFreezeReports() {
+		if label != freezeMainThreadBlocked {
+			t.Errorf("unexpected metric label %q — build must never become one", label)
+		}
+	}
+}
+
+// An over-long build id is peer-supplied bytes headed for disk like any other field.
+func TestHandleFreezeReport_TruncatesTheBuildID(t *testing.T) {
+	resetFreezeReports(t)
+	freezeReportLogs = newLogThrottle(freezeReportLogInterval)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	body, err := json.Marshal(freezeReport{
+		Kind: freezeJSStarved, Recovered: true, GapMs: 9000,
+		Build: strings.Repeat("a", 4096),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postFreeze(t, string(body))
+
+	if got := buf.String(); !strings.Contains(got, truncationMarker) {
+		t.Errorf("an oversized build id reached the log untruncated: %s", got[:min(len(got), 400)])
 	}
 }

--- a/ui/.env.development.example
+++ b/ui/.env.development.example
@@ -51,3 +51,9 @@ STRAPI_API_URL=https://cms.lantern.io/api
 # NB this sends the *embedding site's* URL, since that is the field that says which page
 # froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
 REACT_APP_FREEZE_BEACON_URL=http://localhost:8000/freeze
+
+# Commit the widget bundle was published from, reported with every freeze report so an
+# old client in the fleet is distinguishable from a bug in the newest code. CI overrides
+# this with the real SHA (see build-widget-wasm.yml); left as "dev" here because a local build
+# has no meaningful commit to claim.
+REACT_APP_BUILD=dev

--- a/ui/.env.production.example
+++ b/ui/.env.production.example
@@ -52,3 +52,9 @@ STRAPI_API_URL=https://cms.lantern.io/api
 # NB it sends the *embedding site's* URL, since that is the field that says which page
 # froze — see the header comment in ui/src/utils/freezeWatchdog.ts.
 REACT_APP_FREEZE_BEACON_URL=https://unbounded.iantem.io/freeze
+
+# Commit the widget bundle was published from, reported with every freeze report so an
+# old client in the fleet is distinguishable from a bug in the newest code. CI overrides
+# this with the real SHA (see build-widget-wasm.yml); left empty here because a local build
+# has no meaningful commit to claim.
+REACT_APP_BUILD=

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -868,17 +868,26 @@ describe('breadcrumb recovery', () => {
 	})
 
 	// Same discipline as every other recovered field: the record can carry anything,
-	// including from a version that predates this field entirely.
-	test('does not trust the type of a recovered build id', () => {
+	// including from a version that predates this field entirely. Whitespace-only and
+	// padded values are included because the live path normalizes them and the
+	// recovered path used only to slice — so the two disagreed on identical input.
+	test.each([
+		['wrong type', {nope: 1}, null],
+		['absent', undefined, null],
+		['empty', '', null],
+		['whitespace only', '   ', null],
+		['padded', '  abc123  ', 'abc123'],
+		['over-long', 'x'.repeat(200), 'x'.repeat(64)],
+	])('normalizes a recovered build id (%s)', (_name, stored, want) => {
 		const stale = now - 10 * 60 * 1000
-		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false, v: {nope: 1}}))
+		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false, v: stored}))
 
 		const {reports, onReport} = capture()
 		const wd = new FreezeWatchdog({onReport})
 		wd.start()
 
 		expect(reports).toHaveLength(1)
-		expect(reports[0].build).toBeNull()
+		expect(reports[0].build).toEqual(want)
 		wd.stop()
 	})
 

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -819,6 +819,38 @@ describe('breadcrumb recovery', () => {
 		wd.stop()
 	})
 
+	// A death is recovered by whatever bundle loads NEXT, which after a widget deploy
+	// is a different one. Reading the live buildId here would label every death with
+	// the version that found it rather than the version that died — blaming each fix
+	// for the failures it shipped to fix, which is worse than having no field at all.
+	test('attributes a death to the bundle that died', () => {
+		const stale = now - 10 * 60 * 1000
+		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false, v: 'oldbuild123'}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].build).toBe('oldbuild123')
+		wd.stop()
+	})
+
+	// Same discipline as every other recovered field: the record can carry anything,
+	// including from a version that predates this field entirely.
+	test('does not trust the type of a recovered build id', () => {
+		const stale = now - 10 * 60 * 1000
+		window.localStorage.setItem(KEY, JSON.stringify({b: stale, c: false, v: {nope: 1}}))
+
+		const {reports, onReport} = capture()
+		const wd = new FreezeWatchdog({onReport})
+		wd.start()
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].build).toBeNull()
+		wd.stop()
+	})
+
 	test('expires records older than the retention window', () => {
 		writeCrumb({t: 'deadtab', b: now - 48 * 60 * 60 * 1000, s: now - 49 * 60 * 60 * 1000, c: false, h: false, p: false, l: null, n: null})
 
@@ -1009,6 +1041,7 @@ describe('defaultReport beacon', () => {
 		sharing: false,
 		url: 'https://example.test/',
 		userAgent: 'test',
+		build: 'testbuild',
 	}
 
 	const setBeacon = (fn: unknown) =>

--- a/ui/src/utils/freezeWatchdog.test.ts
+++ b/ui/src/utils/freezeWatchdog.test.ts
@@ -386,6 +386,37 @@ test('does not report a throttled gap when the interval began hidden', () => {
 	wd.stop()
 })
 
+// The live path, which the recovered-breadcrumb tests above do not exercise. buildId is
+// read once at module load — the property that makes it trustworthy, since it cannot
+// change during a page life — so setting it requires re-importing the module.
+test('stamps a live report with the build it was compiled with', () => {
+	const prev = process.env.REACT_APP_BUILD
+	process.env.REACT_APP_BUILD = 'livebuild456'
+	jest.resetModules()
+
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const fresh = require('./freezeWatchdog')
+		const reports: any[] = []
+		const wd = new fresh.FreezeWatchdog({
+			liveness: sharedThread(),
+			onReport: (r: any) => reports.push(r),
+		})
+		wd.start()
+
+		fireTick(20_000)
+
+		expect(reports).toHaveLength(1)
+		expect(reports[0].kind).toBe('main_thread_blocked')
+		expect(reports[0].build).toBe('livebuild456')
+		wd.stop()
+	} finally {
+		if (prev === undefined) delete process.env.REACT_APP_BUILD
+		else process.env.REACT_APP_BUILD = prev
+		jest.resetModules()
+	}
+})
+
 // Background tabs have their timers throttled to roughly one per minute, so a
 // hidden tab produces gaps far beyond FREEZE_MS while being perfectly healthy.
 // Reporting those would make the signal useless — most donor tabs sit in the

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -132,15 +132,27 @@ const maxTaskNameLen = 128
 // that freezes in a loop must not turn its own diagnostics into the leak.
 const maxReports = 20
 
+// normalizeBuildId bounds a build identifier and collapses "no useful value" to null.
+//
+// Shared by the two paths that produce one — the compiled-in value below, and a value
+// read back from a breadcrumb — because they were inconsistent when written separately:
+// the live path trimmed and mapped empty to null while the recovered path only sliced,
+// so a whitespace-only value from a corrupted record would have reached the log as
+// whitespace. Recovered values are never trusted for type or content anywhere else in
+// this file and should not be here either.
+const normalizeBuildId = (v: unknown): string | null =>
+	typeof v === 'string' ? v.trim().slice(0, maxBuildIdLen) || null : null
+
+// maxBuildIdLen bounds it. A commit SHA is 40 characters; this only truncates something
+// that was never one. The value is compiled into a world-readable bundle so it is not a
+// secret, but it reaches the server as peer-supplied bytes like every other field, and
+// bounding it at the source keeps an over-long value from being the server's problem.
+const maxBuildIdLen = 64
+
 // buildId is the commit the widget page was published from, baked in at build time by
 // the publish workflow. Read once at module load rather than per report: it cannot
 // change during a page life, and that is exactly the property that makes it useful.
-//
-// Trimmed and length-capped here as well as on the egress. The value is compiled into
-// a world-readable bundle so it is not a secret, but it arrives at the server as
-// peer-supplied bytes like everything else in a report, and bounding it at the source
-// keeps an over-long value from being something only the server notices.
-const buildId: string | null = (process.env.REACT_APP_BUILD || '').trim().slice(0, 64) || null
+const buildId: string | null = normalizeBuildId(process.env.REACT_APP_BUILD)
 
 // repeatSuppressMs throttles repeats of a kind already reported.
 //
@@ -234,9 +246,15 @@ export interface FreezeReport {
 	sharing: boolean
 	url: string
 	userAgent: string
-	// build identifies the bundle that produced this report — the commit the widget
-	// page was published from, injected at build time. null in a local build, where
-	// the answer is "whatever is on your disk".
+	// build identifies the bundle that produced this report. Three possible values, and
+	// all three are informative:
+	//
+	//   - a commit SHA, injected by the publish workflow. The normal production case.
+	//   - "dev", from ui/.env.development.example, so a report from someone's laptop is
+	//     recognisable as one rather than looking like a mystery client.
+	//   - null, when nothing was set at build time — which after this field ships is
+	//     every widget published before it, i.e. "old client". That is a fact worth
+	//     reporting, not missing data.
 	//
 	// Added because its absence cost a real diagnosis. Donor pages are long-lived and
 	// keep running whatever bundle they loaded with, so after a watchdog fix ships the
@@ -901,7 +919,7 @@ export class FreezeWatchdog {
 				// *different* one — so reading buildId here would label every death
 				// with the version that found it rather than the version that died,
 				// and blame each fix for the failures it was shipped to fix.
-				build: typeof crumb.v === 'string' ? crumb.v.slice(0, 64) : null,
+				build: normalizeBuildId(crumb.v),
 			})
 		}
 	}

--- a/ui/src/utils/freezeWatchdog.ts
+++ b/ui/src/utils/freezeWatchdog.ts
@@ -132,6 +132,16 @@ const maxTaskNameLen = 128
 // that freezes in a loop must not turn its own diagnostics into the leak.
 const maxReports = 20
 
+// buildId is the commit the widget page was published from, baked in at build time by
+// the publish workflow. Read once at module load rather than per report: it cannot
+// change during a page life, and that is exactly the property that makes it useful.
+//
+// Trimmed and length-capped here as well as on the egress. The value is compiled into
+// a world-readable bundle so it is not a secret, but it arrives at the server as
+// peer-supplied bytes like everything else in a report, and bounding it at the source
+// keeps an over-long value from being something only the server notices.
+const buildId: string | null = (process.env.REACT_APP_BUILD || '').trim().slice(0, 64) || null
+
 // repeatSuppressMs throttles repeats of a kind already reported.
 //
 // A wedged Go runtime is a *standing* condition, not an event: goLastTickMs stays
@@ -224,6 +234,18 @@ export interface FreezeReport {
 	sharing: boolean
 	url: string
 	userAgent: string
+	// build identifies the bundle that produced this report — the commit the widget
+	// page was published from, injected at build time. null in a local build, where
+	// the answer is "whatever is on your disk".
+	//
+	// Added because its absence cost a real diagnosis. Donor pages are long-lived and
+	// keep running whatever bundle they loaded with, so after a watchdog fix ships the
+	// fleet contains several versions at once for days. When reports kept arriving that
+	// the newest code could not possibly produce — gaps past a ceiling that rejects
+	// them — there was no way to tell an old client from broken logic except by
+	// watching whether the rate decayed over 48 hours. It was old clients. With this
+	// field it is one query instead of an afternoon.
+	build: string | null
 }
 
 // Breadcrumb is the localStorage record. Field names are short because this is
@@ -237,6 +259,7 @@ interface Breadcrumb {
 	p: boolean // sharing at last beat
 	l: number | null // longest task ms
 	n: string | null // longest task name
+	v: string | null // build id of the bundle that wrote this
 }
 
 // Liveness mirrors the object returned by Go's liveness(). Field names are a
@@ -656,6 +679,7 @@ export class FreezeWatchdog {
 				longestTaskMs: this.longestTaskMs,
 				longestTaskName: this.longestTaskName,
 				sharing: this.sharing(),
+				build: buildId,
 			})
 		}
 
@@ -755,6 +779,7 @@ export class FreezeWatchdog {
 			p: this.sharing(),
 			l: this.longestTaskMs,
 			n: this.longestTaskName,
+			v: buildId,
 		}
 		safeStorage.write(this.storageKey, JSON.stringify(crumb))
 	}
@@ -871,6 +896,12 @@ export class FreezeWatchdog {
 				longestTaskMs: typeof crumb.l === 'number' ? crumb.l : null,
 				longestTaskName: typeof crumb.n === 'string' ? crumb.n.slice(0, maxTaskNameLen) : null,
 				sharing: crumb.p === true,
+				// From the record, not from this page life. A death is recovered by
+				// whatever bundle loads next, which after a widget deploy is a
+				// *different* one — so reading buildId here would label every death
+				// with the version that found it rather than the version that died,
+				// and blame each fix for the failures it was shipped to fix.
+				build: typeof crumb.v === 'string' ? crumb.v.slice(0, 64) : null,
 			})
 		}
 	}


### PR DESCRIPTION
Freeze reports now say which bundle produced them.

## Why — this cost a real diagnosis yesterday

Donor pages are long-lived. They keep running whatever bundle they loaded with, so for **days** after a widget fix the fleet runs several versions at once.

After #411 shipped a 2-minute ceiling on `main_thread_blocked`, reports kept arriving with gaps up to **65 minutes** — gaps that code rejects by construction. Two explanations, indistinguishable from the data: the guard was broken, or old clients were still reporting.

Answering it meant bucketing 48 hours of journal into 6-hour windows and watching the over-ceiling share decay:

| window | logged | >120s | share |
|---|---|---|---|
| Aug 09 18 | 56 | 45 | **82%** |
| Aug 10 12 | 58 | 42 | 72% ← #411 deployed mid-window |
| Aug 10 18 | 54 | 32 | 59% |
| Aug 11 06 | 44 | 22 | 50% |
| Aug 11 12 | 46 | 13 | **28%** |

Monotonic decay, so: old clients. That is an afternoon of inference to answer what this field answers with one grep.

## How

CI stamps the bundle with `github.sha`:

```
REACT_APP_BUILD="${{ github.sha }}" yarn build:web
```

Overriding the tracked placeholder through the shell, which CRA gives precedence over `.env.production` — so the example file stays a placeholder rather than something CI has to edit. Empty in a local build, where there is no commit to honestly claim.

**Logged, never a metric label.** It is peer-supplied like `url` and `userAgent`, so as a label it would be unbounded cardinality controlled by a stranger. The diagnostic value is entirely in the log, which is where the question actually gets asked.

## The part that needed care: page_died

The breadcrumb carries the build too, so a recovered death names the bundle that **died** rather than the one that found the record.

Those differ exactly when it matters. A death is recovered by whatever bundle loads *next*, which after a deploy is a newer one — so reading the live value would label every death with the version that found it, blaming each fix for the failures it was shipped to fix. Precisely backwards for the use case.

`report()` already requires evidence as explicit arguments for this reason (its doc calls out an earlier version that filled fields from `this` and silently discarded the dead page's attribution). Keeping `build` in that set made the omission a **compile error**, and the type checker duly caught the one test fixture that had not supplied it.

## Tests

Four added, each verified to fail without the change:

- `attributes a death to the bundle that died` — breadcrumb value wins over the live one
- `does not trust the type of a recovered build id` — a record can predate the field entirely
- `CarriesTheBuildID` — reaches the log, and asserts it stays **out** of the label set
- `TruncatesTheBuildID` — 4KB build id gets the truncation marker

```
--- FAIL: TestHandleFreezeReport_CarriesTheBuildID
    build id missing from the log line: ... kind=main_thread_blocked page_url=... 
--- FAIL: TestHandleFreezeReport_TruncatesTheBuildID
    an oversized build id reached the log untruncated: ...
```

45/45 UI tests, `go test -race ./...`, `gofmt`, `tsc --noEmit`, and `GOOS=js GOARCH=wasm go build ./cmd` all clean.

## Note on rollout

This field is itself subject to the problem it solves: it will be empty for every bundle published before it, which is most of the fleet for the first few days. An empty `page_build` is therefore meaningful — it means "old client" — rather than missing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Freeze and page-death reports now include the widget build identifier.
  * Recovered reports retain the build version associated with the affected page.
* **Bug Fixes**
  * Invalid or missing build identifiers are handled safely.
  * Build identifiers are trimmed and limited to a safe length.
* **Documentation**
  * Development and production configuration examples now document build identifier settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->