### PR TITLE
ui: stop the widget starting to proxy on page load without consent

### DIFF
--- a/ui/src/components/molecules/modal/index.test.tsx
+++ b/ui/src/components/molecules/modal/index.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import Modal from './index'
+import {AppContextProvider} from '../../../context'
+import {defaultSettings, Layouts, Settings} from '../../../constants'
+
+// The modal's copy is irrelevant here and an uninitialised i18next only adds
+// noise to the run.
+jest.mock('react-i18next', () => ({
+	useTranslation: () => ({t: (key: string) => key}),
+}))
+
+// context.tsx instantiates a WasmInterface for its default value, and that
+// module's import chain reaches the Go wasm glue, which throws at load in jsdom
+// (no globalThis.crypto). The modal never uses it, so stub the module out.
+jest.mock('../../../utils/wasmInterface', () => ({
+	WasmInterface: class {},
+}))
+
+// onIgnore is wired by useSharingToggle to toggle(true, true): it bypasses the
+// geo gate and starts sharing. So "onIgnore was called" means "the widget began
+// proxying", which is what makes each of these assertions about consent.
+const renderModal = (settings: Partial<Settings>, isCensored: boolean) => {
+	const onIgnore = jest.fn()
+	render(
+		<AppContextProvider value={{
+			width: 0,
+			setWidth: () => {},
+			settings: {...defaultSettings, ...settings},
+			wasmInterface: undefined as any,
+		}}>
+			<Modal isCensored={isCensored} onIgnore={onIgnore} />
+		</AppContextProvider>
+	)
+	return onIgnore
+}
+
+describe('censored-region modal', () => {
+	// The default embed: banner layout, collapsed. The modal cannot render in that
+	// layout, and until the isCensored guard the effect fired for every visitor on
+	// mount -- so the widget was proxying with nobody having opted in.
+	test('does not start sharing on mount for a visitor who is not censored (collapsed banner)', () => {
+		const onIgnore = renderModal({layout: Layouts.BANNER, collapse: true}, false)
+		expect(onIgnore).not.toHaveBeenCalled()
+	})
+
+	test('does not start sharing on mount for a visitor who is not censored (collapsed floating)', () => {
+		const onIgnore = renderModal({layout: Layouts.FLOATING, collapse: true}, false)
+		expect(onIgnore).not.toHaveBeenCalled()
+	})
+
+	// The behaviour the effect exists for: a censored visitor whose layout cannot
+	// show the warning would otherwise be stuck, so proceed for them.
+	test('still auto-proceeds for a censored visitor whose layout cannot show the modal', () => {
+		const onIgnore = renderModal({layout: Layouts.BANNER, collapse: true}, true)
+		expect(onIgnore).toHaveBeenCalledTimes(1)
+	})
+
+	// When the modal can render, the visitor gets the warning and decides for
+	// themselves; nothing should proceed on their behalf.
+	test('leaves the decision to a censored visitor when the modal can render (panel)', () => {
+		const onIgnore = renderModal({layout: Layouts.PANEL, collapse: true}, true)
+		expect(onIgnore).not.toHaveBeenCalled()
+	})
+})

--- a/ui/src/components/molecules/modal/index.tsx
+++ b/ui/src/components/molecules/modal/index.tsx
@@ -15,8 +15,11 @@ const Modal = ({ onIgnore, isCensored }: {onIgnore: () => void, isCensored: bool
 	const canRenderModal = !collapse || layout === Layouts.PANEL || layout === Layouts.SIMPLE;
 
 	useEffect(() => {
-		// if the modal can't be rendered, we to auto ignore the censored state otherwise the user will be stuck
-		if (!canRenderModal) {
+		// A censored visitor whose layout can't show this modal would otherwise be
+		// stuck, so proceed for them. Only for them: onIgnore() starts sharing, and
+		// without the isCensored check this fired on mount for every visitor of a
+		// collapsed banner or floating embed -- proxying with no one having opted in.
+		if (isCensored && !canRenderModal) {
 			onIgnore();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Every collapsed **banner** or **floating** embed — the defaults — has been starting to proxy the moment the page loaded, for every visitor, with nobody having flipped the switch. Reproduced live on a bare HTML page containing nothing but the script tag and the element: switch checked, `Status: ON`, two consumers being relayed within ~20 s of load.

This is the widget bundle, not the WordPress plugin — the plugin only prints the tag. It has been this way since **2024-11-19**.

## The path

```mermaid
sequenceDiagram
    autonumber
    participant P as Page load<br/>index.tsx
    participant M as Modal<br/>modal/index.tsx
    participant T as useSharingToggle<br/>useSharingToggle.ts
    participant W as WasmInterface<br/>wasmInterface.ts

    P->>M: mount, isCensored=false
    Note over M: modal/index.tsx:15<br/>canRenderModal = !collapse or PANEL or SIMPLE<br/>banner + collapse=true → false ⚠️
    rect rgba(255, 200, 200, 0.3)
        Note over M: modal/index.tsx:17-23<br/>useEffect runs on mount<br/>if (!canRenderModal) onIgnore() 🐛<br/>never checked isCensored
    end
    M->>T: onIgnore()
    Note over T: useSharingToggle.ts:71-74<br/>setIgnoreCensored(true), toggle(true, true)
    T->>T: useSharingToggle.ts:48-55<br/>ignoreCensored=true skips the geo gate
    T->>W: useSharingToggle.ts:60<br/>init() downloads 12MB wasm
    T->>W: useSharingToggle.ts:61<br/>start()
    Note over W: wasmInterface.ts:198<br/>sharingEmitter.update(true) ⚠️
    W-->>P: switch checked, Status ON, relaying<br/>nobody clicked anything
```

The censored-region modal's effect exists for one case: a censored visitor whose layout can't show the warning would otherwise be stuck, so proceed for them. But `onIgnore()` is wired by `useSharingToggle` to `toggle(true, true)` — skip the geo gate, lazily init the wasm client, `start()` — and the effect never checked `isCensored`. `useEffect` runs on mount, and `canRenderModal` is `false` for banner/floating whenever `collapse` is `true` (the default), so on the default configuration `onIgnore()` fired on mount for **everyone**.

## The fix

The missing half of the condition:

```ts
if (isCensored && !canRenderModal) {
    onIgnore();
}
```

Intended behaviour is unchanged: a censored visitor on a collapsed banner still proceeds. A visitor who is not censored is left alone.

## History

`git blame` puts the unguarded call at `26fed8a` (2024-11-19, "fix locale modal embed bugs"). It is **not** a recent regression — the only later touch, `66b1980` (2026-07-09), added `SIMPLE` to `canRenderModal` and *narrowed* the exposure. Panel, simple, and any layout with `collapse=false` were never affected, which matches exactly the layouts observed to behave.

Worth knowing while assessing impact: the partner embeds (CDT, RZ, etc.) run the default banner. And Nelson's April note that "the widget receives no connections" reads differently in this light — donors were running the whole time; there were no consumers yet.

## Verification

**Regression test** (`modal/index.test.tsx`), four cells:

| case | expect |
|---|---|
| not censored · collapsed banner | `onIgnore` **not** called on mount |
| not censored · collapsed floating | not called |
| censored · collapsed banner | called once (the intent) |
| censored · panel | not called — modal renders, visitor decides |

Run against the **pre-fix** source (source change stashed, test kept): exactly the two not-censored cases fail, the two intent cases pass. So the test discriminates this bug and nothing else.

**Live confirmation on the deployed (pre-fix) bundle.** Three bare HTML pages, same bundle from `embed.lantern.io`, same browser, read at the same instant ~22 s after load. A→B changes exactly one attribute, `data-collapse`, which is exactly what flips `canRenderModal`:

| | layout | collapse | switch | status | relaying |
|---|---|---|---|---|---|
| A | banner | `true` (default) | checked | **ON** | 1 consumer |
| B | banner | `false` | unchecked | OFF | 0 |
| C | panel | default | unchecked | OFF | 0 |

The test mocks `utils/wasmInterface`: `context.tsx` instantiates one at module load and that import chain reaches the Go wasm glue, which throws in jsdom for lack of `globalThis.crypto`. The modal never uses it. **That same import-time throw is why `src/App.test.tsx` has been unable to load since the glue landed** — pre-existing, deliberately left alone here.

Also: `tsc --noEmit` clean · `CI=true yarn build:web` (the exact CI command; ESLint warnings promoted to errors) compiles · all loadable suites pass (55 tests). `build-widget-wasm.yml` triggers on `pull_request` for `ui/**`, so CI builds the real page + wasm on this PR too.

## Why this landed on the WordPress track

`ui/wp-plugin/readme.txt` (#421) tells wordpress.org reviewers "the switch is off when the page loads" — the load-bearing guideline 7/9 claim. As deployed, that was false. The plugin submission should wait for this to merge and `embed.lantern.io` to republish, then be re-verified live.

Separately observed while testing: for a stretch on 2026-09-09 `embed.lantern.io` returned **503** (plain HTTP) / TLS reset from GitHub's edge for that hostname while `getlantern.github.io` answered, with the Pages API reporting `built` and cert `approved`. It recovered on its own. Unrelated to this change, but it was a full outage of every embed and the demo while it lasted.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh3TcyWL8MMtTYPo7H2buS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed modal behavior so automatic dismissal only occurs for censored visitors when the warning cannot be displayed.
  - Non-censored visitors and visitors with a renderable warning panel are no longer dismissed automatically.

- **Tests**
  - Added coverage for censored and non-censored visitor scenarios, including renderable and non-renderable modal layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
