### PR TITLE
wp-plugin: prepare publishing to the wordpress.org directory

### DIFF
--- a/.github/workflows/publish-wp-plugin.yml
+++ b/.github/workflows/publish-wp-plugin.yml
@@ -48,9 +48,13 @@ jobs:
       - name: Refuse to run without SVN credentials
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |
-          if [ -z "$SVN_USERNAME" ]; then
-            echo "SVN_USERNAME / SVN_PASSWORD are not set. Either the plugin has not been approved by wordpress.org yet, or the secrets were never added." >&2
+          missing=""
+          [ -n "$SVN_USERNAME" ] || missing="SVN_USERNAME"
+          [ -n "$SVN_PASSWORD" ] || missing="${missing:+$missing and }SVN_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "$missing not set. Either the plugin has not been approved by wordpress.org yet, or the secrets were never added." >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-wp-plugin.yml
+++ b/.github/workflows/publish-wp-plugin.yml
@@ -24,7 +24,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # Nothing here pushes to git -- the deploy target is SVN -- so the token
+      # actions/checkout would otherwise leave in .git/config has no use, and a
+      # third-party action runs in this workspace after it.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Derive the version from the tag
         id: v

--- a/.github/workflows/publish-wp-plugin.yml
+++ b/.github/workflows/publish-wp-plugin.yml
@@ -1,0 +1,64 @@
+name: Publish WordPress plugin
+
+# Publishes ui/wp-plugin to the wordpress.org Plugin Directory (SVN) when a
+# wp-plugin/v* tag is pushed. Inert until the directory has approved the plugin
+# and SVN_USERNAME / SVN_PASSWORD exist as repository secrets.
+#
+# The tag is the release. Its version must equal the plugin's Version header and
+# the readme's Stable tag, because wordpress.org serves whatever Stable tag
+# points at -- a mismatch ships a tags/ directory nobody is served from.
+#
+# The previous distribution channel for this plugin was a zip uploaded to S3 by
+# hand in 2024 that nobody could update; it served a stale build for two and a
+# half years. Publishing from a tag keeps the directory pinned to the tree.
+
+on:
+  push:
+    tags:
+      - 'wp-plugin/v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive the version from the tag
+        id: v
+        run: echo "version=${GITHUB_REF_NAME#wp-plugin/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build the plugin directory
+        run: bash ui/wp-plugin/demo-site/build.sh
+
+      - name: Tag must match the plugin Version and the readme Stable tag
+        env:
+          TAG_VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -eu
+          php=$(sed -n 's/^ \* Version: *//p' ui/wp-plugin/unbounded.php | head -1)
+          stable=$(sed -n 's/^Stable tag: *//p' ui/wp-plugin/readme.txt | head -1)
+          if [ "$TAG_VERSION" != "$php" ] || [ "$TAG_VERSION" != "$stable" ]; then
+            echo "tag says $TAG_VERSION, unbounded.php says $php, readme Stable tag says $stable" >&2
+            exit 1
+          fi
+
+      - name: Refuse to run without SVN credentials
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        run: |
+          if [ -z "$SVN_USERNAME" ]; then
+            echo "SVN_USERNAME / SVN_PASSWORD are not set. Either the plugin has not been approved by wordpress.org yet, or the secrets were never added." >&2
+            exit 1
+          fi
+
+      - name: Deploy to wordpress.org SVN
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: unbounded
+          VERSION: ${{ steps.v.outputs.version }}
+          BUILD_DIR: ui/wp-plugin/demo-site/package/unbounded

--- a/ui/wp-plugin/demo-site/.gitignore
+++ b/ui/wp-plugin/demo-site/.gitignore
@@ -1,1 +1,2 @@
 dist/
+package/

--- a/ui/wp-plugin/demo-site/build.sh
+++ b/ui/wp-plugin/demo-site/build.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 plugin_dir="$(dirname "$here")"
 out="$here/dist"
+pkg="$here/package"
 slug="unbounded"
 
 command -v python3 >/dev/null || {
@@ -23,18 +24,20 @@ command -v python3 >/dev/null || {
   exit 1
 }
 
-rm -rf "$out"
-mkdir -p "$out/stage/$slug"
+rm -rf "$out" "$pkg"
+mkdir -p "$out" "$pkg/$slug"
 
 # Only what a WordPress install needs. README.md, docker-compose.yml and the
 # demo site itself are development files and stay out of the distributed plugin.
 for f in unbounded.php readme.txt uninstall.php; do
-  cp "$plugin_dir/$f" "$out/stage/$slug/$f"
+  cp "$plugin_dir/$f" "$pkg/$slug/$f"
 done
 
 # zipfile rather than the zip(1) binary: Cloudflare's Pages build image ships
 # python3 but not zip, and this keeps the local and CI builds on one code path.
-python3 - "$out/stage" "$out/$slug.zip" <<'PY'
+# The staged directory is kept: publish-wp-plugin.yml hands it to the SVN
+# deploy as BUILD_DIR, so the directory and the zip can never differ.
+python3 - "$pkg" "$out/$slug.zip" <<'PY'
 import os, sys, zipfile
 
 stage, target = sys.argv[1], sys.argv[2]
@@ -48,7 +51,6 @@ with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as z:
             path = os.path.join(root, name)
             z.write(path, os.path.relpath(path, stage))
 PY
-rm -rf "$out/stage"
 
 cp "$here/index.html" "$here/blueprint.json" "$here/_headers" "$out/"
 

--- a/ui/wp-plugin/readme.txt
+++ b/ui/wp-plugin/readme.txt
@@ -1,5 +1,5 @@
 === Unbounded ===
-Contributors: lantern
+Contributors: getlantern
 Tags: censorship, privacy, proxy, volunteer, webrtc
 Requires at least: 5.0
 Tested up to: 7.1


### PR DESCRIPTION
Everything between the current tree and a listing on wordpress.org, minus the two steps only a human with the account can do.

## What's in here

**`readme.txt` — the author credit was wrong.** It named the wordpress.org user `lantern`. That account exists, has plugin activity, and is not ours — no website, no bio, nothing linking it to Lantern. Shipping it would have listed a stranger as the plugin's author on the directory page. `getlantern` is unregistered and matches the GitHub org, so the readme now names that. **Whoever registers the account should either use that name or change this line to match** — the directory keys the listing to it.

**`publish-wp-plugin.yml` — publishing from a tag instead of by hand.** Post-approval publishing is SVN (`trunk/` + `tags/<version>/`). This plugin's previous channel was a zip uploaded to S3 by hand in 2024 that nobody could update; it served a stale build for two and a half years. The workflow runs on a `wp-plugin/v*` tag, runs `build.sh`, and hands the staged directory to [`10up/action-wordpress-plugin-deploy@stable`](https://github.com/10up/action-wordpress-plugin-deploy). It is deliberately inert until approval:

- triggers **only** on `wp-plugin/v*` tags (the egress `v*` tags don't touch it)
- **refuses** a tag whose version differs from the plugin `Version` header or the readme `Stable tag` — wordpress.org serves whatever `Stable tag` points at, so a mismatch ships a `tags/` directory nobody is served from
- **fails plainly** if either `SVN_USERNAME` or `SVN_PASSWORD` is absent, naming which, rather than half-deploying
- checks out with `persist-credentials: false` — nothing here pushes to git, and a third-party action runs in the workspace afterwards

**`build.sh` — one file set, two outputs.** The deploy action takes a directory, not a zip, so the build now keeps its staged `package/unbounded/` instead of deleting it, and the zip is built from that same directory. Verified: `package/unbounded` and `dist/unbounded.zip` have identical file sets. `package/` is gitignored alongside `dist/`; `dist/` (what Cloudflare Pages serves) is unchanged in shape.

## How publishing works once this merges

1. **Register** a wordpress.org account from an official `@getlantern.org` address — `getlantern` is available — and whitelist `plugins@wordpress.org`.
2. **Submit** `unbounded.zip` (from `bash ui/wp-plugin/demo-site/build.sh`) at wordpress.org/plugins/developers/add. The slug is generated from the `Plugin Name` header — `Unbounded` → `unbounded`, confirmed unclaimed — and is **permanent** after approval. An automated email states the slug at submission.
3. **Review** takes up to ~14 business days after it reaches the queue. Issues arrive by email with the subject `[WordPress Plugin Directory] Review in Progress: Unbounded`.
4. **On approval**, add the SVN credentials as repository secrets `SVN_USERNAME` / `SVN_PASSWORD`, then publish with a tag:
   ```
   git tag wp-plugin/v1.2.0 && git push origin wp-plugin/v1.2.0
   ```
   Every release after that is a version bump in `unbounded.php` + `readme.txt` (the build fails if they disagree) and a new tag.

Not covered here: directory **assets** (banner, icon, screenshots) live in the SVN `assets/` directory and are optional at submission; they can follow via the action's `ASSETS_DIR` once someone makes them.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh3TcyWL8MMtTYPo7H2buS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated publishing of the WordPress plugin to WordPress.org when a release tag is pushed.
  - Added validation to ensure release tags match the plugin and readme versions.
- **Bug Fixes**
  - Improved plugin packaging by preserving a staging directory for deployment.
  - Updated the WordPress plugin contributor attribution to “getlantern.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
