### PR TITLE
wp-plugin: demo copy says "above", matching where the widget now renders

### DIFF
--- a/ui/wp-plugin/demo-site/blueprint.json
+++ b/ui/wp-plugin/demo-site/blueprint.json
@@ -11,7 +11,7 @@
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once '/wordpress/wp-load.php'; $id = wp_insert_post(array('post_type'=>'page','post_title'=>'Unbounded Demo','post_status'=>'publish','post_content'=>'<p>This page is running the Unbounded WordPress plugin. The widget below turns this browser into a volunteer proxy that helps people reach the open internet.</p>')); update_post_meta($id,'_browsers_unbounded_enable','1'); update_option('browsers_unbounded_options', array('layout'=>'banner','theme'=>'dark','location'=>'header','homepage'=>'on')); update_option('show_on_front','page'); update_option('page_on_front',$id); update_option('blogname','Unbounded Demo');"
+      "code": "<?php require_once '/wordpress/wp-load.php'; $id = wp_insert_post(array('post_type'=>'page','post_title'=>'Unbounded Demo','post_status'=>'publish','post_content'=>'<p>This page is running the Unbounded WordPress plugin. The widget above turns this browser into a volunteer proxy that helps people reach the open internet.</p>')); update_post_meta($id,'_browsers_unbounded_enable','1'); update_option('browsers_unbounded_options', array('layout'=>'banner','theme'=>'dark','location'=>'header','homepage'=>'on')); update_option('show_on_front','page'); update_option('page_on_front',$id); update_option('blogname','Unbounded Demo');"
     }
   ]
 }


### PR DESCRIPTION
One-word copy fix on the Playground demo page.

`location=header` (from #419) renders the widget as the first child of `<body>`, above the page content — but the copy still read **"The widget below"**, written when the blueprint placed it in the footer. It pointed readers the wrong way on the live demo.

Now reads "The widget above".

Worth noting the coupling: this sentence depends on the `location` setting in `blueprint.json`. If that ever goes back to `footer`, the wording has to move with it. Left it directional rather than neutral ("the widget on this page") because telling a visitor where to look is more useful on a demo whose whole point is the widget.

Verified live at https://unbounded-wp.lantern.io — custom domain is active, cert valid (`CN=unbounded-wp.lantern.io`, Google Trust Services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh3TcyWL8MMtTYPo7H2buS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated demo page content to state that the Unbounded widget appears above the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->