### PR TITLE
wp-plugin: readme discloses everything the widget contacts and stores

### DIFF
--- a/ui/wp-plugin/readme.txt
+++ b/ui/wp-plugin/readme.txt
@@ -52,6 +52,11 @@ their browser contacts:
   small invisible frame the widget uses to remember volunteering statistics.
 * **fonts.googleapis.com / fonts.gstatic.com** -- the widget's typeface,
   Urbanist, from Google Fonts.
+* **plausible.io** -- usage analytics, loaded inside the embed.lantern.io frame.
+  It records that the widget loaded, later whether it was switched on, and the
+  address of the page it is embedded on. Plausible is cookieless and keeps no
+  persistent identifier for the visitor; Lantern uses the counts to report how
+  many sites run the widget and how many visitors volunteer.
 
 Nothing else is contacted until a visitor turns the switch on. After that:
 

--- a/ui/wp-plugin/readme.txt
+++ b/ui/wp-plugin/readme.txt
@@ -53,12 +53,14 @@ their browser contacts:
 * **fonts.googleapis.com / fonts.gstatic.com** -- the widget's typeface,
   Urbanist, from Google Fonts.
 * **plausible.io** -- usage analytics, loaded inside the embed.lantern.io frame.
-  The widget sends it two events: that it loaded, and later whether it was
-  switched on. Plausible's own script adds its usual page metadata, including
-  the frame's referrer -- the site the widget is embedded on, usually just the
-  origin, as trimmed by that site's referrer policy. Plausible is cookieless
-  and keeps no persistent identifier for the visitor; Lantern uses the counts
-  to report how many sites run the widget and how many visitors volunteer.
+  On load the widget sends it two events: that it rendered, tagged with the
+  embed type (web page or browser extension), and the state of the switch,
+  which is off. The switch event is sent again whenever a visitor changes it.
+  Plausible's own script adds its usual page metadata, including the frame's
+  referrer -- the site the widget is embedded on, usually just the origin, as
+  trimmed by that site's referrer policy. Plausible is cookieless and keeps no
+  persistent identifier for the visitor; Lantern uses the counts to report how
+  many sites run the widget and how many visitors volunteer.
 
 Nothing else is contacted until a visitor turns the switch on. After that:
 

--- a/ui/wp-plugin/readme.txt
+++ b/ui/wp-plugin/readme.txt
@@ -45,21 +45,35 @@ This plugin is a client for the Unbounded network, run by Lantern. The widget
 cannot work locally: relaying traffic for someone in another country requires
 peers, signaling, and exit infrastructure, all of which live in the service.
 
-When the widget renders on a page, the visitor's browser contacts:
+When the widget renders on a page -- before the visitor has done anything --
+their browser contacts:
 
-* **embed.lantern.io** — serves the widget bundle, and the WebAssembly proxy
-  engine once a visitor turns the switch on. The engine is around 12 MB, which
-  is why it is fetched on demand from the service rather than bundled into this
+* **embed.lantern.io** -- serves the widget bundle and its images, and hosts a
+  small invisible frame the widget uses to remember volunteering statistics.
+* **fonts.googleapis.com / fonts.gstatic.com** -- the widget's typeface,
+  Urbanist, from Google Fonts.
+
+Nothing else is contacted until a visitor turns the switch on. After that:
+
+* **embed.lantern.io** -- the WebAssembly proxy engine, around 12 MB, which is
+  why it is fetched on demand from the service rather than bundled into this
   plugin.
-* **geo.getiantem.org** — a country lookup, used to draw the map and to warn
+* **geo.getiantem.org** -- a country lookup, used to draw the map and to warn
   visitors who appear to be in a censored region that volunteering may not be
   appropriate for them.
-* **freddie.iantem.io** — peer discovery and connection signaling.
-* **unbounded.iantem.io** — the exit servers that relayed traffic egresses
-  through.
+* **freddie.iantem.io** -- peer discovery and connection signaling.
+* **unbounded.iantem.io** -- the exit servers that relayed traffic egresses
+  through. If the widget's page freezes or crashes, a small diagnostic report
+  (timing data, no personal data) is also sent here.
+* **netstated-d7bbec1ed55b.herokuapp.com** -- anonymous network-state updates
+  that power the live map of active connections.
 
-Only the first of these is contacted when the page loads. The rest are contacted
-only after a visitor turns the switch on.
+= What is kept in the visitor's browser =
+
+The widget stores a few values in browser storage: the interface language, a
+crash-recovery marker, and -- inside the embed.lantern.io frame, so it follows
+the visitor across sites that run the widget -- running totals of people
+helped. None of it identifies the visitor.
 
 Unbounded does not track visitors, set advertising identifiers, or collect
 personal data. Relayed traffic is end-to-end encrypted between the person being

--- a/ui/wp-plugin/readme.txt
+++ b/ui/wp-plugin/readme.txt
@@ -53,10 +53,12 @@ their browser contacts:
 * **fonts.googleapis.com / fonts.gstatic.com** -- the widget's typeface,
   Urbanist, from Google Fonts.
 * **plausible.io** -- usage analytics, loaded inside the embed.lantern.io frame.
-  It records that the widget loaded, later whether it was switched on, and the
-  address of the page it is embedded on. Plausible is cookieless and keeps no
-  persistent identifier for the visitor; Lantern uses the counts to report how
-  many sites run the widget and how many visitors volunteer.
+  The widget sends it two events: that it loaded, and later whether it was
+  switched on. Plausible's own script adds its usual page metadata, including
+  the frame's referrer -- the site the widget is embedded on, usually just the
+  origin, as trimmed by that site's referrer policy. Plausible is cookieless
+  and keeps no persistent identifier for the visitor; Lantern uses the counts
+  to report how many sites run the widget and how many visitors volunteer.
 
 Nothing else is contacted until a visitor turns the switch on. After that:
 
@@ -68,8 +70,9 @@ Nothing else is contacted until a visitor turns the switch on. After that:
   appropriate for them.
 * **freddie.iantem.io** -- peer discovery and connection signaling.
 * **unbounded.iantem.io** -- the exit servers that relayed traffic egresses
-  through. If the widget's page freezes or crashes, a small diagnostic report
-  (timing data, no personal data) is also sent here.
+  through. If the widget's page freezes or crashes, a diagnostic report is also
+  sent here: timing measurements, the page's address, the browser's user-agent
+  string, and the widget build. It carries no identifier for the visitor.
 * **netstated-d7bbec1ed55b.herokuapp.com** -- anonymous network-state updates
   that power the live map of active connections.
 


### PR DESCRIPTION
`readme.txt` only. The **External services** section is the argument for guidelines 6, 7 and 8, so it has to be exactly right — and it wasn't.

## What was wrong

The section listed four hosts and claimed only `embed.lantern.io` was contacted on page load. Measured on a bare HTML page (nothing but the script tag and the element) with the switch untouched, reading the network log across **all frames**:

| before consent | request |
|---|---|
| `embed.lantern.io` | `main.js`, `storage.html` |
| `fonts.googleapis.com` / `fonts.gstatic.com` | Urbanist CSS + woff2 |
| **`plausible.io`** | `script.js` + **two** `POST /api/event` |

Google Fonts was undisclosed (guideline 8 permits font CDNs outright, but guideline 7 asks for every external contact to be documented). **Plausible was undisclosed entirely** — `ui/public/storage.html:15` loads it inside the storage frame and the Storage component posts a `load` event on mount, so every visitor reports to a third-party analytics service before doing anything. Two post-consent hosts were also missing: `netstated` (network-state updates behind the live map) and the freeze beacon on `unbounded.iantem.io`.

Codex caught the Plausible omission on this branch. My first capture had read only the top document's resource-timing entries, which can't see a cross-origin frame's requests — a genuine blind spot, now closed by reading the browser's network log instead.

## What changed

- Pre-consent list is now `embed.lantern.io`, Google Fonts, and Plausible — with exactly what Plausible receives: two events on load (`load`, tagged with the embed type, and `sharing` with the switch state, which is off), the switch event again on every change, and its own page metadata including the frame's referrer (the embedding site, usually just the origin, as trimmed by that site's referrer policy) — and what it doesn't (cookies, a persistent identifier)
- The freeze-beacon entry names its actual fields — timing measurements, the page's address, the user-agent string, the widget build — instead of the understated "timing data, no personal data"
- Post-consent list adds `netstated` and the freeze beacon
- New subsection on what's kept in browser storage: interface language, crash-recovery marker, and the running totals inside the `embed.lantern.io` frame

wordpress.org's readme validator accepts the result.

## Worth a decision, not just a disclosure

Disclosing Plausible is the minimum. Whether a third-party analytics beacon should fire on visitors **before** they opt in is a separate question — guideline 7 reads "plugins may not contact external servers without explicit and authorized consent," and while Plausible is cookieless and the SaaS exemption likely covers Lantern's own endpoints, `plausible.io` is a third party. The clean fix is widget-side (defer the analytics load to opt-in, or drop the `load` event), and it trades against the grant metrics that report depends on. Flagging for a decision rather than deciding it here.

## Pre-PR review (local Codex gate)
- Rounds: 2 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: `ui/wp-plugin/readme.txt:56` — pre-consent service list omitted Plausible, which `storage.html` loads and the widget posts a `load` event to on mount

Review rounds after the gate (Copilot ×3, CodeRabbit ×2) tightened the wording three more times — each time the code said something more specific than the readme did. All resolved; see the threads.
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh3TcyWL8MMtTYPo7H2buS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized the plugin’s external services information by separating services contacted during widget rendering from those contacted after visitors enable the switch.
  - Added details about the external resources and endpoints involved in each stage.
  - Documented the non-identifying information stored in a visitor’s browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
